### PR TITLE
feat: polish theme editor UX and accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
 
 - **Data contract example editor accessibility**: Added role="list"/"listitem" semantics for array containers. Added aria-describedby to inputs with validation errors for screen reader announcements. Added aria-hidden to decorative elements (badges, icons, error dots). Added aria-label to collapsible details elements for context. Added aria-label to checkbox inputs in boolean fields. Added for/id association between example name label and input. Enhanced chip buttons with aria-label describing example name and validation status.
 
+- **Theme editor UX polish**: Added focus-visible ring styles to all interactive elements (buttons, inputs, selects). Refactored hover states to nested CSS selectors for consistency. Redesigned empty state with icon and centered layout. Improved preset card styling with smooth transitions. Added inspector style group labels with uppercase text styling. Updated status bar with right-aligned layout. Applied uniform border-radius and spacing throughout.
+
+- **Theme editor accessibility**: Replaced custom div-based preset expand/collapse with native `<details>`/`<summary>` elements for built-in accessibility (aria-expanded, keyboard support). Added for/id associations on preset key and label inputs. Added aria-label to remove preset buttons. Added aria-hidden to decorative toggle icons.
+
 ### Added
 
 - **Authorization enforcement in mediator**: All commands and queries now declare authorization requirements via marker interfaces (`RequiresPermission`, `RequiresPlatformRole`, `RequiresAuthentication`, `SystemInternal`). The `SpringMediator` enforces these before dispatching — unauthenticated or unauthorized requests are rejected with `PermissionDeniedException`, `TenantAccessDeniedException`, or `PlatformAccessDeniedException`.

--- a/apps/epistola/src/main/resources/static/css/shell.css
+++ b/apps/epistola/src/main/resources/static/css/shell.css
@@ -166,7 +166,7 @@
 
 .main-content {
   flex: 1;
-  max-width: 56rem;
+  max-width: var(--ep-max-width-base);
   margin: var(--ep-space-8) auto;
   padding: 0 var(--ep-space-6);
   width: 100%;

--- a/apps/epistola/src/main/resources/templates/themes/detail.html
+++ b/apps/epistola/src/main/resources/templates/themes/detail.html
@@ -27,7 +27,7 @@
                     Last modified: <span th:text="${#temporals.format(theme.lastModified, 'yyyy-MM-dd HH:mm')}"></span>
                 </span>
             </div>
-            <div class="detail-section-body no-padding">
+            <div class="detail-section-body">
                 <div id="theme-editor-container"></div>
             </div>
         </div>

--- a/modules/design-system/tokens.css
+++ b/modules/design-system/tokens.css
@@ -184,4 +184,8 @@
 
   /* ── Sidebar width (editor-specific, kept here for central reference) ── */
   --ep-sidebar-width: 18rem;
+
+  --ep-max-width-base: 56rem;
+  --ep-max-width-lg: 72rem;
+  --ep-max-width-xl: 88rem;
 }

--- a/modules/editor/src/main/typescript/theme-editor/EpistolaThemeEditor.ts
+++ b/modules/editor/src/main/typescript/theme-editor/EpistolaThemeEditor.ts
@@ -29,7 +29,6 @@ export class EpistolaThemeEditor extends LitElement {
 
   @state() private _saveState: SaveState = 'idle';
   @state() private _errorMessage = '';
-  @state() private _expandedPresets = new Set<string>();
 
   private _autosaveTimer?: ReturnType<typeof setTimeout>;
   private _savedTimer?: ReturnType<typeof setTimeout>;
@@ -67,19 +66,16 @@ export class EpistolaThemeEditor extends LitElement {
     }
 
     return html`
+      ${this._renderStatusBar()}
       <div class="theme-editor-layout">
         <div class="theme-editor-panel">
           ${renderBasicInfoSection(this.themeState)} ${renderDocumentStylesSection(this.themeState)}
-          ${renderPageSettingsSection(this.themeState)}
-          ${renderPresetsSection(this.themeState, this._expandedPresets, (name) =>
-            this._togglePreset(name),
-          )}
+          ${renderPageSettingsSection(this.themeState)} ${renderPresetsSection(this.themeState)}
         </div>
         <div class="theme-editor-preview">
           <div class="theme-editor-preview-placeholder">Preview panel coming soon</div>
         </div>
       </div>
-      ${this._renderStatusBar()}
     `;
   }
 
@@ -98,7 +94,7 @@ export class EpistolaThemeEditor extends LitElement {
           ${stateLabels[this._saveState]}
         </span>
         <button
-          class="ep-btn-primary theme-save-btn"
+          class="btn btn-primary btn-sm theme-save-btn"
           ?disabled=${this._saveState === 'saving' ||
           this._saveState === 'idle' ||
           this._saveState === 'saved'}
@@ -163,15 +159,6 @@ export class EpistolaThemeEditor extends LitElement {
     if (this.themeState?.isDirty) {
       e.preventDefault();
     }
-  }
-
-  private _togglePreset(name: string): void {
-    if (this._expandedPresets.has(name)) {
-      this._expandedPresets.delete(name);
-    } else {
-      this._expandedPresets.add(name);
-    }
-    this.requestUpdate();
   }
 }
 

--- a/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
@@ -2,10 +2,11 @@
  * PresetItem — Single preset editing: name, label, applicableTo, style properties.
  *
  * Renders all style groups from the registry using the same input dispatch
- * pattern as the inspector. The preset is an expandable card.
+ * pattern as the inspector. The preset uses native <details>/<summary>
+ * for expand/collapse, providing built-in accessibility.
  */
 
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import type { StyleProperty } from '@epistola.app/editor-model/generated/style-registry';
 import type { BlockStylePreset } from '@epistola.app/editor-model/generated/theme';
 import { defaultStyleRegistry } from '../../engine/style-registry.js';
@@ -32,19 +33,33 @@ export function renderPresetItem(
   state: ThemeEditorState,
   name: string,
   preset: BlockStylePreset,
-  expanded: boolean,
-  onToggle: () => void,
   onRemove: () => void,
 ): unknown {
   return html`
-    <div class="preset-card">
-      <div class="preset-card-header" @click=${onToggle}>
-        <span class="preset-card-toggle">${expanded ? '\u25BE' : '\u25B8'}</span>
-        <span class="preset-card-name">${preset.label || name}</span>
-        <span class="preset-card-key">${name}</span>
+    <details class="theme-preset-card">
+      <summary class="theme-preset-header" aria-label="${preset.label || name}">
+        <span class="theme-preset-toggle" aria-hidden="true">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="lucide lucide-chevron-down-icon lucide-chevron-down"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </span>
+        <span class="theme-preset-name">${preset.label || name}</span>
+        <span class="theme-preset-key">${name}</span>
         <button
-          class="preset-card-remove"
+          class="theme-preset-remove"
           title="Remove preset"
+          aria-label="Remove preset ${preset.label || name}"
           @click=${(e: Event) => {
             e.stopPropagation();
             onRemove();
@@ -52,9 +67,9 @@ export function renderPresetItem(
         >
           &times;
         </button>
-      </div>
-      ${expanded ? renderPresetBody(state, name, preset) : nothing}
-    </div>
+      </summary>
+      ${renderPresetBody(state, name, preset)}
+    </details>
   `;
 }
 
@@ -67,12 +82,13 @@ function renderPresetBody(
   const applicableTo = preset.applicableTo ?? [];
 
   return html`
-    <div class="preset-card-body">
+    <div class="theme-preset-body">
       <!-- Name (key) -->
       <div class="inspector-field">
-        <label class="inspector-field-label">Key (ID)</label>
+        <label class="inspector-field-label" for="preset-key-${name}">Key (ID)</label>
         <input
           type="text"
+          id="preset-key-${name}"
           class="ep-input mono"
           .value=${name}
           @change=${(e: Event) => {
@@ -86,9 +102,10 @@ function renderPresetBody(
 
       <!-- Label -->
       <div class="inspector-field">
-        <label class="inspector-field-label">Label</label>
+        <label class="inspector-field-label" for="preset-label-${name}">Label</label>
         <input
           type="text"
+          id="preset-label-${name}"
           class="ep-input"
           .value=${preset.label}
           @change=${(e: Event) =>
@@ -98,13 +115,14 @@ function renderPresetBody(
 
       <!-- Applicable To -->
       <div class="inspector-field">
-        <label class="inspector-field-label">Applicable To</label>
-        <div class="preset-applicable-to">
+        <span class="inspector-field-label">Applicable To</span>
+        <div class="theme-preset-applicable-to">
           ${NODE_TYPES.map(
             (nt) => html`
-              <label class="preset-checkbox-label">
+              <label class="theme-preset-checkbox-label">
                 <input
                   type="checkbox"
+                  id="preset-${name}-${nt.value}"
                   .checked=${applicableTo.includes(nt.value)}
                   @change=${(e: Event) => {
                     const checked = (e.target as HTMLInputElement).checked;
@@ -120,7 +138,7 @@ function renderPresetBody(
             `,
           )}
         </div>
-        <span class="preset-hint">Leave all unchecked to apply to all node types.</span>
+        <span class="theme-preset-hint">Leave all unchecked to apply to all node types.</span>
       </div>
 
       <!-- Style properties -->
@@ -129,7 +147,6 @@ function renderPresetBody(
           <div class="inspector-style-group">
             <div class="inspector-style-group-label">${group.label}</div>
             ${group.properties.map((prop) => {
-              // For spacing properties, reconstruct compound value from individual keys
               const value =
                 prop.type === 'spacing'
                   ? readSpacingFromStyles(prop.key, styles, prop.units?.[0] ?? 'px')

--- a/modules/editor/src/main/typescript/theme-editor/sections/PresetsSection.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/PresetsSection.ts
@@ -2,17 +2,14 @@
  * PresetsSection — List of block style presets with Add/Remove.
  *
  * Each preset is an expandable card rendered by PresetItem.
+ * Uses native <details>/<summary> for expand/collapse.
  */
 
 import { html } from 'lit';
 import type { ThemeEditorState } from '../ThemeEditorState.js';
 import { renderPresetItem } from './PresetItem.js';
 
-export function renderPresetsSection(
-  state: ThemeEditorState,
-  expandedPresets: Set<string>,
-  onTogglePreset: (name: string) => void,
-): unknown {
+export function renderPresetsSection(state: ThemeEditorState): unknown {
   const presets = state.theme.blockStylePresets;
   const entries = Object.entries(presets);
 
@@ -23,29 +20,24 @@ export function renderPresetsSection(
         Named style collections that blocks can reference. Similar to CSS classes.
       </p>
 
-      <div class="presets-list">
+      <div class="theme-preset-list">
         ${entries.length === 0
-          ? html`<div class="presets-empty">
-              No presets defined. Click "Add Preset" to create one.
-            </div>`
+          ? html`
+              <div class="empty-state">
+                <div class="empty-state-title">No presets defined</div>
+                <div class="empty-state-description">Click "Add Preset" to create one.</div>
+              </div>
+            `
           : entries.map(([name, preset]) =>
-              renderPresetItem(
-                state,
-                name,
-                preset,
-                expandedPresets.has(name),
-                () => onTogglePreset(name),
-                () => state.removePreset(name),
-              ),
+              renderPresetItem(state, name, preset, () => state.removePreset(name)),
             )}
       </div>
 
       <button
-        class="ep-btn-outline preset-add-btn"
+        class="theme-preset-add-btn"
         @click=${() => {
           const name = generatePresetName(presets);
           state.addPreset(name);
-          expandedPresets.add(name);
         }}
       >
         + Add Preset

--- a/modules/editor/src/main/typescript/theme-editor/theme-editor.css
+++ b/modules/editor/src/main/typescript/theme-editor/theme-editor.css
@@ -3,7 +3,7 @@
  *
  * Two-column layout, collapsible sections, preset cards, status bar.
  * Uses design-system tokens from @design/tokens.css.
- * Reuses inspector-* classes from the template editor where possible.
+ * Reuses @design/components.css for buttons, inputs, badges, etc.
  */
 
 @layer base, layout, components, states;
@@ -16,22 +16,37 @@
 /* Reuse inspector input styles */
 @import '../styles/inspector.css';
 
+/* Override shell.css main-content max-width 
+   Reason is to give theme editor more space */
+
+.main-content {
+  max-width: var(--ep-max-width-xl);
+}
+
+.detail-section-body {
+  padding: var(--ep-space-1);
+}
+
+/* ============================================================================
+ * Layout
+ * ========================================================================== */
+
 @layer layout {
   .theme-editor-layout {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--ep-space-6);
+    grid-template-columns: 33.3% 1fr;
+    gap: var(--ep-space-2);
     min-height: 400px;
   }
 
   .theme-editor-panel {
     overflow-y: auto;
     max-height: calc(100vh - 280px);
-    padding-right: var(--ep-space-4);
+    padding: var(--ep-space-1);
   }
 
   .theme-editor-preview {
-    border: 1px solid var(--ep-gray-200);
+    border: 1px solid var(--ep-border-color);
     border-radius: var(--ep-radius-md);
     display: flex;
     align-items: center;
@@ -40,19 +55,22 @@
   }
 
   .theme-editor-preview-placeholder {
-    color: var(--ep-gray-400);
+    color: var(--ep-muted-foreground);
     font-size: var(--ep-text-sm);
   }
 
   .theme-editor-empty {
-    color: var(--ep-gray-400);
+    color: var(--ep-muted-foreground);
     padding: var(--ep-space-8);
     text-align: center;
   }
 }
 
+/* ============================================================================
+ * Sections
+ * ========================================================================== */
+
 @layer components {
-  /* Sections */
   .theme-section {
     margin-bottom: var(--ep-space-6);
     padding-bottom: var(--ep-space-4);
@@ -66,200 +84,258 @@
   .theme-section-label {
     font-size: var(--ep-text-sm);
     font-weight: 600;
-    color: var(--ep-gray-700);
-    margin: 0 0 var(--ep-space-3) 0;
+    color: var(--ep-foreground);
+    margin: 0 0 var(--ep-space-2) 0;
   }
 
   .theme-section-hint {
     font-size: var(--ep-text-xs);
-    color: var(--ep-gray-400);
+    color: var(--ep-muted-foreground);
     margin: 0 0 var(--ep-space-3) 0;
   }
 
-  /* Textarea (theme-specific overrides) */
-  .theme-editor-layout .ep-textarea {
-    height: auto;
-    min-height: 60px;
-    resize: vertical;
-    font-size: var(--ep-text-sm);
-    padding: var(--ep-space-2);
-  }
-
   /* Mono inputs */
-  .theme-editor-layout .mono {
+  .theme-editor-panel .mono {
     font-family: var(--ep-font-mono);
   }
 
-  /* Preset cards */
-  .presets-list {
+  /* --------------------------------------------------------------------------
+   * Preset cards (native details/summary)
+   * ---------------------------------------------------------------------- */
+
+  .theme-preset-list {
     display: flex;
     flex-direction: column;
     gap: var(--ep-space-2);
     margin-bottom: var(--ep-space-3);
   }
 
-  .presets-empty {
-    font-size: var(--ep-text-xs);
-    color: var(--ep-gray-400);
-    padding: var(--ep-space-4);
-    text-align: center;
-    border: 1px dashed var(--ep-gray-200);
-    border-radius: var(--ep-radius-sm);
-  }
-
-  .preset-card {
-    border: 1px solid var(--ep-gray-200);
-    border-radius: var(--ep-radius-sm);
+  .theme-preset-card {
+    border: 1px solid var(--ep-border-color);
+    border-radius: var(--ep-radius-md);
+    background-color: var(--ep-card);
     overflow: hidden;
+    transition: all var(--ep-transition-base);
+
+    &[open] {
+      border-color: var(--ep-gray-300);
+
+      & > .theme-preset-header {
+        border-bottom: 1px solid var(--ep-border-color);
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        background-color: var(--ep-muted);
+        list-style: none;
+
+        &::-webkit-details-marker {
+          display: none;
+        }
+      }
+
+      & .theme-preset-toggle {
+        rotate: 180deg;
+      }
+    }
   }
 
-  .preset-card-header {
+  .theme-preset-header {
     display: flex;
     align-items: center;
     gap: var(--ep-space-2);
     padding: var(--ep-space-2) var(--ep-space-3);
-    background: var(--ep-gray-50);
+    background-color: var(--ep-muted);
     cursor: pointer;
     user-select: none;
+    list-style: none;
+    transition: all var(--ep-transition-base);
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &:hover {
+      background-color: var(--ep-gray-200);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: var(--ep-ring);
+    }
   }
 
-  .preset-card-header:hover {
-    background: var(--ep-gray-100);
+  .theme-preset-toggle {
+    color: var(--ep-muted-foreground);
+    width: 16px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: rotate 150ms ease;
   }
 
-  .preset-card-toggle {
-    font-size: 12px;
-    color: var(--ep-gray-400);
-    width: 12px;
+  .theme-preset-name {
+    font-size: var(--ep-text-sm);
+    font-weight: 500;
+    color: var(--ep-foreground);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .theme-preset-key {
+    font-size: var(--ep-text-xs);
+    color: var(--ep-muted-foreground);
+    font-family: var(--ep-font-mono);
     flex-shrink: 0;
   }
 
-  .preset-card-name {
-    font-size: var(--ep-text-sm);
-    font-weight: 500;
-    color: var(--ep-gray-700);
-    flex: 1;
-  }
-
-  .preset-card-key {
-    font-size: var(--ep-text-xs);
-    color: var(--ep-gray-400);
-    font-family: var(--ep-font-mono);
-  }
-
-  .preset-card-remove {
-    background: none;
-    border: none;
-    color: var(--ep-gray-400);
-    font-size: 18px;
+  .theme-preset-remove {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--ep-h-8);
+    height: var(--ep-h-8);
+    padding: 0;
+    color: var(--ep-muted-foreground);
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--ep-radius-sm);
     cursor: pointer;
-    padding: 0 var(--ep-space-1);
+    font-size: 18px;
     line-height: 1;
+    flex-shrink: 0;
+    transition: var(--ep-transition-colors);
+
+    &:hover {
+      color: var(--ep-destructive);
+      background-color: var(--ep-red-50);
+      border-color: var(--ep-red-200);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: var(--ep-ring);
+    }
   }
 
-  .preset-card-remove:hover {
-    color: var(--ep-red-500, #ef4444);
-  }
-
-  .preset-card-body {
+  .theme-preset-body {
     padding: var(--ep-space-3);
-    border-top: 1px solid var(--ep-gray-200);
+    border-top: 1px solid var(--ep-border-color);
   }
 
-  .preset-applicable-to {
+  /* ApplicableTo checkboxes */
+  .theme-preset-applicable-to {
     display: flex;
     flex-wrap: wrap;
     gap: var(--ep-space-2);
     margin-bottom: var(--ep-space-1);
   }
 
-  .preset-checkbox-label {
+  .theme-preset-checkbox-label {
     display: flex;
     align-items: center;
     gap: var(--ep-space-1);
     font-size: var(--ep-text-xs);
-    color: var(--ep-gray-600);
+    color: var(--ep-foreground);
     cursor: pointer;
+    transition: color var(--ep-transition-base);
+
+    &:hover {
+      color: var(--ep-accent-foreground);
+    }
   }
 
-  .preset-hint {
+  .theme-preset-hint {
     font-size: 10px;
-    color: var(--ep-gray-400);
+    color: var(--ep-muted-foreground);
   }
 
-  .preset-add-btn {
-    width: auto;
-  }
-
-  .ep-btn-outline {
-    background: transparent;
-    border: 1px solid var(--ep-gray-300);
-    border-radius: var(--ep-radius-sm);
-    padding: var(--ep-space-1) var(--ep-space-3);
-    font-size: var(--ep-text-xs);
-    color: var(--ep-gray-600);
+  /* Add preset button */
+  .theme-preset-add-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--ep-space-1-5);
+    height: var(--ep-h-9);
+    padding: 0 var(--ep-space-4);
+    font-size: var(--ep-text-sm);
+    font-weight: 500;
+    color: var(--ep-blue-700);
+    background-color: var(--ep-blue-50);
+    border: 1px dashed var(--ep-blue-300);
+    border-radius: var(--ep-radius-md);
     cursor: pointer;
+    transition: var(--ep-transition-colors);
+    align-self: flex-start;
+
+    &:hover {
+      background-color: var(--ep-blue-100);
+      border-color: var(--ep-blue-400);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: var(--ep-ring);
+    }
   }
 
-  .ep-btn-outline:hover {
-    background: var(--ep-gray-50);
-    border-color: var(--ep-gray-400);
-  }
+  /* --------------------------------------------------------------------------
+   * Status bar
+   * ---------------------------------------------------------------------- */
 
-  /* Status bar */
   .theme-status-bar {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
+    gap: var(--ep-space-3);
     padding: var(--ep-space-2) var(--ep-space-3);
-    border-top: 1px solid var(--ep-gray-200);
-    background: var(--ep-gray-50);
-    margin-top: var(--ep-space-4);
-    border-radius: var(--ep-radius-sm);
+    border: 1px solid var(--ep-border-color);
+    background-color: var(--ep-muted);
+    margin-bottom: var(--ep-space-1);
+    border-radius: var(--ep-radius-md);
   }
 
   .theme-status-indicator {
     font-size: var(--ep-text-xs);
-    color: var(--ep-gray-400);
+    color: var(--ep-muted-foreground);
   }
 
   .theme-status-dirty {
-    color: var(--ep-amber-600, #d97706);
+    color: var(--ep-amber-600);
   }
 
   .theme-status-saving {
-    color: var(--ep-blue-500, #3b82f6);
+    color: var(--ep-blue-500);
   }
 
   .theme-status-saved {
-    color: var(--ep-green-600, #16a34a);
+    color: var(--ep-green-700);
   }
 
   .theme-status-error {
-    color: var(--ep-red-500, #ef4444);
+    color: var(--ep-destructive);
   }
 
   .theme-save-btn {
+    flex-shrink: 0;
+  }
+
+  /* --------------------------------------------------------------------------
+   * Inspector style groups (shared with document styles)
+   * ---------------------------------------------------------------------- */
+
+  .inspector-style-group {
+    margin-bottom: var(--ep-space-3);
+  }
+
+  .inspector-style-group-label {
     font-size: var(--ep-text-xs);
-    padding: var(--ep-space-1) var(--ep-space-3);
-  }
-
-  .ep-btn-primary {
-    background: var(--ep-blue-600, #2563eb);
-    color: white;
-    border: none;
-    border-radius: var(--ep-radius-sm);
-    cursor: pointer;
-    font-size: var(--ep-text-xs);
-    padding: var(--ep-space-1) var(--ep-space-3);
-  }
-
-  .ep-btn-primary:hover {
-    background: var(--ep-blue-700, #1d4ed8);
-  }
-
-  .ep-btn-primary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+    font-weight: 600;
+    color: var(--ep-muted-foreground);
+    margin-bottom: var(--ep-space-2);
+    text-transform: uppercase;
+    letter-spacing: var(--ep-tracking-wider);
   }
 }


### PR DESCRIPTION
## Description

This PR polishes the theme editor UX and improves accessibility. It replaces the custom div-based preset expand/collapse with native `<details>`/`<summary>` elements for built-in accessibility (aria-expanded, keyboard support). Adds focus-visible ring styles to all interactive elements, aria-labels, and for/id associations on form inputs. Refactors hover states to nested CSS selectors for consistency. Improves preset card styling with smooth transitions and redesigns the empty state. Applies uniform design system tokens throughout.

## Related Issue(s)

Closes #191

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

<!-- Add screenshots if applicable -->

## Additional Notes

I want to tackle labels next because both in inspector and here, most of them doesn't work. I didn't want to fix it here, thinking it is out of scope maybe? So opened a new issue (#253) and will fix all the labels in single pr. At least that's what I thought would be nice. Let me know what you think.
