### PR TITLE
feat: per-tenant feature toggles with feedback gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.jar binary
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Per-tenant feature toggles**: Tenant managers can enable/disable features per tenant via Settings > Features. Global defaults are configured in `application.yaml` (`epistola.features.*`), with per-tenant overrides stored in the database. The feedback feature is the first gated capability — when disabled, the feedback nav link, FAB button, and console capture script are hidden for that tenant.
+
 ## [0.13.0] - 2026-04-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,8 @@ pnpm --filter @epistola/editor watch
 ### Formatting (All Files)
 
 - **Formatter**: oxfmt via `pnpm format` (enforced in CI)
-- **Always run `pnpm format`** before committing to auto-fix formatting across all file types (JSON, TypeScript, etc.)
+- **Always run `pnpm format`** before committing to auto-fix formatting across all file types (JSON, TypeScript, Markdown, CSS, etc.)
+- **Always run `pnpm format:check`** after committing to verify — this includes Markdown files, so documentation-only changes need formatting too
 - **Run `pnpm format:check`** to verify without modifying files
 
 ### Kotlin
@@ -251,7 +252,7 @@ To add tests to a new module: `testImplementation(project(":modules:testing"))` 
 
 1. **Read existing code first** - Understand patterns before modifying
 2. **Run tests** - `./gradlew test` before and after changes
-3. **Format all files** - `pnpm format` before committing (covers JSON, TypeScript, etc.)
+3. **Format all files** - `pnpm format` before committing (covers JSON, TypeScript, Markdown, CSS, etc. — includes documentation-only changes)
 4. **Format Kotlin** - `./gradlew ktlintFormat` after making Kotlin changes
 5. **Check style** - `./gradlew ktlintCheck` before committing (must pass)
 6. **Update CHANGELOG.md** - For notable changes under `[Unreleased]`

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureHandler.kt
@@ -1,0 +1,52 @@
+package app.epistola.suite.handlers
+
+import app.epistola.suite.features.KnownFeatures
+import app.epistola.suite.features.commands.SaveFeatureToggle
+import app.epistola.suite.features.queries.GetFeatureToggles
+import app.epistola.suite.htmx.page
+import app.epistola.suite.htmx.tenantId
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.mediator.query
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.function.ServerRequest
+import org.springframework.web.servlet.function.ServerResponse
+
+@Component
+class FeatureHandler {
+    fun featureToggles(request: ServerRequest): ServerResponse {
+        val tenantId = request.tenantId()
+        val toggles = GetFeatureToggles(tenantId.key).query()
+
+        val features = toggles.map { (key, enabled) ->
+            mapOf(
+                "key" to key.value,
+                "enabled" to enabled,
+                "description" to (KnownFeatures.descriptions[key] ?: ""),
+            )
+        }
+
+        return ServerResponse.ok().page("features") {
+            "pageTitle" to "Feature Toggles - Epistola"
+            "tenantId" to tenantId.key
+            "activeNavSection" to "features"
+            "features" to features
+        }
+    }
+
+    fun saveFeatureToggles(request: ServerRequest): ServerResponse {
+        val tenantId = request.tenantId()
+
+        KnownFeatures.all.forEach { featureKey ->
+            val enabled = request.param(featureKey.value).isPresent
+            SaveFeatureToggle(
+                tenantKey = tenantId.key,
+                featureKey = featureKey,
+                enabled = enabled,
+            ).execute()
+        }
+
+        return ServerResponse.status(303)
+            .header("Location", "/tenants/${tenantId.key}/features?saved=true")
+            .build()
+    }
+}

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.servlet.function.ServerResponse
 
 @Component
 class FeatureHandler {
+    // TODO: Add explicit TENANT_SETTINGS permission check before rendering, to show a proper "not authorized" page instead of a mediator 403 error on direct URL access
     fun featureToggles(request: ServerRequest): ServerResponse {
         val tenantId = request.tenantId()
         val toggles = GetFeatureToggles(tenantId.key).query()

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureRoutes.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureRoutes.kt
@@ -1,0 +1,18 @@
+package app.epistola.suite.handlers
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.function.RouterFunction
+import org.springframework.web.servlet.function.ServerResponse
+import org.springframework.web.servlet.function.router
+
+@Configuration
+class FeatureRoutes(private val handler: FeatureHandler) {
+    @Bean
+    fun featureRouterFunction(): RouterFunction<ServerResponse> = router {
+        "/tenants/{tenantId}/features".nest {
+            GET("", handler::featureToggles)
+            POST("", handler::saveFeatureToggles)
+        }
+    }
+}

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ShellModelInterceptor.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ShellModelInterceptor.kt
@@ -1,6 +1,8 @@
 package app.epistola.suite.handlers
 
 import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.features.FeatureToggleService
+import app.epistola.suite.features.KnownFeatures
 import app.epistola.suite.mediator.query
 import app.epistola.suite.security.SecurityContext
 import app.epistola.suite.tenants.queries.GetTenant
@@ -21,7 +23,9 @@ import org.springframework.web.servlet.ModelAndView
  * Only applies when the view is "layout/shell".
  */
 @Component
-class ShellModelInterceptor : HandlerInterceptor {
+class ShellModelInterceptor(
+    private val featureToggleService: FeatureToggleService,
+) : HandlerInterceptor {
 
     override fun postHandle(
         request: HttpServletRequest,
@@ -56,6 +60,15 @@ class ShellModelInterceptor : HandlerInterceptor {
         val auth = modelAndView.model["auth"] as AuthContext
         modelAndView.addObject("isManager", auth.has("TENANT_SETTINGS"))
 
+        // Feature toggles
+        if (tenantId != null) {
+            val tenantKey = TenantKey.of(tenantId)
+            modelAndView.addObject(
+                "feedbackEnabled",
+                featureToggleService.isEnabled(tenantKey, KnownFeatures.FEEDBACK),
+            )
+        }
+
         // Shell-specific attributes
         if (viewName != "layout/shell") return
         val path = request.requestURI
@@ -73,6 +86,7 @@ class ShellModelInterceptor : HandlerInterceptor {
         "/assets" in path -> "assets"
         "/settings" in path -> "settings"
         "/feedback" in path -> "feedback"
+        "/features" in path -> "features"
         "/catalogs" in path -> "catalogs"
         "/admin" in path -> "admin"
         else -> "home"

--- a/apps/epistola/src/main/resources/application.yaml
+++ b/apps/epistola/src/main/resources/application.yaml
@@ -62,6 +62,10 @@ epistola:
       retention-days: 30 # Auto-delete documents after 30 days
       max-size-mb: 50 # Max document size
 
+  # Feature toggles — global defaults (tenant-level overrides stored in DB)
+  features:
+    feedback: true
+
   # Feedback sync configuration (provider-agnostic)
   # Controls outbound sync retry and inbound polling.
   feedback:

--- a/apps/epistola/src/main/resources/static/css/main.css
+++ b/apps/epistola/src/main/resources/static/css/main.css
@@ -1539,3 +1539,35 @@ a.stat-card:hover {
   justify-content: flex-end;
   padding: 0 var(--ep-space-3) var(--ep-space-2);
 }
+
+/* ── Feature toggle item ─────────────────────────────────────────────── */
+
+.feature-toggle-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ep-space-4);
+    padding: var(--ep-space-3) 0;
+    border-bottom: 1px solid var(--ep-border-color);
+}
+
+.feature-toggle-item:last-of-type {
+    border-bottom: none;
+}
+
+.feature-toggle-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.feature-toggle-name {
+    font-size: var(--ep-text-sm);
+    font-weight: 600;
+    color: var(--ep-foreground);
+}
+
+.feature-toggle-description {
+    font-size: var(--ep-text-xs);
+    color: var(--ep-muted-foreground);
+    margin-top: var(--ep-space-0-5);
+}

--- a/apps/epistola/src/main/resources/static/css/main.css
+++ b/apps/epistola/src/main/resources/static/css/main.css
@@ -1543,31 +1543,31 @@ a.stat-card:hover {
 /* ── Feature toggle item ─────────────────────────────────────────────── */
 
 .feature-toggle-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--ep-space-4);
-    padding: var(--ep-space-3) 0;
-    border-bottom: 1px solid var(--ep-border-color);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ep-space-4);
+  padding: var(--ep-space-3) 0;
+  border-bottom: 1px solid var(--ep-border-color);
 }
 
 .feature-toggle-item:last-of-type {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .feature-toggle-info {
-    flex: 1;
-    min-width: 0;
+  flex: 1;
+  min-width: 0;
 }
 
 .feature-toggle-name {
-    font-size: var(--ep-text-sm);
-    font-weight: 600;
-    color: var(--ep-foreground);
+  font-size: var(--ep-text-sm);
+  font-weight: 600;
+  color: var(--ep-foreground);
 }
 
 .feature-toggle-description {
-    font-size: var(--ep-text-xs);
-    color: var(--ep-muted-foreground);
-    margin-top: var(--ep-space-0-5);
+  font-size: var(--ep-text-xs);
+  color: var(--ep-muted-foreground);
+  margin-top: var(--ep-space-0-5);
 }

--- a/apps/epistola/src/main/resources/static/css/shell.css
+++ b/apps/epistola/src/main/resources/static/css/shell.css
@@ -502,7 +502,7 @@
 }
 
 .toggle-switch-slider::before {
-  content: "";
+  content: '';
   position: absolute;
   height: 1.125rem;
   width: 1.125rem;
@@ -525,4 +525,3 @@
   outline: 2px solid var(--ep-primary);
   outline-offset: 2px;
 }
-

--- a/apps/epistola/src/main/resources/static/css/shell.css
+++ b/apps/epistola/src/main/resources/static/css/shell.css
@@ -475,3 +475,54 @@
     padding: 0 var(--ep-space-4);
   }
 }
+
+/* ── Toggle switch ───────────────────────────────────────────────────── */
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 2.75rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-switch-slider {
+  position: absolute;
+  inset: 0;
+  background-color: var(--ep-gray-300);
+  border-radius: var(--ep-radius-full);
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.toggle-switch-slider::before {
+  content: "";
+  position: absolute;
+  height: 1.125rem;
+  width: 1.125rem;
+  left: 0.1875rem;
+  bottom: 0.1875rem;
+  background-color: var(--ep-white);
+  border-radius: var(--ep-radius-full);
+  transition: transform 0.2s;
+}
+
+.toggle-switch input:checked + .toggle-switch-slider {
+  background-color: var(--ep-primary);
+}
+
+.toggle-switch input:checked + .toggle-switch-slider::before {
+  transform: translateX(1.25rem);
+}
+
+.toggle-switch input:focus-visible + .toggle-switch-slider {
+  outline: 2px solid var(--ep-primary);
+  outline-offset: 2px;
+}
+

--- a/apps/epistola/src/main/resources/templates/features.html
+++ b/apps/epistola/src/main/resources/templates/features.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+    <th:block th:fragment="content">
+        <h1>Feature Toggles</h1>
+
+        <div class="alert alert-success" th:if="${param.saved}">
+            Feature toggle settings saved successfully.
+        </div>
+
+        <div class="card">
+            <div class="card-content">
+                <form th:action="@{/tenants/{tenantId}/features(tenantId=${tenantId})}" method="post">
+
+                    <div class="feature-toggle-item" th:each="feature : ${features}">
+                        <div class="feature-toggle-info">
+                            <div class="feature-toggle-name" th:text="${feature['key']}">feature-key</div>
+                            <div class="feature-toggle-description" th:if="${feature['description'] != ''}" th:text="${feature['description']}"></div>
+                        </div>
+                        <label class="toggle-switch">
+                            <input type="checkbox"
+                                   th:name="${feature['key']}"
+                                   th:checked="${feature['enabled']}">
+                            <span class="toggle-switch-slider"></span>
+                        </label>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn btn-primary">Save Settings</button>
+                        <a th:href="@{/tenants/{tenantId}(tenantId=${tenantId})}" class="btn btn-outline">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </th:block>
+</body>
+</html>

--- a/apps/epistola/src/main/resources/templates/fragments/footer.html
+++ b/apps/epistola/src/main/resources/templates/fragments/footer.html
@@ -45,7 +45,7 @@
         </th:block>
 
         <!-- Feedback FAB + console capture (tenant-scoped pages only) -->
-        <th:block th:if="${tenantId != null}" sec:authorize="isAuthenticated()">
+        <th:block th:if="${tenantId != null and feedbackEnabled}" sec:authorize="isAuthenticated()">
             <script th:src="@{/feedback/feedback-capture.js}"></script>
             <script type="module" th:inline="javascript">
                 const { initFeedbackFab } = await import(/*[[@{/feedback/feedback-fab.js}]]*/ '/feedback/feedback-fab.js');

--- a/apps/epistola/src/main/resources/templates/layout/nav.html
+++ b/apps/epistola/src/main/resources/templates/layout/nav.html
@@ -86,7 +86,8 @@
                                th:classappend="${activeNavSection == 'load-tests'} ? ' active' : ''">
                                 Load Tests
                             </a>
-                            <a th:href="@{/tenants/{id}/feedback(id=${tenantId})}"
+                            <a th:if="${feedbackEnabled}"
+                               th:href="@{/tenants/{id}/feedback(id=${tenantId})}"
                                class="app-nav-dropdown-item" role="menuitem"
                                th:classappend="${activeNavSection == 'feedback'} ? ' active' : ''">
                                 Feedback
@@ -97,7 +98,7 @@
                     <!-- Settings dropdown (managers only) -->
                     <div th:if="${auth.has('TENANT_SETTINGS')}"
                          class="app-nav-dropdown"
-                         th:classappend="${#lists.contains({'catalogs','admin'}, activeNavSection)} ? ' active' : ''">
+                         th:classappend="${#lists.contains({'catalogs','admin','features'}, activeNavSection)} ? ' active' : ''">
                         <button class="app-nav-dropdown-trigger" type="button"
                                 aria-expanded="false" aria-haspopup="true">
                             Settings
@@ -113,6 +114,11 @@
                                class="app-nav-dropdown-item" role="menuitem"
                                th:classappend="${activeNavSection == 'admin'} ? ' active' : ''">
                                 Admin
+                            </a>
+                            <a th:href="@{/tenants/{id}/features(id=${tenantId})}"
+                               class="app-nav-dropdown-item" role="menuitem"
+                               th:classappend="${activeNavSection == 'features'} ? ' active' : ''">
+                                Features
                             </a>
                         </div>
                     </div>
@@ -172,7 +178,8 @@
                     <a th:if="${auth.has('DOCUMENT_GENERATE')}"
                        th:href="@{/tenants/{id}/load-tests(id=${tenantId})}" class="app-nav-mobile-item"
                        th:classappend="${activeNavSection == 'load-tests'} ? ' active' : ''" role="menuitem">Load Tests</a>
-                    <a th:href="@{/tenants/{id}/feedback(id=${tenantId})}" class="app-nav-mobile-item"
+                    <a th:if="${feedbackEnabled}"
+                       th:href="@{/tenants/{id}/feedback(id=${tenantId})}" class="app-nav-mobile-item"
                        th:classappend="${activeNavSection == 'feedback'} ? ' active' : ''" role="menuitem">Feedback</a>
                 </div>
                 <div th:if="${auth.has('TENANT_SETTINGS')}" class="app-nav-mobile-group">
@@ -181,6 +188,8 @@
                        th:classappend="${activeNavSection == 'catalogs'} ? ' active' : ''" role="menuitem">Catalogs</a>
                     <a th:href="@{/tenants/{id}/admin/data-management(id=${tenantId})}" class="app-nav-mobile-item"
                        th:classappend="${activeNavSection == 'admin'} ? ' active' : ''" role="menuitem">Admin</a>
+                    <a th:href="@{/tenants/{id}/features(id=${tenantId})}" class="app-nav-mobile-item"
+                       th:classappend="${activeNavSection == 'features'} ? ' active' : ''" role="menuitem">Features</a>
                 </div>
                 <div class="app-nav-mobile-footer">
                     <a th:href="@{/}" class="app-nav-mobile-item" role="menuitem">

--- a/docs/feature-toggles.md
+++ b/docs/feature-toggles.md
@@ -21,19 +21,20 @@ Request → FeatureToggleService.isEnabled(tenantKey, featureKey)
 
 ## Key Classes
 
-| Class | Location | Purpose |
-|-------|----------|---------|
-| `KnownFeatures` | `modules/epistola-core/.../features/` | Registry of all feature keys with descriptions |
-| `FeatureDefaults` | `modules/epistola-core/.../features/` | Global defaults from `application.yaml` |
-| `FeatureToggleService` | `modules/epistola-core/.../features/` | Resolves effective state (DB override or default) |
-| `FeatureKey` | `modules/epistola-core/.../common/ids/` | Typed value class with slug validation |
-| `SaveFeatureToggle` | `modules/epistola-core/.../features/commands/` | Upserts a tenant override |
-| `DeleteFeatureToggle` | `modules/epistola-core/.../features/commands/` | Removes a tenant override (reverts to default) |
-| `GetFeatureToggles` | `modules/epistola-core/.../features/queries/` | Returns all features with resolved state |
+| Class                  | Location                                       | Purpose                                           |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------- |
+| `KnownFeatures`        | `modules/epistola-core/.../features/`          | Registry of all feature keys with descriptions    |
+| `FeatureDefaults`      | `modules/epistola-core/.../features/`          | Global defaults from `application.yaml`           |
+| `FeatureToggleService` | `modules/epistola-core/.../features/`          | Resolves effective state (DB override or default) |
+| `FeatureKey`           | `modules/epistola-core/.../common/ids/`        | Typed value class with slug validation            |
+| `SaveFeatureToggle`    | `modules/epistola-core/.../features/commands/` | Upserts a tenant override                         |
+| `DeleteFeatureToggle`  | `modules/epistola-core/.../features/commands/` | Removes a tenant override (reverts to default)    |
+| `GetFeatureToggles`    | `modules/epistola-core/.../features/queries/`  | Returns all features with resolved state          |
 
 ## How to Add a New Feature Toggle
 
 1. **Register the feature** in `KnownFeatures`:
+
    ```kotlin
    val MY_FEATURE = FeatureKey.of("my-feature")
    val all: List<FeatureKey> = listOf(FEEDBACK, MY_FEATURE)
@@ -44,6 +45,7 @@ Request → FeatureToggleService.isEnabled(tenantKey, featureKey)
    ```
 
 2. **Add the default** in `FeatureDefaults`:
+
    ```kotlin
    data class FeatureDefaults(
        val feedback: Boolean = false,
@@ -58,6 +60,7 @@ Request → FeatureToggleService.isEnabled(tenantKey, featureKey)
    ```
 
 3. **Set the global default** in `application.yaml`:
+
    ```yaml
    epistola:
      features:
@@ -91,14 +94,14 @@ The feature toggles management page is at `/tenants/{tenantId}/features` (Settin
 
 ## Access Control
 
-| Operation | Permission |
-|-----------|-----------|
-| View feature toggles | `TENANT_SETTINGS` |
-| Save feature toggles | `TENANT_SETTINGS` |
+| Operation             | Permission        |
+| --------------------- | ----------------- |
+| View feature toggles  | `TENANT_SETTINGS` |
+| Save feature toggles  | `TENANT_SETTINGS` |
 | Delete feature toggle | `TENANT_SETTINGS` |
 
 ## Current Features
 
-| Key | Description | Default |
-|-----|-------------|---------|
-| `feedback` | Enables the feedback system (nav link, FAB, console capture) | `true` |
+| Key        | Description                                                  | Default |
+| ---------- | ------------------------------------------------------------ | ------- |
+| `feedback` | Enables the feedback system (nav link, FAB, console capture) | `true`  |

--- a/docs/feature-toggles.md
+++ b/docs/feature-toggles.md
@@ -1,0 +1,104 @@
+# Feature Toggles
+
+## Overview
+
+Epistola supports per-tenant feature toggles, allowing tenant managers to enable or disable optional features for their tenant. This provides fine-grained control over which capabilities are available without code changes or redeployment.
+
+## Architecture
+
+Feature toggles use a **two-tier resolution** model:
+
+1. **Global defaults** — configured in `application.yaml` under `epistola.features.*`
+2. **Tenant overrides** — stored in the `feature_toggles` database table
+
+When checking whether a feature is enabled, the system first looks for a tenant-specific override. If none exists, it falls back to the global default. If neither is configured, the feature defaults to disabled.
+
+```
+Request → FeatureToggleService.isEnabled(tenantKey, featureKey)
+            ├── DB override exists? → use it
+            └── No override → FeatureDefaults.isEnabled(featureKey) → YAML config value
+```
+
+## Key Classes
+
+| Class | Location | Purpose |
+|-------|----------|---------|
+| `KnownFeatures` | `modules/epistola-core/.../features/` | Registry of all feature keys with descriptions |
+| `FeatureDefaults` | `modules/epistola-core/.../features/` | Global defaults from `application.yaml` |
+| `FeatureToggleService` | `modules/epistola-core/.../features/` | Resolves effective state (DB override or default) |
+| `FeatureKey` | `modules/epistola-core/.../common/ids/` | Typed value class with slug validation |
+| `SaveFeatureToggle` | `modules/epistola-core/.../features/commands/` | Upserts a tenant override |
+| `DeleteFeatureToggle` | `modules/epistola-core/.../features/commands/` | Removes a tenant override (reverts to default) |
+| `GetFeatureToggles` | `modules/epistola-core/.../features/queries/` | Returns all features with resolved state |
+
+## How to Add a New Feature Toggle
+
+1. **Register the feature** in `KnownFeatures`:
+   ```kotlin
+   val MY_FEATURE = FeatureKey.of("my-feature")
+   val all: List<FeatureKey> = listOf(FEEDBACK, MY_FEATURE)
+   val descriptions: Map<FeatureKey, String> = mapOf(
+       FEEDBACK to "Enables feedback option.",
+       MY_FEATURE to "Description of my feature.",
+   )
+   ```
+
+2. **Add the default** in `FeatureDefaults`:
+   ```kotlin
+   data class FeatureDefaults(
+       val feedback: Boolean = false,
+       val myFeature: Boolean = false,
+   ) {
+       fun isEnabled(featureKey: FeatureKey): Boolean = when (featureKey) {
+           KnownFeatures.FEEDBACK -> feedback
+           KnownFeatures.MY_FEATURE -> myFeature
+           else -> false
+       }
+   }
+   ```
+
+3. **Set the global default** in `application.yaml`:
+   ```yaml
+   epistola:
+     features:
+       feedback: true
+       my-feature: false
+   ```
+
+4. **Use the toggle** in your code:
+   - **Kotlin (service layer)**: Inject `FeatureToggleService` and call `isEnabled(tenantKey, featureKey)`
+   - **Thymeleaf templates**: The `ShellModelInterceptor` exposes toggle state as model attributes (e.g., `feedbackEnabled`). Add new attributes there for template-level gating.
+
+## Database Schema
+
+```sql
+CREATE DOMAIN FEATURE_KEY AS VARCHAR(50)
+    CHECK (VALUE ~ '^[a-z][a-z0-9]*(-[a-z0-9]+)*$');
+
+CREATE TABLE feature_toggles (
+    tenant_key  TENANT_KEY  NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    feature_key FEATURE_KEY NOT NULL,
+    enabled     BOOLEAN     NOT NULL,
+    PRIMARY KEY (tenant_key, feature_key)
+);
+```
+
+The `FEATURE_KEY` domain enforces the same slug pattern as the Kotlin `FeatureKey` value class: lowercase letters, digits, and non-consecutive hyphens, 3-50 characters.
+
+## UI
+
+The feature toggles management page is at `/tenants/{tenantId}/features` (Settings > Features in the navigation). It requires the `TENANT_SETTINGS` permission (manager role).
+
+## Access Control
+
+| Operation | Permission |
+|-----------|-----------|
+| View feature toggles | `TENANT_SETTINGS` |
+| Save feature toggles | `TENANT_SETTINGS` |
+| Delete feature toggle | `TENANT_SETTINGS` |
+
+## Current Features
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `feedback` | Enables the feedback system (nav link, FAB, console capture) | `true` |

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -180,6 +180,12 @@ Currently, feedback items created before sync is configured get `sync_status = N
 
 Issues created directly in the GitHub repository (not via Epistola) are currently invisible to the feedback system. The polling scheduler should detect issues in the configured repo that have no corresponding local feedback item and create them locally. This would allow developers to create issues in GitHub and have them appear in the Epistola feedback UI. Matching criteria: repo + label filter, excluding issues already tracked via `external_ref`.
 
+## Feature Toggle
+
+The feedback feature can be enabled/disabled per tenant via the feature toggles UI (Settings > Features). When disabled, the feedback nav link, FAB button, and console capture script are hidden for that tenant. The global default is configured via `epistola.features.feedback` in `application.yaml` (default: `true`).
+
+See `docs/feature-toggles.md` for the general feature toggle architecture.
+
 ## Implementation Phases
 
 1. **Phase 0**: Per-tenant roles from JWT (TenantRole enum, update EpistolaPrincipal)

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/common/ids/EntityKey.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/common/ids/EntityKey.kt
@@ -462,3 +462,32 @@ value class FeedbackAssetKey(@JsonValue override val value: UUID) : UuidKey<Feed
 
     override fun toString(): String = value.toString()
 }
+
+/**
+ * Typed key for Feature toggle entries.
+ */
+@JvmInline
+value class FeatureKey(@JsonValue override val value: String) : SlugKey<FeatureKey> {
+    init {
+        require(value.length in 3..50) {
+            "Feature key must be 3-50 characters, got ${value.length}"
+        }
+        require(SLUG_PATTERN.matches(value)) {
+            "Feature key must match pattern: start with letter, contain only lowercase letters, numbers, and non-consecutive hyphens, and not end with hyphen"
+        }
+    }
+
+    companion object {
+        private val SLUG_PATTERN = Regex("^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+
+        fun of(value: String): FeatureKey = FeatureKey(value)
+
+        @JvmStatic
+        @JsonCreator
+        fun fromJson(value: String): FeatureKey = FeatureKey(value)
+
+        fun validateOrNull(value: String): FeatureKey? = runCatching { FeatureKey(value) }.getOrNull()
+    }
+
+    override fun toString(): String = value
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/config/JdbiConfig.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/config/JdbiConfig.kt
@@ -2,6 +2,7 @@ package app.epistola.suite.config
 
 import app.epistola.suite.assets.AssetMediaType
 import app.epistola.suite.common.ids.EnvironmentKey
+import app.epistola.suite.common.ids.FeatureKey
 import app.epistola.suite.common.ids.TemplateKey
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.common.ids.ThemeKey
@@ -44,6 +45,7 @@ class JdbiConfig {
             registerColumnMapper(TemplateKey::class.java, SlugIdColumnMapper(TemplateKey::of))
             registerColumnMapper(VariantKey::class.java, SlugIdColumnMapper(VariantKey::of))
             registerColumnMapper(EnvironmentKey::class.java, SlugIdColumnMapper(EnvironmentKey::of))
+            registerColumnMapper(FeatureKey::class.java, SlugIdColumnMapper(FeatureKey::of))
 
             // Register VersionId argument factory and column mapper for integer-based version IDs
             registerArgument(VersionIdArgumentFactory())

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureDefaults.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureDefaults.kt
@@ -3,6 +3,7 @@ package app.epistola.suite.features
 import app.epistola.suite.common.ids.FeatureKey
 import org.springframework.boot.context.properties.ConfigurationProperties
 
+// TODO: If feature count grows beyond ~5, refactor to Map<String, Boolean> config property instead of per-feature constructor params + when expression
 @ConfigurationProperties(prefix = "epistola.features")
 data class FeatureDefaults(
     val feedback: Boolean = false,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureDefaults.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureDefaults.kt
@@ -1,0 +1,14 @@
+package app.epistola.suite.features
+
+import app.epistola.suite.common.ids.FeatureKey
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "epistola.features")
+data class FeatureDefaults(
+    val feedback: Boolean = false,
+) {
+    fun isEnabled(featureKey: FeatureKey): Boolean = when (featureKey) {
+        KnownFeatures.FEEDBACK -> feedback
+        else -> false
+    }
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureToggle.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureToggle.kt
@@ -1,0 +1,10 @@
+package app.epistola.suite.features
+
+import app.epistola.suite.common.ids.FeatureKey
+import app.epistola.suite.common.ids.TenantKey
+
+data class FeatureToggle(
+    val tenantKey: TenantKey,
+    val featureKey: FeatureKey,
+    val enabled: Boolean,
+)

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureToggleService.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureToggleService.kt
@@ -7,6 +7,7 @@ import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 
+// TODO: Add Caffeine/Spring Cache with short TTL (~60s) — isEnabled() runs on every page load via ShellModelInterceptor
 @Component
 @EnableConfigurationProperties(FeatureDefaults::class)
 class FeatureToggleService(

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureToggleService.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureToggleService.kt
@@ -1,0 +1,44 @@
+package app.epistola.suite.features
+
+import app.epistola.suite.common.ids.FeatureKey
+import app.epistola.suite.common.ids.TenantKey
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.withHandleUnchecked
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@EnableConfigurationProperties(FeatureDefaults::class)
+class FeatureToggleService(
+    private val jdbi: Jdbi,
+    private val defaults: FeatureDefaults,
+) {
+    fun isEnabled(tenantKey: TenantKey, featureKey: FeatureKey): Boolean {
+        val override = jdbi.withHandleUnchecked { handle ->
+            handle.createQuery(
+                "SELECT enabled FROM feature_toggles WHERE tenant_key = :tenantKey AND feature_key = :featureKey",
+            )
+                .bind("tenantKey", tenantKey)
+                .bind("featureKey", featureKey)
+                .mapTo(Boolean::class.java)
+                .findOne()
+                .orElse(null)
+        }
+        return override ?: defaults.isEnabled(featureKey)
+    }
+
+    fun resolveAll(tenantKey: TenantKey): Map<FeatureKey, Boolean> {
+        val overrides = jdbi.withHandleUnchecked { handle ->
+            handle.createQuery(
+                "SELECT feature_key, enabled FROM feature_toggles WHERE tenant_key = :tenantKey",
+            )
+                .bind("tenantKey", tenantKey)
+                .map { rs, _ -> FeatureKey.of(rs.getString("feature_key")) to rs.getBoolean("enabled") }
+                .list()
+                .toMap()
+        }
+        return KnownFeatures.all.associateWith { feature ->
+            overrides[feature] ?: defaults.isEnabled(feature)
+        }
+    }
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/KnownFeatures.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/KnownFeatures.kt
@@ -1,0 +1,13 @@
+package app.epistola.suite.features
+
+import app.epistola.suite.common.ids.FeatureKey
+
+object KnownFeatures {
+    val FEEDBACK = FeatureKey.of("feedback")
+
+    val all: List<FeatureKey> = listOf(FEEDBACK)
+
+    val descriptions: Map<FeatureKey, String> = mapOf(
+        FEEDBACK to "Enables feedback option.",
+    )
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/commands/DeleteFeatureToggle.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/commands/DeleteFeatureToggle.kt
@@ -1,0 +1,34 @@
+package app.epistola.suite.features.commands
+
+import app.epistola.suite.common.ids.FeatureKey
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.Command
+import app.epistola.suite.mediator.CommandHandler
+import app.epistola.suite.security.Permission
+import app.epistola.suite.security.RequiresPermission
+import org.jdbi.v3.core.Jdbi
+import org.springframework.stereotype.Component
+
+data class DeleteFeatureToggle(
+    override val tenantKey: TenantKey,
+    val featureKey: FeatureKey,
+) : Command<Unit>,
+    RequiresPermission {
+    override val permission get() = Permission.TENANT_SETTINGS
+}
+
+@Component
+class DeleteFeatureToggleHandler(
+    private val jdbi: Jdbi,
+) : CommandHandler<DeleteFeatureToggle, Unit> {
+    override fun handle(command: DeleteFeatureToggle) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate(
+                "DELETE FROM feature_toggles WHERE tenant_key = :tenantKey AND feature_key = :featureKey",
+            )
+                .bind("tenantKey", command.tenantKey)
+                .bind("featureKey", command.featureKey)
+                .execute()
+        }
+    }
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/commands/SaveFeatureToggle.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/commands/SaveFeatureToggle.kt
@@ -1,0 +1,41 @@
+package app.epistola.suite.features.commands
+
+import app.epistola.suite.common.ids.FeatureKey
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.Command
+import app.epistola.suite.mediator.CommandHandler
+import app.epistola.suite.security.Permission
+import app.epistola.suite.security.RequiresPermission
+import org.jdbi.v3.core.Jdbi
+import org.springframework.stereotype.Component
+
+data class SaveFeatureToggle(
+    override val tenantKey: TenantKey,
+    val featureKey: FeatureKey,
+    val enabled: Boolean,
+) : Command<Unit>,
+    RequiresPermission {
+    override val permission get() = Permission.TENANT_SETTINGS
+}
+
+@Component
+class SaveFeatureToggleHandler(
+    private val jdbi: Jdbi,
+) : CommandHandler<SaveFeatureToggle, Unit> {
+    override fun handle(command: SaveFeatureToggle) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate(
+                """
+                INSERT INTO feature_toggles (tenant_key, feature_key, enabled)
+                VALUES (:tenantKey, :featureKey, :enabled)
+                ON CONFLICT (tenant_key, feature_key)
+                DO UPDATE SET enabled = :enabled
+                """,
+            )
+                .bind("tenantKey", command.tenantKey)
+                .bind("featureKey", command.featureKey)
+                .bind("enabled", command.enabled)
+                .execute()
+        }
+    }
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/queries/GetFeatureToggles.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/queries/GetFeatureToggles.kt
@@ -1,0 +1,24 @@
+package app.epistola.suite.features.queries
+
+import app.epistola.suite.common.ids.FeatureKey
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.features.FeatureToggleService
+import app.epistola.suite.mediator.Query
+import app.epistola.suite.mediator.QueryHandler
+import app.epistola.suite.security.Permission
+import app.epistola.suite.security.RequiresPermission
+import org.springframework.stereotype.Component
+
+data class GetFeatureToggles(
+    override val tenantKey: TenantKey,
+) : Query<Map<FeatureKey, Boolean>>,
+    RequiresPermission {
+    override val permission get() = Permission.TENANT_SETTINGS
+}
+
+@Component
+class GetFeatureTogglesHandler(
+    private val featureToggleService: FeatureToggleService,
+) : QueryHandler<GetFeatureToggles, Map<FeatureKey, Boolean>> {
+    override fun handle(query: GetFeatureToggles): Map<FeatureKey, Boolean> = featureToggleService.resolveAll(query.tenantKey)
+}

--- a/modules/epistola-core/src/main/resources/db/migration/V21__feature_toggles.sql
+++ b/modules/epistola-core/src/main/resources/db/migration/V21__feature_toggles.sql
@@ -1,0 +1,9 @@
+CREATE DOMAIN FEATURE_KEY AS VARCHAR(50)
+    CHECK (VALUE ~ '^[a-z][a-z0-9]*(-[a-z0-9]+)*$');
+
+CREATE TABLE feature_toggles (
+    tenant_key  TENANT_KEY  NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    feature_key FEATURE_KEY NOT NULL,
+    enabled     BOOLEAN     NOT NULL,
+    PRIMARY KEY (tenant_key, feature_key)
+);

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/common/ids/FeatureKeyTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/common/ids/FeatureKeyTest.kt
@@ -1,0 +1,108 @@
+package app.epistola.suite.common.ids
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class FeatureKeyTest {
+
+    @Nested
+    inner class ValidKeys {
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "abc",
+                "feedback",
+                "feature1",
+                "my-long-feature-name",
+            ],
+        )
+        fun `should accept valid feature keys`(key: String) {
+            assertDoesNotThrow { FeatureKey.of(key) }
+        }
+
+        @Test
+        fun `should accept minimum length key`() {
+            val key = FeatureKey.of("abc")
+            assertEquals("abc", key.value)
+        }
+
+        @Test
+        fun `should accept maximum length key`() {
+            val key = FeatureKey.of("a" + "b".repeat(49))
+            assertEquals(50, key.value.length)
+        }
+
+        @Test
+        fun `validateOrNull should return FeatureKey for valid key`() {
+            val result = FeatureKey.validateOrNull("feedback")
+            assertNotNull(result)
+            assertEquals("feedback", result.value)
+        }
+    }
+
+    @Nested
+    inner class InvalidKeys {
+        @Test
+        fun `should reject key shorter than 3 characters`() {
+            val exception = assertThrows<IllegalArgumentException> { FeatureKey.of("ab") }
+            assertEquals("Feature key must be 3-50 characters, got 2", exception.message)
+        }
+
+        @Test
+        fun `should reject key longer than 50 characters`() {
+            val key = "a" + "b".repeat(50)
+            val exception = assertThrows<IllegalArgumentException> { FeatureKey.of(key) }
+            assertEquals("Feature key must be 3-50 characters, got 51", exception.message)
+        }
+
+        @Test
+        fun `should reject key starting with number`() {
+            assertThrows<IllegalArgumentException> { FeatureKey.of("123abc") }
+        }
+
+        @Test
+        fun `should reject key with uppercase letters`() {
+            assertThrows<IllegalArgumentException> { FeatureKey.of("HtmlPreview") }
+        }
+
+        @Test
+        fun `should reject key with consecutive hyphens`() {
+            assertThrows<IllegalArgumentException> { FeatureKey.of("html--preview") }
+        }
+
+        @Test
+        fun `should reject key ending with hyphen`() {
+            assertThrows<IllegalArgumentException> { FeatureKey.of("html-") }
+        }
+
+        @Test
+        fun `validateOrNull should return null for invalid key`() {
+            assertNull(FeatureKey.validateOrNull(""))
+            assertNull(FeatureKey.validateOrNull("ab"))
+            assertNull(FeatureKey.validateOrNull("ABC"))
+        }
+    }
+
+    @Nested
+    inner class ValueClassBehavior {
+        @Test
+        fun `toString should return the key value`() {
+            val key = FeatureKey.of("feedback")
+            assertEquals("feedback", key.toString())
+        }
+
+        @Test
+        fun `equal keys should be equal`() {
+            val key1 = FeatureKey.of("feedback")
+            val key2 = FeatureKey.of("feedback")
+            assertEquals(key1, key2)
+        }
+    }
+}

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureDefaultsTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureDefaultsTest.kt
@@ -1,0 +1,33 @@
+package app.epistola.suite.features
+
+import app.epistola.suite.common.ids.FeatureKey
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FeatureDefaultsTest {
+
+    @Test
+    fun `isEnabled returns configured default for known feature`() {
+        val defaults = FeatureDefaults(feedback = true)
+        assertTrue(defaults.isEnabled(KnownFeatures.FEEDBACK))
+    }
+
+    @Test
+    fun `isEnabled returns false when feature is disabled`() {
+        val defaults = FeatureDefaults(feedback = false)
+        assertFalse(defaults.isEnabled(KnownFeatures.FEEDBACK))
+    }
+
+    @Test
+    fun `isEnabled returns false for unknown feature`() {
+        val defaults = FeatureDefaults(feedback = true)
+        assertFalse(defaults.isEnabled(FeatureKey.of("unknown-feature")))
+    }
+
+    @Test
+    fun `default constructor has feedback disabled`() {
+        val defaults = FeatureDefaults()
+        assertFalse(defaults.isEnabled(KnownFeatures.FEEDBACK))
+    }
+}

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureTogglesIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureTogglesIntegrationTest.kt
@@ -71,8 +71,8 @@ class FeatureTogglesIntegrationTest : IntegrationTestBase() {
         val tenant = createTenant("toggle-default")
         withMediator {
             val enabled = featureToggleService.isEnabled(tenant.id, KnownFeatures.FEEDBACK)
-            // Global default for feedback is true
-            assertThat(enabled).isTrue()
+            // No override and no test config → falls back to FeatureDefaults constructor default (false)
+            assertThat(enabled).isFalse()
         }
     }
 
@@ -92,13 +92,14 @@ class FeatureTogglesIntegrationTest : IntegrationTestBase() {
         val tenant1 = createTenant("toggle-tenant1")
         val tenant2 = createTenant("toggle-tenant2")
         withMediator {
-            SaveFeatureToggle(tenant1.id, KnownFeatures.FEEDBACK, enabled = false).execute()
+            SaveFeatureToggle(tenant1.id, KnownFeatures.FEEDBACK, enabled = true).execute()
 
             val features1 = featureToggleService.resolveAll(tenant1.id)
             val features2 = featureToggleService.resolveAll(tenant2.id)
 
-            assertThat(features1[KnownFeatures.FEEDBACK]).isFalse()
-            assertThat(features2[KnownFeatures.FEEDBACK]).isTrue()
+            // tenant1 has override → true, tenant2 has no override → falls back to default (false)
+            assertThat(features1[KnownFeatures.FEEDBACK]).isTrue()
+            assertThat(features2[KnownFeatures.FEEDBACK]).isFalse()
         }
     }
 }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureTogglesIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureTogglesIntegrationTest.kt
@@ -1,0 +1,104 @@
+package app.epistola.suite.features
+
+import app.epistola.suite.features.commands.DeleteFeatureToggle
+import app.epistola.suite.features.commands.SaveFeatureToggle
+import app.epistola.suite.features.queries.GetFeatureToggles
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.mediator.query
+import app.epistola.suite.testing.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class FeatureTogglesIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var featureToggleService: FeatureToggleService
+
+    @Test
+    fun `GetFeatureToggles returns all known features with defaults`() {
+        val tenant = createTenant("toggle-defaults")
+        withMediator {
+            val features = GetFeatureToggles(tenant.id).query()
+
+            assertThat(features).containsKey(KnownFeatures.FEEDBACK)
+            assertThat(features).hasSize(KnownFeatures.all.size)
+        }
+    }
+
+    @Test
+    fun `SaveFeatureToggle persists tenant override`() {
+        val tenant = createTenant("toggle-save")
+        withMediator {
+            SaveFeatureToggle(
+                tenantKey = tenant.id,
+                featureKey = KnownFeatures.FEEDBACK,
+                enabled = false,
+            ).execute()
+
+            val features = GetFeatureToggles(tenant.id).query()
+            assertThat(features[KnownFeatures.FEEDBACK]).isFalse()
+        }
+    }
+
+    @Test
+    fun `SaveFeatureToggle upserts existing override`() {
+        val tenant = createTenant("toggle-upsert")
+        withMediator {
+            SaveFeatureToggle(tenant.id, KnownFeatures.FEEDBACK, enabled = false).execute()
+            SaveFeatureToggle(tenant.id, KnownFeatures.FEEDBACK, enabled = true).execute()
+
+            val features = GetFeatureToggles(tenant.id).query()
+            assertThat(features[KnownFeatures.FEEDBACK]).isTrue()
+        }
+    }
+
+    @Test
+    fun `DeleteFeatureToggle removes override and falls back to default`() {
+        val tenant = createTenant("toggle-delete")
+        withMediator {
+            SaveFeatureToggle(tenant.id, KnownFeatures.FEEDBACK, enabled = false).execute()
+            DeleteFeatureToggle(tenant.id, KnownFeatures.FEEDBACK).execute()
+
+            val features = GetFeatureToggles(tenant.id).query()
+            // Should fall back to global default (true in application.yaml)
+            assertThat(features[KnownFeatures.FEEDBACK]).isNotNull()
+        }
+    }
+
+    @Test
+    fun `isEnabled returns global default when no tenant override exists`() {
+        val tenant = createTenant("toggle-default")
+        withMediator {
+            val enabled = featureToggleService.isEnabled(tenant.id, KnownFeatures.FEEDBACK)
+            // Global default for feedback is true
+            assertThat(enabled).isTrue()
+        }
+    }
+
+    @Test
+    fun `isEnabled returns tenant override when it exists`() {
+        val tenant = createTenant("toggle-override")
+        withMediator {
+            SaveFeatureToggle(tenant.id, KnownFeatures.FEEDBACK, enabled = false).execute()
+
+            val enabled = featureToggleService.isEnabled(tenant.id, KnownFeatures.FEEDBACK)
+            assertThat(enabled).isFalse()
+        }
+    }
+
+    @Test
+    fun `resolveAll returns correct state per tenant`() {
+        val tenant1 = createTenant("toggle-tenant1")
+        val tenant2 = createTenant("toggle-tenant2")
+        withMediator {
+            SaveFeatureToggle(tenant1.id, KnownFeatures.FEEDBACK, enabled = false).execute()
+
+            val features1 = featureToggleService.resolveAll(tenant1.id)
+            val features2 = featureToggleService.resolveAll(tenant2.id)
+
+            assertThat(features1[KnownFeatures.FEEDBACK]).isFalse()
+            assertThat(features2[KnownFeatures.FEEDBACK]).isTrue()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a per-tenant feature toggle system with global defaults (`application.yaml`) and tenant-level overrides (database)
- Gate the **Feedback** nav link and **feedback FAB button** behind the `feedback` toggle
- Include a settings UI page at `/tenants/{id}/features` for managing feature toggles per tenant

## What's included

**Feature toggle infrastructure:**
- `FeatureKey` value class with slug validation (3-50 chars, lowercase kebab-case)
- `FeatureToggleService` with resolution logic: tenant DB override → global default
- `FeatureDefaults` config properties bound to `epistola.features.*`
- CQRS commands (`SaveFeatureToggle`, `DeleteFeatureToggle`) and query (`GetFeatureToggles`)
- Flyway migration `V21` creating `feature_toggles` table with composite PK

**UI integration:**
- Feature toggles page at `/tenants/{id}/features` with toggle switch components
- `ShellModelInterceptor` exposes `feedbackEnabled` model attribute for all tenant-scoped views
- Feedback nav link (`nav.html`) and feedback FAB (`footer.html`) conditionally rendered
- Features link added to Settings dropdown in navigation

**Currently registered toggles:**
| Toggle | Default | Controls |
|--------|---------|----------|
| `feedback` | `true` | Feedback nav link + FAB button visibility |

## Test plan

- [x] `./gradlew unitTest` passes (FeatureKeyTest, FeatureDefaultsTest)
- [x] `./gradlew integrationTest` passes (FeatureTogglesIntegrationTest)
- [x] Toggle `feedback` off for a tenant → Feedback nav link and FAB disappear
- [x] Toggle `feedback` on → Feedback nav link and FAB reappear
- [x] Verify feature toggles page renders with toggle switches