### PR TITLE
feat: clean mode toggle and collapsible containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Clean mode toggle**: New toolbar button and keyboard shortcut (Leader + C) to toggle between design mode (full block chrome) and clean mode (headers and borders hidden, shown on hover). Persists across sessions via localStorage.
+- **Collapsible containers**: Container blocks (sections, columns, loops, conditionals, etc.) can now be collapsed to a single header line showing the component label and child count. Click the chevron in the block header to toggle. Reduces vertical clutter when working on large templates.
+
 ### Fixed
 
 - **Table rendering broken in demo**: Fixed table nodes in the invoice demo template using an old `rows` array format instead of the current numeric `rows`/`columns`/`headerRows` props.

--- a/modules/editor/src/main/typescript/editor.css
+++ b/modules/editor/src/main/typescript/editor.css
@@ -19,6 +19,7 @@
 @import './styles/sidebar.css';
 @import './styles/tree.css';
 @import './styles/canvas.css';
+@import './styles/clean-mode.css';
 @import './styles/preview.css';
 @import './styles/palette.css';
 @import './styles/inspector.css';

--- a/modules/editor/src/main/typescript/shortcuts/editor-runtime.test.ts
+++ b/modules/editor/src/main/typescript/shortcuts/editor-runtime.test.ts
@@ -24,6 +24,11 @@ describe('editor shortcut runtime registry', () => {
         (command) => command.id === EDITOR_SHORTCUT_COMMAND_IDS.openDataPreview,
       ),
     ).toBe(true);
+    expect(
+      registry.commands.some(
+        (command) => command.id === EDITOR_SHORTCUT_COMMAND_IDS.toggleCleanMode,
+      ),
+    ).toBe(true);
   });
 
   it('uses editor context for core shortcuts and global context for leader chords', () => {
@@ -42,6 +47,13 @@ describe('editor shortcut runtime registry', () => {
     expect(previewBinding).toBeDefined();
     expect(previewBinding?.context).toBe('global');
     expect(previewBinding?.keys).toContain('mod+code:space p');
+
+    const cleanModeBinding = registry.keybindings.find(
+      (binding) => binding.commandId === EDITOR_SHORTCUT_COMMAND_IDS.toggleCleanMode,
+    );
+    expect(cleanModeBinding).toBeDefined();
+    expect(cleanModeBinding?.context).toBe('global');
+    expect(cleanModeBinding?.keys).toContain('mod+code:space c');
   });
 
   it('preserves leader alias keys for opening shortcuts help', () => {
@@ -60,9 +72,10 @@ describe('editor shortcut runtime registry', () => {
       EDITOR_SHORTCUT_COMMAND_IDS.togglePreview,
       EDITOR_SHORTCUT_COMMAND_IDS.openShortcutsHelp,
       EDITOR_SHORTCUT_COMMAND_IDS.openDataPreview,
+      EDITOR_SHORTCUT_COMMAND_IDS.toggleCleanMode,
     ]);
 
-    expect(tokens).toEqual(['P', '?', 'E']);
+    expect(tokens).toEqual(['P', '?', 'E', 'C']);
   });
 
   it('returns toolbar display labels from runtime registry bindings', () => {
@@ -75,6 +88,9 @@ describe('editor shortcut runtime registry', () => {
     );
     expect(getShortcutDisplayForCommandId(EDITOR_SHORTCUT_COMMAND_IDS.openDataPreview)).toBe(
       'Leader + E',
+    );
+    expect(getShortcutDisplayForCommandId(EDITOR_SHORTCUT_COMMAND_IDS.toggleCleanMode)).toBe(
+      'Leader + C',
     );
   });
 });

--- a/modules/editor/src/main/typescript/shortcuts/editor-runtime.ts
+++ b/modules/editor/src/main/typescript/shortcuts/editor-runtime.ts
@@ -30,6 +30,7 @@ export const EDITOR_SHORTCUT_COMMAND_IDS = {
   focusResizeHandle: 'resize.handle.focus',
   moveSelectedBlockUp: 'editor.block.move-up',
   moveSelectedBlockDown: 'editor.block.move-down',
+  toggleCleanMode: 'editor.canvas.toggle-clean-mode',
 } as const;
 
 export type EditorShortcutCommandId =
@@ -58,6 +59,7 @@ export interface EditorShortcutRuntimeContext {
   focusResizeHandle: () => boolean;
   moveSelectedBlockUp: () => boolean;
   moveSelectedBlockDown: () => boolean;
+  toggleCleanMode: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,6 +266,19 @@ const EDITOR_SHORTCUT_COMMANDS: readonly CommandDefinition<EditorShortcutRuntime
     ),
     metadata: { idleToken: '\u2193' },
   },
+  {
+    id: C.toggleCleanMode,
+    label: 'Clean mode',
+    category: 'Leader',
+    run: leaderRun(
+      (ctx) => {
+        ctx.toggleCleanMode();
+      },
+      'Clean mode toggled',
+      'Cannot toggle clean mode',
+    ),
+    metadata: { idleToken: 'C' },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -385,6 +400,13 @@ const EDITOR_SHORTCUT_KEYBINDINGS: readonly KeybindingDefinition<EditorShortcutR
     keys: leaderKeys('arrowdown'),
     preventDefault: true,
     display: 'Leader + \u2193',
+  },
+  {
+    commandId: C.toggleCleanMode,
+    context: 'global',
+    keys: leaderKeys('c'),
+    preventDefault: true,
+    display: 'Leader + C',
   },
 ];
 

--- a/modules/editor/src/main/typescript/styles/canvas.css
+++ b/modules/editor/src/main/typescript/styles/canvas.css
@@ -153,4 +153,41 @@
   .canvas-column {
     min-width: 0; /* prevent overflow from long content */
   }
+
+  /* Collapse toggle button */
+  .canvas-block-collapse {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border: none;
+    border-radius: var(--ep-radius-sm);
+    background: transparent;
+    color: var(--ep-gray-400);
+    cursor: pointer;
+    padding: 0;
+    transition:
+      transform var(--ep-transition-fast),
+      color var(--ep-transition-fast);
+  }
+
+  .canvas-block-collapse:hover {
+    color: var(--ep-gray-600);
+  }
+
+  /* Chevron rotates 90deg when expanded (not collapsed) */
+  .canvas-block:not(.collapsed) .canvas-block-collapse {
+    transform: rotate(90deg);
+  }
+
+  /* Child count badge */
+  .canvas-block-child-count {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--ep-gray-400);
+    background: var(--ep-gray-100);
+    padding: 0 var(--ep-space-1);
+    border-radius: var(--ep-radius-sm);
+  }
 }

--- a/modules/editor/src/main/typescript/styles/clean-mode.css
+++ b/modules/editor/src/main/typescript/styles/clean-mode.css
@@ -1,0 +1,72 @@
+/*
+ * Clean Mode
+ *
+ * Hides block chrome (headers, borders, margins) for a cleaner
+ * editing experience. Shows subtle feedback on hover and selection.
+ */
+
+@layer states {
+  /* Hide block headers */
+  .clean-mode .canvas-block-header {
+    display: none;
+  }
+
+  /* Remove block content borders and padding */
+  .clean-mode .canvas-block-content {
+    border: none;
+    padding: 0;
+    border-radius: 0;
+  }
+
+  /* Remove block margin and default hover shadow */
+  .clean-mode .canvas-block {
+    margin-block: 0;
+    box-shadow: none;
+    border-radius: 0;
+  }
+
+  /* Hover: subtle outline + floating label */
+  .clean-mode .canvas-block:hover {
+    box-shadow: 0 0 0 1px var(--ep-blue-200);
+  }
+
+  .clean-mode .canvas-block:hover:not([data-drop-edge]):not(.dragging)::before {
+    content: attr(data-block-label);
+    position: absolute;
+    top: -1.25rem;
+    left: var(--ep-space-1);
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--ep-blue-500);
+    background: var(--ep-white);
+    padding: 0 var(--ep-space-1);
+    border-radius: var(--ep-radius-sm);
+    box-shadow: var(--ep-shadow-xs);
+    pointer-events: none;
+    z-index: 1;
+    white-space: nowrap;
+  }
+
+  /* Selected block: keep blue ring */
+  .clean-mode .canvas-block.selected {
+    box-shadow: 0 0 0 2px var(--ep-blue-500);
+  }
+
+  /* Subtle empty slots */
+  .clean-mode .canvas-slot.empty {
+    min-height: 1.5rem;
+    border-color: var(--ep-gray-200);
+  }
+
+  .clean-mode .canvas-slot-hint {
+    color: var(--ep-gray-300);
+  }
+
+  /* Collapsed blocks in clean mode still show their header */
+  .clean-mode .canvas-block.collapsed .canvas-block-header {
+    display: flex;
+    background: transparent;
+    border: 1px dashed var(--ep-gray-200);
+    padding: var(--ep-space-0-5) var(--ep-space-2);
+  }
+}

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import {
   draggable,
@@ -16,6 +16,7 @@ import { isDragData, isBlockDrag, type DragData } from '../dnd/types.js';
 import { resolveDropOnBlockEdge, canDropHere, type Edge } from '../dnd/drop-logic.js';
 import { handleDrop } from '../dnd/drop-handler.js';
 import { icon } from './icons.js';
+import { isCollapsible, countChildren } from './collapse.js';
 import '../ui/EpistolaTextEditor.js';
 
 @customElement('epistola-canvas')
@@ -27,6 +28,9 @@ export class EpistolaCanvas extends LitElement {
   @property({ attribute: false }) engine?: EditorEngine;
   @property({ attribute: false }) doc?: TemplateDocument;
   @property({ attribute: false }) selectedNodeId: NodeId | null = null;
+  @property({ type: Boolean }) cleanMode = false;
+
+  @state() private _collapsedNodes = new Set<NodeId>();
 
   private _dndCleanup: (() => void) | null = null;
   private _unsubComponentState?: () => void;
@@ -44,6 +48,11 @@ export class EpistolaCanvas extends LitElement {
 
   private _handleDeleteBlock(nodeId: NodeId) {
     if (!this.engine) return;
+    if (this._collapsedNodes.has(nodeId)) {
+      const next = new Set(this._collapsedNodes);
+      next.delete(nodeId);
+      this._collapsedNodes = next;
+    }
     this.engine.dispatch({ type: 'RemoveNode', nodeId });
     this.engine.selectNode(null);
   }
@@ -114,7 +123,9 @@ export class EpistolaCanvas extends LitElement {
         cleanups.push(
           draggable({
             element: blockEl,
-            dragHandle: blockEl.querySelector<HTMLElement>('.canvas-block-header') ?? blockEl,
+            dragHandle: this.cleanMode
+              ? blockEl
+              : (blockEl.querySelector<HTMLElement>('.canvas-block-header') ?? blockEl),
             getInitialData: (): DragData => ({
               source: 'block',
               nodeId,
@@ -272,6 +283,29 @@ export class EpistolaCanvas extends LitElement {
   }
 
   // ---------------------------------------------------------------------------
+  // Collapse
+  // ---------------------------------------------------------------------------
+
+  private _handleToggleCollapse(e: Event, nodeId: NodeId) {
+    e.stopPropagation();
+    const next = new Set(this._collapsedNodes);
+    if (next.has(nodeId)) {
+      next.delete(nodeId);
+    } else {
+      next.add(nodeId);
+    }
+    this._collapsedNodes = next;
+  }
+
+  private _isCollapsible(nodeId: NodeId): boolean {
+    return this.doc ? isCollapsible(this.doc, nodeId) : false;
+  }
+
+  private _countChildren(nodeId: NodeId): number {
+    return this.doc ? countChildren(this.doc, nodeId) : 0;
+  }
+
+  // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
 
@@ -287,7 +321,10 @@ export class EpistolaCanvas extends LitElement {
     }
 
     return html`
-      <div class="epistola-canvas" @click=${this._handleCanvasClick}>
+      <div
+        class="epistola-canvas ${this.cleanMode ? 'clean-mode' : ''}"
+        @click=${this._handleCanvasClick}
+      >
         <div class="canvas-page" style=${styleMap(pageStyle)}>
           ${this._renderNodeChildren(this.doc.root)}
         </div>
@@ -339,6 +376,8 @@ export class EpistolaCanvas extends LitElement {
     const isSelected = this.selectedNodeId === nodeId;
     const def = this.engine!.registry.get(node.type);
     const label = def?.label ?? node.type;
+    const collapsible = this._isCollapsible(nodeId);
+    const collapsed = collapsible && this._collapsedNodes.has(nodeId);
 
     // Resolve styles through the full cascade, filtered by component's applicable styles
     const resolvedStyles = this.engine!.getResolvedNodeStyles(nodeId);
@@ -348,16 +387,36 @@ export class EpistolaCanvas extends LitElement {
 
     return html`
       <div
-        class="canvas-block ${isSelected ? 'selected' : ''}"
+        class="canvas-block ${isSelected ? 'selected' : ''} ${collapsed ? 'collapsed' : ''}"
         data-testid="canvas-block"
         data-node-id=${nodeId}
+        data-block-label=${label}
         tabindex="0"
         @click=${(e: Event) => this._handleSelect(e, nodeId)}
         @focus=${() => this._handleFocus(nodeId)}
       >
         <!-- Block header -->
         <div class="canvas-block-header">
+          ${collapsible
+            ? html`
+                <button
+                  class="canvas-block-collapse"
+                  title="${collapsed ? 'Expand' : 'Collapse'}"
+                  @click=${(e: Event) => this._handleToggleCollapse(e, nodeId)}
+                >
+                  ${icon('chevron-right', 14)}
+                </button>
+              `
+            : nothing}
           <span class="canvas-block-label">${label}</span>
+          ${collapsed
+            ? html`<span class="canvas-block-child-count"
+                >${(() => {
+                  const count = this._countChildren(nodeId);
+                  return count === 0 ? 'empty' : `${count} blocks`;
+                })()}</span
+              >`
+            : nothing}
           <span class="canvas-block-id">${nodeId.slice(0, 6)}</span>
           ${isSelected
             ? html`
@@ -375,13 +434,17 @@ export class EpistolaCanvas extends LitElement {
             : nothing}
         </div>
 
-        <!-- Block content area -->
-        <div
-          class="canvas-block-content ${node.type === 'text' ? 'text-type' : ''}"
-          style=${styleMap(contentStyle)}
-        >
-          ${this._renderBlockContent(nodeId)}
-        </div>
+        <!-- Block content area (hidden when collapsed) -->
+        ${collapsed
+          ? nothing
+          : html`
+              <div
+                class="canvas-block-content ${node.type === 'text' ? 'text-type' : ''}"
+                style=${styleMap(contentStyle)}
+              >
+                ${this._renderBlockContent(nodeId)}
+              </div>
+            `}
       </div>
     `;
   }

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
@@ -119,6 +119,7 @@ export class EpistolaEditor extends LitElement {
   @state() private _doc?: TemplateDocument;
   @state() private _selectedNodeId: NodeId | null = null;
   @state() private _previewOpen = false;
+  @state() private _cleanMode = false;
   @state() private _saveState: SaveState = { status: 'idle' };
   @state() private _leaderVisible = false;
   @state() private _leaderStatus: 'idle' | 'success' | 'error' = 'idle';
@@ -134,6 +135,7 @@ export class EpistolaEditor extends LitElement {
   private _insertTarget: InsertTarget | null = null;
 
   private static readonly PREVIEW_OPEN_KEY = 'ep:preview-open';
+  private static readonly CLEAN_MODE_KEY = 'ep:clean-mode';
 
   get engine(): EditorEngine | undefined {
     return this._engine;
@@ -230,12 +232,14 @@ export class EpistolaEditor extends LitElement {
     validateCoreShortcutRegistriesOnStartup();
     window.addEventListener('keydown', this._onKeydown);
     this.addEventListener('toggle-preview', this._handleTogglePreview);
+    this.addEventListener('toggle-clean-mode', this._handleToggleCleanMode);
     this.addEventListener('force-save', this._handleForceSave);
     window.addEventListener('beforeunload', this._onBeforeUnload);
 
     // Restore preview open state from localStorage
     try {
       this._previewOpen = localStorage.getItem(EpistolaEditor.PREVIEW_OPEN_KEY) === 'true';
+      this._cleanMode = localStorage.getItem(EpistolaEditor.CLEAN_MODE_KEY) === 'true';
     } catch {
       // localStorage may be unavailable
     }
@@ -244,6 +248,7 @@ export class EpistolaEditor extends LitElement {
   override disconnectedCallback(): void {
     window.removeEventListener('keydown', this._onKeydown);
     this.removeEventListener('toggle-preview', this._handleTogglePreview);
+    this.removeEventListener('toggle-clean-mode', this._handleToggleCleanMode);
     this.removeEventListener('force-save', this._handleForceSave);
     window.removeEventListener('beforeunload', this._onBeforeUnload);
     super.disconnectedCallback();
@@ -323,6 +328,9 @@ export class EpistolaEditor extends LitElement {
       focusResizeHandle: () => this._focusResizeHandle(),
       moveSelectedBlockUp: () => this._moveSelectedNode(-1),
       moveSelectedBlockDown: () => this._moveSelectedNode(1),
+      toggleCleanMode: () => {
+        this._handleToggleCleanMode();
+      },
     };
   }
 
@@ -1088,6 +1096,15 @@ export class EpistolaEditor extends LitElement {
     }
   };
 
+  private _handleToggleCleanMode = () => {
+    this._cleanMode = !this._cleanMode;
+    try {
+      localStorage.setItem(EpistolaEditor.CLEAN_MODE_KEY, String(this._cleanMode));
+    } catch {
+      // localStorage may be unavailable
+    }
+  };
+
   private _handleForceSave = () => {
     if (this._saveService && this._doc) {
       this._saveService.forceSave(this._doc);
@@ -1141,6 +1158,7 @@ export class EpistolaEditor extends LitElement {
         <epistola-toolbar
           .engine=${this._engine}
           .previewOpen=${this._previewOpen}
+          .cleanMode=${this._cleanMode}
           .hasPreview=${hasPreview}
           .hasSave=${hasSave}
           .saveState=${this._saveState}
@@ -1164,6 +1182,7 @@ export class EpistolaEditor extends LitElement {
             .engine=${this._engine}
             .doc=${this._doc}
             .selectedNodeId=${this._selectedNodeId}
+            .cleanMode=${this._cleanMode}
           ></epistola-canvas>
 
           ${showPreview

--- a/modules/editor/src/main/typescript/ui/EpistolaToolbar.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaToolbar.ts
@@ -49,6 +49,7 @@ export class EpistolaToolbar extends LitElement {
   @property({ attribute: false }) engine?: EditorEngine;
   @property({ type: Boolean }) previewOpen = false;
   @property({ type: Boolean }) hasPreview = false;
+  @property({ type: Boolean }) cleanMode = false;
   @property({ type: Boolean }) hasSave = false;
   @property({ attribute: false }) saveState?: SaveState;
   @property({ attribute: false }) pluginActions?: ToolbarAction[];
@@ -196,6 +197,10 @@ export class EpistolaToolbar extends LitElement {
 
   private _handleTogglePreview() {
     this.dispatchEvent(new CustomEvent('toggle-preview', { bubbles: true, composed: true }));
+  }
+
+  private _handleToggleCleanMode() {
+    this.dispatchEvent(new CustomEvent('toggle-clean-mode', { bubbles: true, composed: true }));
   }
 
   private _handleExampleChange(e: Event) {
@@ -691,6 +696,15 @@ export class EpistolaToolbar extends LitElement {
               </button>
             `
           : nothing}
+        <div class="toolbar-separator"></div>
+        <button
+          class="toolbar-btn ${this.cleanMode ? 'active' : ''}"
+          @click=${this._handleToggleCleanMode}
+          title="${this.cleanMode ? 'Show block chrome' : 'Hide block chrome'}"
+        >
+          ${this.cleanMode ? icon('eye') : icon('sparkles')} Clean
+        </button>
+
         ${hasExamples ? this._renderExampleSelector(examples!) : nothing}
         ${this._renderPluginActions()}
       </div>

--- a/modules/editor/src/main/typescript/ui/collapse.test.ts
+++ b/modules/editor/src/main/typescript/ui/collapse.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { isCollapsible, countChildren } from './collapse.js';
+import {
+  createTestDocument,
+  createTestDocumentWithChildren,
+  nodeId,
+  slotId,
+} from '../engine/test-helpers.js';
+
+describe('isCollapsible', () => {
+  it('returns false for the root node', () => {
+    const doc = createTestDocument();
+    expect(isCollapsible(doc, doc.root)).toBe(false);
+  });
+
+  it('returns false for a leaf node (no slots)', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    expect(isCollapsible(doc, textNodeId)).toBe(false);
+  });
+
+  it('returns true for a container node with slots', () => {
+    const { doc, containerNodeId } = createTestDocumentWithChildren();
+    expect(isCollapsible(doc, containerNodeId)).toBe(true);
+  });
+
+  it('returns false for a non-existent node', () => {
+    const doc = createTestDocument();
+    expect(isCollapsible(doc, nodeId('nonexistent'))).toBe(false);
+  });
+});
+
+describe('countChildren', () => {
+  it('returns 0 for a container with an empty slot', () => {
+    const { doc, containerNodeId } = createTestDocumentWithChildren();
+    expect(countChildren(doc, containerNodeId)).toBe(0);
+  });
+
+  it('counts children across all slots', () => {
+    const rootId = nodeId('r');
+    const rootSlot = slotId('rs');
+    const containerId = nodeId('c');
+    const slot1 = slotId('s1');
+    const slot2 = slotId('s2');
+    const child1 = nodeId('ch1');
+    const child2 = nodeId('ch2');
+    const child3 = nodeId('ch3');
+
+    const doc = createTestDocument({
+      root: rootId,
+      nodes: {
+        [rootId]: { id: rootId, type: 'root', slots: [rootSlot] },
+        [containerId]: { id: containerId, type: 'columns', slots: [slot1, slot2] },
+        [child1]: { id: child1, type: 'text', slots: [] },
+        [child2]: { id: child2, type: 'text', slots: [] },
+        [child3]: { id: child3, type: 'text', slots: [] },
+      },
+      slots: {
+        [rootSlot]: { id: rootSlot, nodeId: rootId, name: 'children', children: [containerId] },
+        [slot1]: { id: slot1, nodeId: containerId, name: 'column-0', children: [child1, child2] },
+        [slot2]: { id: slot2, nodeId: containerId, name: 'column-1', children: [child3] },
+      },
+    });
+
+    expect(countChildren(doc, containerId)).toBe(3);
+  });
+
+  it('returns 0 for a non-existent node', () => {
+    const doc = createTestDocument();
+    expect(countChildren(doc, nodeId('nonexistent'))).toBe(0);
+  });
+
+  it('returns 0 for a leaf node', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    expect(countChildren(doc, textNodeId)).toBe(0);
+  });
+});

--- a/modules/editor/src/main/typescript/ui/collapse.ts
+++ b/modules/editor/src/main/typescript/ui/collapse.ts
@@ -1,0 +1,30 @@
+/**
+ * Collapse helpers for the editor canvas.
+ *
+ * Pure functions that determine collapsibility and child counts
+ * for container blocks in the template document.
+ */
+import type { TemplateDocument, NodeId } from '../types/index.js';
+
+/**
+ * Returns true if a node can be collapsed (has child slots and is not the root).
+ */
+export function isCollapsible(doc: TemplateDocument, nodeId: NodeId): boolean {
+  const node = doc.nodes[nodeId];
+  if (!node) return false;
+  return node.slots.length > 0 && nodeId !== doc.root;
+}
+
+/**
+ * Counts the total number of direct children across all slots of a node.
+ */
+export function countChildren(doc: TemplateDocument, nodeId: NodeId): number {
+  const node = doc.nodes[nodeId];
+  if (!node) return 0;
+  let count = 0;
+  for (const slotId of node.slots) {
+    const slot = doc.slots[slotId];
+    if (slot) count += slot.children.length;
+  }
+  return count;
+}

--- a/modules/editor/src/main/typescript/ui/shortcuts.test.ts
+++ b/modules/editor/src/main/typescript/ui/shortcuts.test.ts
@@ -85,7 +85,7 @@ describe('shortcut helper projection', () => {
         {
           "fullWidth": false,
           "id": "leader-commands",
-          "itemCount": 11,
+          "itemCount": 12,
           "layout": "two-column",
           "title": "Leader Commands",
         },


### PR DESCRIPTION
## Summary

- **Clean mode**: toolbar toggle and keyboard shortcut (Leader + C) that hides block headers and borders for a distraction-free editing experience. Chrome reappears on hover with a floating label. Persisted to localStorage.
- **Collapsible containers**: container blocks (sections, columns, loops, conditionals, tables, etc.) get a chevron toggle in the header. Collapsed blocks show a summary line with child count. Content is not rendered when collapsed.
- Extracted collapse helpers as pure testable functions. Added test coverage for shortcuts registry and collapse logic.

## Test plan

- [ ] Toggle clean mode via toolbar button — headers/borders disappear, hover shows floating label
- [ ] Toggle via Leader + C — same behavior, leader hint shows "Clean mode toggled"
- [ ] Clean mode persists across page reload (localStorage)
- [ ] DnD works in clean mode (entire block is drag handle)
- [ ] Selection ring visible in both modes
- [ ] Collapse a container — content hidden, chevron points right, badge shows child count
- [ ] Collapse empty container — shows "empty" instead of "0 blocks"
- [ ] Expand — content reappears, chevron points down
- [ ] Delete a collapsed block — no stale state
- [ ] Collapse in clean mode — minimal dashed header visible with chevron
- [ ] `pnpm --filter @epistola/editor test` passes (873 tests)
- [ ] `./gradlew unitTest integrationTest` passes