### PR TITLE
feat(api): wire up attribute definitions REST endpoints

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ json-schema-validator = "3.0.1"
 uuid-creator = "6.1.1"
 spring-web = "7.0.6"
 playwright = "1.58.0"
-epistola-contract = "0.1.19"
+epistola-contract = "0.1.20"
 epistola-editor-model = "0.1.19"
 aws-sdk = "2.42.23"
 

--- a/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/EpistolaTenantApi.kt
+++ b/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/EpistolaTenantApi.kt
@@ -1,16 +1,28 @@
 package app.epistola.suite.api.v1
 
+import app.epistola.api.AttributesApi
 import app.epistola.api.EnvironmentsApi
 import app.epistola.api.TenantsApi
+import app.epistola.api.model.AttributeDto
+import app.epistola.api.model.AttributeListResponse
+import app.epistola.api.model.CreateAttributeRequest
 import app.epistola.api.model.CreateEnvironmentRequest
 import app.epistola.api.model.CreateTenantRequest
 import app.epistola.api.model.EnvironmentDto
 import app.epistola.api.model.EnvironmentListResponse
 import app.epistola.api.model.TenantDto
 import app.epistola.api.model.TenantListResponse
+import app.epistola.api.model.UpdateAttributeRequest
 import app.epistola.api.model.UpdateEnvironmentRequest
 import app.epistola.api.model.UpdateTenantRequest
 import app.epistola.suite.api.v1.shared.toDto
+import app.epistola.suite.attributes.commands.CreateAttributeDefinition
+import app.epistola.suite.attributes.commands.DeleteAttributeDefinition
+import app.epistola.suite.attributes.commands.UpdateAttributeDefinition
+import app.epistola.suite.attributes.queries.GetAttributeDefinition
+import app.epistola.suite.attributes.queries.ListAttributeDefinitions
+import app.epistola.suite.common.ids.AttributeId
+import app.epistola.suite.common.ids.AttributeKey
 import app.epistola.suite.common.ids.EnvironmentId
 import app.epistola.suite.common.ids.EnvironmentKey
 import app.epistola.suite.common.ids.TenantId
@@ -35,6 +47,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api")
 class EpistolaTenantApi :
     TenantsApi,
+    AttributesApi,
     EnvironmentsApi {
 
     // ================== Tenant operations ==================
@@ -90,6 +103,70 @@ class EpistolaTenantApi :
         tenantId: String,
     ): ResponseEntity<Unit> {
         val deleted = DeleteTenant(id = TenantKey.of(tenantId)).execute()
+        return if (deleted) {
+            ResponseEntity.noContent().build()
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+
+    // ================== Attribute operations ==================
+
+    override fun listAttributes(
+        tenantId: String,
+    ): ResponseEntity<AttributeListResponse> {
+        val tenantIdComposite = TenantId(TenantKey.of(tenantId))
+        val attributes = ListAttributeDefinitions(tenantId = tenantIdComposite).query()
+        return ResponseEntity.ok(AttributeListResponse(items = attributes.map { it.toDto() }))
+    }
+
+    override fun createAttribute(
+        tenantId: String,
+        createAttributeRequest: CreateAttributeRequest,
+    ): ResponseEntity<AttributeDto> {
+        val tenantIdComposite = TenantId(TenantKey.of(tenantId))
+        val attributeIdComposite = AttributeId(AttributeKey.of(createAttributeRequest.key), tenantIdComposite)
+        val attribute = CreateAttributeDefinition(
+            id = attributeIdComposite,
+            displayName = createAttributeRequest.description ?: createAttributeRequest.key,
+        ).execute()
+        return ResponseEntity.status(HttpStatus.CREATED).body(attribute.toDto())
+    }
+
+    override fun getAttribute(
+        tenantId: String,
+        attributeKey: String,
+    ): ResponseEntity<AttributeDto> {
+        val tenantIdComposite = TenantId(TenantKey.of(tenantId))
+        val attributeIdComposite = AttributeId(AttributeKey.of(attributeKey), tenantIdComposite)
+        val attribute = GetAttributeDefinition(id = attributeIdComposite).query()
+            ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(attribute.toDto())
+    }
+
+    override fun updateAttribute(
+        tenantId: String,
+        attributeKey: String,
+        updateAttributeRequest: UpdateAttributeRequest,
+    ): ResponseEntity<AttributeDto> {
+        val description = updateAttributeRequest.description
+            ?: return ResponseEntity.badRequest().build()
+        val tenantIdComposite = TenantId(TenantKey.of(tenantId))
+        val attributeIdComposite = AttributeId(AttributeKey.of(attributeKey), tenantIdComposite)
+        val attribute = UpdateAttributeDefinition(
+            id = attributeIdComposite,
+            displayName = description,
+        ).execute() ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(attribute.toDto())
+    }
+
+    override fun deleteAttribute(
+        tenantId: String,
+        attributeKey: String,
+    ): ResponseEntity<Unit> {
+        val tenantIdComposite = TenantId(TenantKey.of(tenantId))
+        val attributeIdComposite = AttributeId(AttributeKey.of(attributeKey), tenantIdComposite)
+        val deleted = DeleteAttributeDefinition(id = attributeIdComposite).execute()
         return if (deleted) {
             ResponseEntity.noContent().build()
         } else {

--- a/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/shared/DtoMappers.kt
+++ b/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/shared/DtoMappers.kt
@@ -1,6 +1,7 @@
 package app.epistola.suite.api.v1.shared
 
 import app.epistola.api.model.ActivationDto
+import app.epistola.api.model.AttributeDto
 import app.epistola.api.model.DataExampleDto
 import app.epistola.api.model.EnvironmentDto
 import app.epistola.api.model.TemplateDto
@@ -10,6 +11,7 @@ import app.epistola.api.model.VariantDto
 import app.epistola.api.model.VariantSummaryDto
 import app.epistola.api.model.VersionDto
 import app.epistola.api.model.VersionSummaryDto
+import app.epistola.suite.attributes.model.VariantAttributeDefinition
 import app.epistola.suite.environments.Environment
 import app.epistola.suite.templates.DocumentTemplate
 import app.epistola.suite.templates.model.ActivationDetails
@@ -23,6 +25,13 @@ import tools.jackson.databind.ObjectMapper
 internal fun Tenant.toDto() = TenantDto(
     id = id.value,
     name = name,
+    createdAt = createdAt,
+)
+
+internal fun VariantAttributeDefinition.toDto() = AttributeDto(
+    key = id.value,
+    tenantId = tenantKey.value,
+    description = displayName,
     createdAt = createdAt,
 )
 


### PR DESCRIPTION
## Summary

- Implements `AttributesApi` from epistola-contract 0.1.20 (epistola-app/epistola-contract#8)
- Wires the existing domain layer (commands/queries in `modules/epistola-core/src/.../attributes/`) to REST endpoints
- Adds `VariantAttributeDefinition.toDto()` mapper (`displayName` → `description`)
- Bumps `epistola-contract` from 0.1.19 to 0.1.20

The domain layer (entity, commands, queries, handlers, migration) was already in place — this PR only adds the REST API wiring.

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/tenants/{tenantId}/attributes` | List attribute definitions |
| `POST` | `/api/tenants/{tenantId}/attributes` | Create attribute definition |
| `GET` | `/api/tenants/{tenantId}/attributes/{attributeKey}` | Get attribute definition |
| `PATCH` | `/api/tenants/{tenantId}/attributes/{attributeKey}` | Update attribute definition |
| `DELETE` | `/api/tenants/{tenantId}/attributes/{attributeKey}` | Delete attribute definition |

## Test plan

- [x] `./gradlew :modules:rest-api:compileKotlin` compiles
- [x] `./gradlew :modules:rest-api:test :modules:epistola-core:test` passes
- [ ] Manual: create/list/get/update/delete attributes via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)