### PR TITLE
fix: editor save, autocomplete, and version filtering bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **Editor save error**: `UpdateDraft` SQL queries were missing `template_key` filter, causing errors when multiple templates share the same variant slug (e.g., "default"). Added `template_key` to UPDATE, SELECT, and MAX(id) queries.
+- **Autocomplete missing data model variables**: `GetEditorContext` cast JSONB `data_model` directly to `ObjectNode` instead of deserializing from `PGobject`, causing it to always be null. Variable autocomplete now correctly shows data model variables.
+- **Version list showing all variants' versions**: SQL JOINs in `ListVersions`, `GetVersion`, and `GetVariant` subqueries were missing `template_key` in JOIN conditions, causing version lists to include versions from other templates when variant slugs collide.
 - **New template form**: Removed the "JSON Schema" textarea from the template creation form — data contracts are managed through the dedicated data contract editor instead.
 - **Page header/footer overlap**: Page header and footer content no longer overlaps with body content in PDF output. The document margins are now automatically increased to reserve space for header/footer bands when present.
 - **Theme margin update crash**: Setting margins in the theme editor no longer crashes with a Jackson null deserialization error. `PageSettings` now has default values for `format` (A4) and `orientation` (portrait), allowing partial payloads from the frontend.

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/commands/versions/UpdateDraft.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/commands/versions/UpdateDraft.kt
@@ -52,10 +52,12 @@ class UpdateDraftHandler(
                 UPDATE template_versions
                 SET template_model = :templateModel::jsonb
                 WHERE tenant_key = :tenantId AND variant_key = :variantId
+                  AND template_key = :templateId
                   AND status = 'draft'
                 """,
         )
             .bind("tenantId", command.variantId.tenantKey)
+            .bind("templateId", command.variantId.templateKey)
             .bind("variantId", command.variantId.key)
             .bind("templateModel", templateModelJson)
             .execute()
@@ -67,10 +69,12 @@ class UpdateDraftHandler(
                     SELECT *
                     FROM template_versions
                     WHERE tenant_key = :tenantId AND variant_key = :variantId
+                      AND template_key = :templateId
                       AND status = 'draft'
                     """,
             )
                 .bind("tenantId", command.variantId.tenantKey)
+                .bind("templateId", command.variantId.templateKey)
                 .bind("variantId", command.variantId.key)
                 .mapTo<TemplateVersion>()
                 .one()
@@ -83,9 +87,11 @@ class UpdateDraftHandler(
                 SELECT COALESCE(MAX(id), 0) + 1 as next_id
                 FROM template_versions
                 WHERE tenant_key = :tenantId AND variant_key = :variantId
+                  AND template_key = :templateId
                 """,
         )
             .bind("tenantId", command.variantId.tenantKey)
+            .bind("templateId", command.variantId.templateKey)
             .bind("variantId", command.variantId.key)
             .mapTo(Int::class.java)
             .one()

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/GetEditorContext.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/GetEditorContext.kt
@@ -103,7 +103,18 @@ class GetEditorContextHandler(
             variantAttributes = variantAttributes,
             templateModel = templateModel,
             dataExamples = dataExamples,
-            dataModel = row["data_model"] as? ObjectNode,
+            dataModel = row["data_model"]?.let { raw ->
+                val json = raw.toString()
+                if (json.isNotBlank() && json != "null") {
+                    try {
+                        objectMapper.readValue(json, ObjectNode::class.java)
+                    } catch (e: Exception) {
+                        null
+                    }
+                } else {
+                    null
+                }
+            },
         )
     }
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/variants/GetVariant.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/variants/GetVariant.kt
@@ -53,11 +53,11 @@ class GetVariantSummariesHandler(
                     tv.title,
                     tv.attributes,
                     tv.is_default,
-                    EXISTS(SELECT 1 FROM template_versions ver WHERE ver.tenant_key = tv.tenant_key AND ver.variant_key = tv.id AND ver.status = 'draft') as has_draft,
+                    EXISTS(SELECT 1 FROM template_versions ver WHERE ver.tenant_key = tv.tenant_key AND ver.template_key = tv.template_key AND ver.variant_key = tv.id AND ver.status = 'draft') as has_draft,
                     COALESCE(
                         (SELECT jsonb_agg(ver.id ORDER BY ver.id)
                          FROM template_versions ver
-                         WHERE ver.tenant_key = tv.tenant_key AND ver.variant_key = tv.id AND ver.status = 'published'),
+                         WHERE ver.tenant_key = tv.tenant_key AND ver.template_key = tv.template_key AND ver.variant_key = tv.id AND ver.status = 'published'),
                         '[]'::jsonb
                     ) as published_versions
                 FROM template_variants tv

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/versions/GetVersion.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/versions/GetVersion.kt
@@ -23,7 +23,7 @@ class GetVersionHandler(
                        ver.created_at, ver.published_at, ver.archived_at,
                        ver.rendering_defaults_version, ver.resolved_theme
                 FROM template_versions ver
-                JOIN template_variants tv ON tv.tenant_key = ver.tenant_key AND tv.id = ver.variant_key
+                JOIN template_variants tv ON tv.tenant_key = ver.tenant_key AND tv.template_key = ver.template_key AND tv.id = ver.variant_key
                 WHERE ver.id = :versionId
                   AND ver.variant_key = :variantId
                   AND ver.tenant_key = :tenantId

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/versions/ListVersions.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/versions/ListVersions.kt
@@ -21,7 +21,7 @@ class ListVersionsHandler(
             """
                 SELECT ver.id, ver.tenant_key, ver.variant_key, ver.status, ver.created_at, ver.published_at, ver.archived_at
                 FROM template_versions ver
-                JOIN template_variants tv ON tv.tenant_key = ver.tenant_key AND tv.id = ver.variant_key
+                JOIN template_variants tv ON tv.tenant_key = ver.tenant_key AND tv.template_key = ver.template_key AND tv.id = ver.variant_key
                 WHERE ver.variant_key = :variantId
                   AND ver.tenant_key = :tenantId
                   AND tv.template_key = :templateId


### PR DESCRIPTION
## Summary
- **Editor save error**: `UpdateDraft` SQL queries were missing `template_key` filter, causing errors when multiple templates share the same variant slug (e.g., "default")
- **Autocomplete missing data model variables**: `GetEditorContext` cast JSONB `data_model` directly to `ObjectNode` instead of deserializing from `PGobject`, so it was always null
- **Version list cross-contamination**: JOINs in `ListVersions`, `GetVersion`, and `GetVariant` subqueries were missing `template_key`, causing versions from other templates to leak through when variant slugs collide

## Test plan
- [x] `./gradlew unitTest integrationTest` — all pass
- [ ] Start app, open editor for any template variant → save should succeed
- [ ] Open editor → autocomplete should show data model variables (not just `sys.page.number`)
- [ ] Open version history for a variant → only that variant's versions shown