### PR TITLE
feat: associate editor and template labels with inputs

### DIFF
--- a/apps/epistola/src/main/resources/templates/feedback/submit-form.html
+++ b/apps/epistola/src/main/resources/templates/feedback/submit-form.html
@@ -56,7 +56,7 @@
 
                 <!-- Screenshot capture -->
                 <div class="form-group">
-                    <label class="ep-label">Screenshot (optional)</label>
+                    <label class="ep-label" for="fb-screenshot-file">Screenshot (optional)</label>
                     <div id="fb-screenshot-zone"
                          style="border: 2px dashed var(--ep-border); border-radius: var(--ep-radius); padding: var(--ep-space-4); text-align: center; cursor: pointer; min-height: 80px; display: flex; align-items: center; justify-content: center; flex-direction: column; gap: var(--ep-space-2);"
                          onclick="document.getElementById('fb-screenshot-file').click()">

--- a/apps/epistola/src/main/resources/templates/settings/feedback-sync.html
+++ b/apps/epistola/src/main/resources/templates/settings/feedback-sync.html
@@ -78,7 +78,7 @@
                     </fieldset>
 
                     <div class="form-group" th:if="${formData != null and formData['lastPolledAt'] != null}">
-                        <label class="ep-label">Last Polled</label>
+                        <span class="ep-label">Last Polled</span>
                         <span class="form-static" th:text="${formData['lastPolledAt']}">-</span>
                     </div>
 

--- a/apps/epistola/src/main/resources/templates/templates/detail.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail.html
@@ -76,8 +76,8 @@
             <div id="variant-filter-bar" class="variant-filter-bar"
                  th:if="${attributeDefinitions != null and !#lists.isEmpty(attributeDefinitions)}">
                 <div class="form-group" th:each="attrDef : ${attributeDefinitions}">
-                    <label th:text="${attrDef.displayName}"></label>
-                    <select class="ep-select" th:data-filter-key="${attrDef.id}" onchange="filterVariants()">
+                    <label th:for="'attr-filter-' + ${attrDef.id}" th:text="${attrDef.displayName}"></label>
+                    <select class="ep-select" th:id="'attr-filter-' + ${attrDef.id}" th:data-filter-key="${attrDef.id}" onchange="filterVariants()">
                         <option value="">All</option>
                         <option th:each="val : ${attrDef.allowedValues}" th:value="${val}" th:text="${val}"></option>
                     </select>

--- a/modules/editor/src/main/typescript/components/columns/columns-registration.ts
+++ b/modules/editor/src/main/typescript/components/columns/columns-registration.ts
@@ -104,7 +104,7 @@ export function createColumnsDefinition(): ComponentDefinition {
 
           <!-- Column count -->
           <div class="inspector-field">
-            <label class="inspector-field-label">Columns</label>
+            <span class="inspector-field-label">Columns</span>
             <div class="inspector-column-count">
               <button
                 class="inspector-column-btn"
@@ -126,7 +126,7 @@ export function createColumnsDefinition(): ComponentDefinition {
 
           <!-- Per-column sizes -->
           <div class="inspector-field">
-            <label class="inspector-field-label">Column Sizes</label>
+            <span class="inspector-field-label">Column Sizes</span>
             <div class="inspector-column-sizes">
               ${columnSizes.map(
                 (size, i) => html`
@@ -136,6 +136,7 @@ export function createColumnsDefinition(): ComponentDefinition {
                       type="number"
                       class="ep-input inspector-column-size-input"
                       min="1"
+                      id=${`columns-size-${i}`}
                       .value=${String(size)}
                       @change=${(e: Event) =>
                         handleColumnSizeChange(i, Number((e.target as HTMLInputElement).value))}
@@ -148,11 +149,12 @@ export function createColumnsDefinition(): ComponentDefinition {
 
           <!-- Gap -->
           <div class="inspector-field">
-            <label class="inspector-field-label">Gap (pt)</label>
+            <label class="inspector-field-label" for="columns-gap">Gap (pt)</label>
             <input
               type="number"
               class="ep-input"
               min="0"
+              id="columns-gap"
               .value=${String(gap)}
               @change=${(e: Event) => handleGapChange(Number((e.target as HTMLInputElement).value))}
             />

--- a/modules/editor/src/main/typescript/components/datatable/datatable-registration.ts
+++ b/modules/editor/src/main/typescript/components/datatable/datatable-registration.ts
@@ -256,7 +256,7 @@ export function createDatatableDefinition(): ComponentDefinition {
         <div class="inspector-section">
           <div class="inspector-section-label">Columns</div>
           <div class="inspector-field">
-            <label class="inspector-field-label">Column Count</label>
+            <span class="inspector-field-label">Column Count</span>
             <div class="inspector-column-count">
               <button
                 class="inspector-column-btn"

--- a/modules/editor/src/main/typescript/components/table/TableInspector.ts
+++ b/modules/editor/src/main/typescript/components/table/TableInspector.ts
@@ -83,7 +83,7 @@ export class TableInspector extends LitElement {
     const { rows } = this._props;
     return html`
       <div class="inspector-field">
-        <label class="inspector-field-label">Rows</label>
+        <span class="inspector-field-label">Rows</span>
         <div class="inspector-column-count">
           <button
             class="inspector-column-btn"
@@ -125,7 +125,7 @@ export class TableInspector extends LitElement {
     const { columns } = this._props;
     return html`
       <div class="inspector-field">
-        <label class="inspector-field-label">Columns</label>
+        <span class="inspector-field-label">Columns</span>
         <div class="inspector-column-count">
           <button
             class="inspector-column-btn"
@@ -174,7 +174,7 @@ export class TableInspector extends LitElement {
     const { columnWidths } = this._props;
     return html`
       <div class="inspector-field">
-        <label class="inspector-field-label">Column Widths</label>
+        <span class="inspector-field-label">Column Widths</span>
         <div class="inspector-column-sizes">
           ${columnWidths.map(
             (width, i) => html`
@@ -184,6 +184,7 @@ export class TableInspector extends LitElement {
                   type="number"
                   class="ep-input inspector-column-size-input"
                   min="1"
+                  id=${`table-column-width-${i}`}
                   .value=${String(width)}
                   @change=${(e: Event) =>
                     this._handleColumnWidthChange(i, Number((e.target as HTMLInputElement).value))}
@@ -216,10 +217,11 @@ export class TableInspector extends LitElement {
     const { headerRows, rows } = this._props;
     return html`
       <div class="inspector-field">
-        <label class="inspector-field-label">Header Rows</label>
+        <label class="inspector-field-label" for="table-header-rows">Header Rows</label>
         <input
           type="number"
           class="ep-input"
+          id="table-header-rows"
           min="0"
           max=${rows}
           .value=${String(headerRows)}
@@ -257,8 +259,8 @@ export class TableInspector extends LitElement {
 
     return html`
       <div class="inspector-field table-merge-controls">
-        <label class="inspector-field-label"
-          >Selection (${sel.startRow},${sel.startCol}) - (${sel.endRow},${sel.endCol})</label
+        <span class="inspector-field-label"
+          >Selection (${sel.startRow},${sel.startCol}) - (${sel.endRow},${sel.endCol})</span
         >
         <div class="table-merge-buttons">
           ${canDoMerge

--- a/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
@@ -139,6 +139,10 @@ function pathToErrorId(path: string): string {
   return `error-${path.replace(/\./g, '-')}`;
 }
 
+function fieldIdFromPath(path: string): string {
+  return `dc-field-${path.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+}
+
 /**
  * Render the example form from a JSON Schema.
  * When no schema exists, shows a placeholder message.
@@ -184,11 +188,12 @@ function renderFormField(
   const type = rawType === 'string' && propSchema.format === 'date' ? 'date' : rawType;
   const value = getNestedValue(rootData, path);
   const fieldError = errors.get(path);
+  const fieldId = fieldIdFromPath(path);
 
   const errorId = fieldError ? pathToErrorId(path) : undefined;
 
   const label = html`
-    <label class="dc-tree-label">
+    <label class="dc-tree-label" for=${fieldId}>
       ${name}${isRequired
         ? html`<span class="dc-required-mark" aria-hidden="true">*</span>`
         : nothing}
@@ -204,6 +209,7 @@ function renderFormField(
             <input
               type="text"
               class="ep-input dc-tree-input ${fieldError ? 'dc-input-error' : ''}"
+              id=${fieldId}
               .value=${String(value ?? '')}
               placeholder="${name}"
               aria-describedby=${fieldError ? errorId : nothing}
@@ -225,6 +231,7 @@ function renderFormField(
               type="number"
               class="ep-input dc-tree-input ${fieldError ? 'dc-input-error' : ''}"
               step="any"
+              id=${fieldId}
               .value=${value != null ? String(value) : ''}
               placeholder="${name}"
               aria-describedby=${fieldError ? errorId : nothing}
@@ -249,6 +256,7 @@ function renderFormField(
               type="number"
               class="ep-input dc-tree-input ${fieldError ? 'dc-input-error' : ''}"
               step="1"
+              id=${fieldId}
               .value=${value != null ? String(value) : ''}
               placeholder="${name}"
               aria-describedby=${fieldError ? errorId : nothing}
@@ -273,6 +281,7 @@ function renderFormField(
               <input
                 type="checkbox"
                 class="ep-checkbox"
+                id=${fieldId}
                 .checked=${value === true}
                 aria-label="${name}"
                 aria-describedby=${fieldError ? errorId : nothing}
@@ -294,6 +303,7 @@ function renderFormField(
             <input
               type="date"
               class="ep-input dc-tree-input ${fieldError ? 'dc-input-error' : ''}"
+              id=${fieldId}
               .value=${String(value ?? '')}
               aria-describedby=${fieldError ? errorId : nothing}
               @change=${(e: Event) => onChange(path, (e.target as HTMLInputElement).value)}
@@ -337,6 +347,7 @@ function renderFormField(
             <input
               type="text"
               class="ep-input dc-tree-input ${fieldError ? 'dc-input-error' : ''}"
+              id=${fieldId}
               .value=${String(value ?? '')}
               placeholder="${name}"
               aria-describedby=${fieldError ? errorId : nothing}
@@ -368,11 +379,11 @@ function renderObjectField(
   if (!propSchema.properties || Object.keys(propSchema.properties).length === 0) {
     return html`
       <div class="dc-tree-row">
-        <label class="dc-tree-label">
+        <span class="dc-tree-label">
           ${name}${isRequired
             ? html`<span class="dc-required-mark" aria-hidden="true">*</span>`
             : nothing}
-        </label>
+        </span>
         <span class="dc-tree-hint">No properties defined</span>
       </div>
     `;

--- a/modules/editor/src/main/typescript/theme-editor/sections/BasicInfoSection.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/BasicInfoSection.ts
@@ -12,18 +12,20 @@ export function renderBasicInfoSection(state: ThemeEditorState): unknown {
     <section class="theme-section">
       <h3 class="theme-section-label">Basic Information</h3>
       <div class="inspector-field">
-        <label class="inspector-field-label">Name</label>
+        <label class="inspector-field-label" for="theme-name">Name</label>
         <input
           type="text"
+          id="theme-name"
           class="ep-input"
           .value=${theme.name}
           @change=${(e: Event) => state.updateName((e.target as HTMLInputElement).value)}
         />
       </div>
       <div class="inspector-field">
-        <label class="inspector-field-label">Description</label>
+        <label class="inspector-field-label" for="theme-description">Description</label>
         <textarea
           class="ep-input ep-textarea"
+          id="theme-description"
           rows="2"
           .value=${theme.description ?? ''}
           @change=${(e: Event) => {

--- a/modules/editor/src/main/typescript/theme-editor/sections/DocumentStylesSection.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/DocumentStylesSection.ts
@@ -48,10 +48,11 @@ function renderStyleProperty(
   value: unknown,
   onChange: (value: unknown) => void,
 ): unknown {
+  const inputId = `theme-doc-style-${prop.key}`;
   return html`
     <div class="inspector-field">
-      <label class="inspector-field-label">${prop.label}</label>
-      ${renderStyleInput(prop, value, onChange)}
+      <label class="inspector-field-label" for=${inputId}>${prop.label}</label>
+      ${renderStyleInput(prop, value, onChange, inputId)}
     </div>
   `;
 }
@@ -60,21 +61,29 @@ function renderStyleInput(
   prop: StyleProperty,
   value: unknown,
   onChange: (value: unknown) => void,
+  inputId: string,
 ): unknown {
   switch (prop.type) {
     case 'select':
-      return renderSelectInput(value, prop.options ?? [], (v) => onChange(v || undefined));
+      return renderSelectInput(value, prop.options ?? [], (v) => onChange(v || undefined), inputId);
     case 'unit':
-      return renderUnitInput(value, prop.units ?? ['px'], (v) => onChange(v));
+      return renderUnitInput(value, prop.units ?? ['px'], (v) => onChange(v), undefined, inputId);
     case 'color':
-      return renderColorInput(value, (v) => onChange(v || undefined));
+      return renderColorInput(value, (v) => onChange(v || undefined), inputId);
     case 'spacing':
-      return renderSpacingInput(value, prop.units ?? ['px'], (v) => onChange(v));
+      return renderSpacingInput(
+        value,
+        prop.units ?? ['px'],
+        (v) => onChange(v),
+        undefined,
+        inputId,
+      );
     default:
       return html`
         <input
           type="text"
           class="ep-input"
+          id=${inputId}
           .value=${String(value ?? '')}
           @change=${(e: Event) => onChange((e.target as HTMLInputElement).value || undefined)}
         />

--- a/modules/editor/src/main/typescript/theme-editor/sections/PageSettingsSection.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/PageSettingsSection.ts
@@ -24,8 +24,9 @@ export function renderPageSettingsSection(state: ThemeEditorState): unknown {
       <h3 class="theme-section-label">Page Settings</h3>
 
       <div class="inspector-field">
-        <label class="inspector-field-label">Format</label>
+        <label class="inspector-field-label" for="theme-page-format">Format</label>
         <select
+          id="theme-page-format"
           class="ep-select"
           @change=${(e: Event) =>
             state.updatePageSetting('format', (e.target as HTMLSelectElement).value)}
@@ -37,8 +38,9 @@ export function renderPageSettingsSection(state: ThemeEditorState): unknown {
       </div>
 
       <div class="inspector-field">
-        <label class="inspector-field-label">Orientation</label>
+        <label class="inspector-field-label" for="theme-page-orientation">Orientation</label>
         <select
+          id="theme-page-orientation"
           class="ep-select"
           @change=${(e: Event) =>
             state.updatePageSetting('orientation', (e.target as HTMLSelectElement).value)}
@@ -54,7 +56,7 @@ export function renderPageSettingsSection(state: ThemeEditorState): unknown {
       </div>
 
       <div class="inspector-field">
-        <label class="inspector-field-label">Margins (mm)</label>
+        <label class="inspector-field-label" for="theme-page-margin-top">Margins (mm)</label>
         <div class="inspector-margins-grid">
           ${(['top', 'right', 'bottom', 'left'] as const).map(
             (side) => html`
@@ -62,6 +64,7 @@ export function renderPageSettingsSection(state: ThemeEditorState): unknown {
                 <span class="style-spacing-label">${side[0].toUpperCase()}</span>
                 <input
                   type="number"
+                  id=${`theme-page-margin-${side}`}
                   class="ep-input style-spacing-number"
                   .value=${String(margins[side])}
                   @change=${(e: Event) =>
@@ -74,20 +77,25 @@ export function renderPageSettingsSection(state: ThemeEditorState): unknown {
       </div>
 
       <div class="inspector-field">
-        <label class="inspector-field-label">Background Color</label>
-        ${renderColorInput(backgroundColor, (value) =>
-          state.updatePageSetting('backgroundColor', value || undefined),
+        <label class="inspector-field-label" for="theme-page-background-color">
+          Background Color
+        </label>
+        ${renderColorInput(
+          backgroundColor,
+          (value) => state.updatePageSetting('backgroundColor', value || undefined),
+          'theme-page-background-color',
         )}
       </div>
 
       <div class="inspector-field">
-        <label class="inspector-field-label">Spacing Unit (pt)</label>
+        <label class="inspector-field-label" for="theme-spacing-unit">Spacing Unit (pt)</label>
         <p class="theme-section-hint">
           Base unit for the spacing scale. All sp values are multiples of this.
         </p>
         <input
           type="number"
           class="ep-input"
+          id="theme-spacing-unit"
           min="1"
           max="16"
           step="0.5"

--- a/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
@@ -151,8 +151,11 @@ function renderPresetBody(
                 prop.type === 'spacing'
                   ? readSpacingFromStyles(prop.key, styles, prop.units?.[0] ?? 'px')
                   : styles[prop.key];
-              return renderPresetStyleProperty(prop, value, (v) =>
-                state.updatePresetStyle(name, prop.key, v),
+              return renderPresetStyleProperty(
+                prop,
+                value,
+                (v) => state.updatePresetStyle(name, prop.key, v),
+                `preset-${name}-style-${prop.key}`,
               );
             })}
           </div>
@@ -166,11 +169,12 @@ function renderPresetStyleProperty(
   prop: StyleProperty,
   value: unknown,
   onChange: (value: unknown) => void,
+  inputId: string,
 ): unknown {
   return html`
     <div class="inspector-field">
-      <label class="inspector-field-label">${prop.label}</label>
-      ${renderPresetStyleInput(prop, value, onChange)}
+      <label class="inspector-field-label" for=${inputId}>${prop.label}</label>
+      ${renderPresetStyleInput(prop, value, onChange, inputId)}
     </div>
   `;
 }
@@ -179,21 +183,29 @@ function renderPresetStyleInput(
   prop: StyleProperty,
   value: unknown,
   onChange: (value: unknown) => void,
+  inputId: string,
 ): unknown {
   switch (prop.type) {
     case 'select':
-      return renderSelectInput(value, prop.options ?? [], (v) => onChange(v || undefined));
+      return renderSelectInput(value, prop.options ?? [], (v) => onChange(v || undefined), inputId);
     case 'unit':
-      return renderUnitInput(value, prop.units ?? ['px'], (v) => onChange(v));
+      return renderUnitInput(value, prop.units ?? ['px'], (v) => onChange(v), undefined, inputId);
     case 'color':
-      return renderColorInput(value, (v) => onChange(v || undefined));
+      return renderColorInput(value, (v) => onChange(v || undefined), inputId);
     case 'spacing':
-      return renderSpacingInput(value, prop.units ?? ['px'], (v) => onChange(v));
+      return renderSpacingInput(
+        value,
+        prop.units ?? ['px'],
+        (v) => onChange(v),
+        undefined,
+        inputId,
+      );
     default:
       return html`
         <input
           type="text"
           class="ep-input"
+          id=${inputId}
           .value=${String(value ?? '')}
           @change=${(e: Event) => onChange((e.target as HTMLInputElement).value || undefined)}
         />

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -135,8 +135,9 @@ export class EpistolaInspector extends LitElement {
         <div class="inspector-section-label">Page Settings</div>
 
         <div class="inspector-field">
-          <label class="inspector-field-label">Format</label>
+          <label class="inspector-field-label" for="page-settings-format">Format</label>
           <select
+            id="page-settings-format"
             class="ep-select"
             @change=${(e: Event) =>
               this._handlePageSettingChange('format', (e.target as HTMLSelectElement).value)}
@@ -148,8 +149,9 @@ export class EpistolaInspector extends LitElement {
         </div>
 
         <div class="inspector-field">
-          <label class="inspector-field-label">Orientation</label>
+          <label class="inspector-field-label" for="page-settings-orientation">Orientation</label>
           <select
+            id="page-settings-orientation"
             class="ep-select"
             @change=${(e: Event) =>
               this._handlePageSettingChange('orientation', (e.target as HTMLSelectElement).value)}
@@ -165,7 +167,7 @@ export class EpistolaInspector extends LitElement {
         </div>
 
         <div class="inspector-field">
-          <label class="inspector-field-label">Margins (mm)</label>
+          <label class="inspector-field-label" for="page-settings-margin-top">Margins (mm)</label>
           <div class="inspector-margins-grid">
             ${(['top', 'right', 'bottom', 'left'] as const).map(
               (side) => html`
@@ -173,6 +175,7 @@ export class EpistolaInspector extends LitElement {
                   <span class="style-spacing-label">${side[0].toUpperCase()}</span>
                   <input
                     type="number"
+                    id=${`page-settings-margin-${side}`}
                     class="ep-input style-spacing-number"
                     .value=${String(settings.margins[side])}
                     @change=${(e: Event) =>
@@ -185,9 +188,13 @@ export class EpistolaInspector extends LitElement {
         </div>
 
         <div class="inspector-field">
-          <label class="inspector-field-label">Background Color</label>
-          ${renderColorInput(settings.backgroundColor ?? '', (value) =>
-            this._handlePageSettingChange('backgroundColor', value),
+          <label class="inspector-field-label" for="page-settings-background-color">
+            Background Color
+          </label>
+          ${renderColorInput(
+            settings.backgroundColor ?? '',
+            (value) => this._handlePageSettingChange('backgroundColor', value),
+            'page-settings-background-color',
           )}
         </div>
       </div>
@@ -217,8 +224,9 @@ export class EpistolaInspector extends LitElement {
       if (applicablePresets.length > 0) {
         return html`
           <div class="inspector-section">
-            <label class="inspector-field-label">Style Preset</label>
+            <label class="inspector-field-label" for="style-preset-select">Style Preset</label>
             <select
+              id="style-preset-select"
               class="ep-select"
               @change=${(e: Event) => {
                 const value = (e.target as HTMLSelectElement).value;
@@ -242,9 +250,10 @@ export class EpistolaInspector extends LitElement {
     // Fallback: text input for preset name (no theme or no applicable presets)
     return html`
       <div class="inspector-section">
-        <label class="inspector-field-label">Style Preset</label>
+        <label class="inspector-field-label" for="style-preset-input">Style Preset</label>
         <input
           type="text"
+          id="style-preset-input"
           class="ep-input"
           .value=${node.stylePreset ?? ''}
           @change=${(e: Event) => {
@@ -317,10 +326,11 @@ export class EpistolaInspector extends LitElement {
     value: unknown,
     onChange: (value: unknown) => void,
   ): unknown {
+    const inputId = `inspector-style-${prop.key}`;
     return html`
       <div class="inspector-field">
-        <label class="inspector-field-label">${prop.label}</label>
-        ${this._renderStyleInput(prop, value, onChange)}
+        <label class="inspector-field-label" for=${inputId}>${prop.label}</label>
+        ${this._renderStyleInput(prop, value, onChange, inputId)}
       </div>
     `;
   }
@@ -329,21 +339,34 @@ export class EpistolaInspector extends LitElement {
     prop: StyleProperty,
     value: unknown,
     onChange: (value: unknown) => void,
+    inputId: string,
   ): unknown {
     switch (prop.type) {
       case 'select':
-        return renderSelectInput(value, prop.options ?? [], (v) => onChange(v || undefined));
+        return renderSelectInput(
+          value,
+          prop.options ?? [],
+          (v) => onChange(v || undefined),
+          inputId,
+        );
       case 'unit':
-        return renderUnitInput(value, prop.units ?? ['px'], (v) => onChange(v));
+        return renderUnitInput(value, prop.units ?? ['px'], (v) => onChange(v), undefined, inputId);
       case 'color':
-        return renderColorInput(value, (v) => onChange(v || undefined));
+        return renderColorInput(value, (v) => onChange(v || undefined), inputId);
       case 'spacing':
-        return renderSpacingInput(value, prop.units ?? ['px'], (v) => onChange(v));
+        return renderSpacingInput(
+          value,
+          prop.units ?? ['px'],
+          (v) => onChange(v),
+          undefined,
+          inputId,
+        );
       case 'number':
         return html`
           <input
             type="number"
             class="ep-input"
+            id=${inputId}
             .value=${String(value ?? '')}
             @change=${(e: Event) => onChange(Number((e.target as HTMLInputElement).value))}
           />
@@ -354,6 +377,7 @@ export class EpistolaInspector extends LitElement {
           <input
             type="text"
             class="ep-input"
+            id=${inputId}
             .value=${String(value ?? '')}
             @change=${(e: Event) => onChange((e.target as HTMLInputElement).value || undefined)}
           />
@@ -377,15 +401,17 @@ export class EpistolaInspector extends LitElement {
   private _renderField(node: Node, field: InspectorField): unknown {
     const props = node.props ?? {};
     const value = getNestedValue(props, field.key);
+    const fieldId = `inspector-prop-${field.key}`;
 
     switch (field.type) {
       case 'text':
         return html`
           <div class="inspector-field">
-            <label class="inspector-field-label">${field.label}</label>
+            <label class="inspector-field-label" for=${fieldId}>${field.label}</label>
             <input
               type="text"
               class="ep-input"
+              id=${fieldId}
               .value=${String(value ?? '')}
               @change=${(e: Event) =>
                 this._handlePropChange(field.key, (e.target as HTMLInputElement).value)}
@@ -395,10 +421,11 @@ export class EpistolaInspector extends LitElement {
       case 'number':
         return html`
           <div class="inspector-field">
-            <label class="inspector-field-label">${field.label}</label>
+            <label class="inspector-field-label" for=${fieldId}>${field.label}</label>
             <input
               type="number"
               class="ep-input"
+              id=${fieldId}
               .value=${String(value ?? 0)}
               @change=${(e: Event) =>
                 this._handlePropChange(field.key, Number((e.target as HTMLInputElement).value))}
@@ -411,27 +438,33 @@ export class EpistolaInspector extends LitElement {
             <input
               type="checkbox"
               class="ep-checkbox"
+              id=${fieldId}
               .checked=${Boolean(value)}
               @change=${(e: Event) =>
                 this._handlePropChange(field.key, (e.target as HTMLInputElement).checked)}
             />
-            <label class="inspector-field-label">${field.label}</label>
+            <label class="inspector-field-label" for=${fieldId}>${field.label}</label>
           </div>
         `;
       case 'unit':
         return html`
           <div class="inspector-field">
-            <label class="inspector-field-label">${field.label}</label>
-            ${renderUnitInput(value, field.units ?? ['pt'], (v) =>
-              this._handlePropChange(field.key, v),
+            <label class="inspector-field-label" for=${fieldId}>${field.label}</label>
+            ${renderUnitInput(
+              value,
+              field.units ?? ['pt'],
+              (v) => this._handlePropChange(field.key, v),
+              undefined,
+              fieldId,
             )}
           </div>
         `;
       case 'select':
         return html`
           <div class="inspector-field">
-            <label class="inspector-field-label">${field.label}</label>
+            <label class="inspector-field-label" for=${fieldId}>${field.label}</label>
             <select
+              id=${fieldId}
               class="ep-select"
               @change=${(e: Event) =>
                 this._handlePropChange(field.key, (e.target as HTMLSelectElement).value)}
@@ -456,8 +489,9 @@ export class EpistolaInspector extends LitElement {
 
         return html`
           <div class="inspector-field">
-            <label class="inspector-field-label">${field.label}</label>
+            <label class="inspector-field-label" for=${fieldId}>${field.label}</label>
             <button
+              id=${fieldId}
               class="inspector-expression-trigger ${validClass}"
               @click=${() => this._openExpressionDialog(field.key, exprValue, node)}
             >
@@ -475,7 +509,7 @@ export class EpistolaInspector extends LitElement {
       default:
         return html`
           <div class="inspector-field">
-            <label class="inspector-field-label">${field.label}</label>
+            <label class="inspector-field-label" for=${fieldId}>${field.label}</label>
             <div class="inspector-unsupported">Unsupported field type: ${field.type}</div>
           </div>
         `;

--- a/modules/editor/src/main/typescript/ui/expression-dialog.ts
+++ b/modules/editor/src/main/typescript/ui/expression-dialog.ts
@@ -266,7 +266,7 @@ export function openExpressionDialog(
           enableBuilderMode
             ? `
         <div class="expression-dialog-header">
-          <label class="expression-dialog-label">${escapeHtml(label)}</label>
+          <label class="expression-dialog-label" for="expression-dialog-input">${escapeHtml(label)}</label>
           <div class="expression-dialog-mode-toggle">
             <button type="button" class="mode-btn${currentMode === 'builder' ? ' active' : ''}" data-mode="builder">Builder</button>
             <button type="button" class="mode-btn${currentMode === 'code' ? ' active' : ''}" data-mode="code">Code</button>
@@ -275,12 +275,12 @@ export function openExpressionDialog(
         <div class="expression-dialog-builder" data-mode-panel="builder"${currentMode !== 'builder' ? ' style="display:none"' : ''}>
           <div class="expression-dialog-builder-row">
             <div class="expression-dialog-builder-field">
-              <label>Field</label>
-              <select class="expression-dialog-field-select">${fieldOptionsHtml}</select>
+              <label for="expression-dialog-field">Field</label>
+              <select class="expression-dialog-field-select" id="expression-dialog-field">${fieldOptionsHtml}</select>
             </div>
             <div class="expression-dialog-builder-format" style="display:none">
-              <label>Format</label>
-              <select class="expression-dialog-builder-format-select">${formatOptionsHtml}</select>
+              <label for="expression-dialog-builder-format">Format</label>
+              <select class="expression-dialog-builder-format-select" id="expression-dialog-builder-format">${formatOptionsHtml}</select>
             </div>
           </div>
           <div class="expression-dialog-preview builder-preview" style="display:none"></div>
@@ -289,12 +289,13 @@ export function openExpressionDialog(
           This expression is too complex for Builder mode.
         </div>
         `
-            : `<label class="expression-dialog-label">${escapeHtml(label)}</label>`
+            : `<label class="expression-dialog-label" for="expression-dialog-input">${escapeHtml(label)}</label>`
         }
         <div class="expression-dialog-code" data-mode-panel="code"${enableBuilderMode && currentMode !== 'code' ? ' style="display:none"' : ''}>
           <input
             type="text"
             class="expression-dialog-input"
+            id="expression-dialog-input"
             value="${escapeAttr(initialValue)}"
             placeholder="${escapeAttr(placeholder)}"
             autocomplete="off"
@@ -302,8 +303,8 @@ export function openExpressionDialog(
           ${
             !enableBuilderMode
               ? `<div class="expression-dialog-format-row" style="display:none">
-            <label class="expression-dialog-format-label">Date format</label>
-            <select class="expression-dialog-format-select">${formatOptionsHtml}</select>
+            <label class="expression-dialog-format-label" for="expression-dialog-date-format">Date format</label>
+            <select class="expression-dialog-format-select" id="expression-dialog-date-format">${formatOptionsHtml}</select>
           </div>`
               : ''
           }

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -39,6 +39,7 @@ export function renderUnitInput(
   units: string[],
   onChange: (value: string) => void,
   baseUnit: number = DEFAULT_SPACING_UNIT,
+  inputId?: string,
 ): unknown {
   const defaultUnit = units[0] ?? 'pt';
   const parsed = parseValueWithUnit(value, defaultUnit);
@@ -66,6 +67,7 @@ export function renderUnitInput(
       <input
         type="number"
         class="ep-input style-unit-number"
+        id=${inputId ?? nothing}
         step=${parsed.unit === 'sp' ? '0.5' : '1'}
         .value=${String(parsed.value)}
         @change=${handleNumberChange}
@@ -87,7 +89,11 @@ export function renderUnitInput(
 // Color input: native color picker + text input
 // ---------------------------------------------------------------------------
 
-export function renderColorInput(value: unknown, onChange: (value: string) => void): unknown {
+export function renderColorInput(
+  value: unknown,
+  onChange: (value: string) => void,
+  inputId?: string,
+): unknown {
   const colorValue = value != null ? String(value) : '';
   // Ensure the color picker gets a valid hex value
   const pickerValue = colorValue.startsWith('#') ? colorValue : '#000000';
@@ -103,6 +109,7 @@ export function renderColorInput(value: unknown, onChange: (value: string) => vo
       <input
         type="text"
         class="ep-input style-color-text"
+        id=${inputId ?? nothing}
         .value=${colorValue}
         @change=${(e: Event) => onChange((e.target as HTMLInputElement).value)}
         placeholder="#000000"
@@ -261,11 +268,13 @@ export function renderSpacingInput(
   units: string[],
   onChange: (value: SpacingValue) => void,
   baseUnit: number = DEFAULT_SPACING_UNIT,
+  inputId?: string,
 ): unknown {
   const firstAbsUnit = units.find((u) => u !== 'sp') ?? 'pt';
   const parsed = parseSpacingValue(value, firstAbsUnit);
   const currentUnit = detectSpacingUnit(parsed, firstAbsUnit);
   const sides = ['top', 'right', 'bottom', 'left'] as const;
+  const topInputId = inputId ?? undefined;
 
   const handleSideChange = (side: string, newValue: string) => {
     onChange({ ...parsed, [side]: newValue });
@@ -294,6 +303,7 @@ export function renderSpacingInput(
             <input
               type="number"
               class="ep-input style-spacing-number"
+              id=${side === 'top' && topInputId ? topInputId : nothing}
               step=${currentUnit === 'sp' ? '0.5' : '1'}
               min="0"
               .value=${String(sideNumber(parsed[side]))}
@@ -412,12 +422,14 @@ export function renderSelectInput(
   value: unknown,
   options: { label: string; value: string }[],
   onChange: (value: string) => void,
+  selectId?: string,
 ): unknown {
   const currentValue = value != null ? String(value) : '';
 
   return html`
     <select
       class="ep-select"
+      id=${selectId ?? nothing}
       @change=${(e: Event) => onChange((e.target as HTMLSelectElement).value)}
     >
       <option value="" ?selected=${!currentValue}>—</option>


### PR DESCRIPTION
## Description

Improve label accessibility across the editor and server templates by wiring labels to their
associated inputs and replacing display-only labels with non-label elements.

## Related Issue(s)

Closes #253

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

N/A

## Additional Notes

No automated tests were run for this change.
