### PR TITLE
fix: highlight selected version in changelog dialog

### DIFF
--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ChangelogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ChangelogHandler.kt
@@ -22,23 +22,18 @@ class ChangelogHandler(
         val version = request.queryParam("version")
         val entries = changelogRenderer.entries()
 
-        return if (version != null) {
-            val entry = entries.find { it.version == version }
-            ServerResponse.ok().render(
-                "fragments/changelog :: version-content",
-                mapOf("entries" to listOfNotNull(entry)),
-            )
-        } else {
-            val latestEntry = entries.firstOrNull()
-            ServerResponse.ok().render(
-                "fragments/changelog :: content",
-                mapOf(
-                    "entries" to listOfNotNull(latestEntry),
-                    "versions" to entries,
-                    "selectedVersion" to latestEntry?.version,
-                ),
-            )
-        }
+        val selectedVersion = version ?: entries.firstOrNull()?.version
+        val selectedEntry = entries.find { it.version == selectedVersion }
+        val fragment = if (version != null) "layout" else "content"
+
+        return ServerResponse.ok().render(
+            "fragments/changelog :: $fragment",
+            mapOf(
+                "entries" to listOfNotNull(selectedEntry),
+                "versions" to entries,
+                "selectedVersion" to selectedVersion,
+            ),
+        )
     }
 
     fun acknowledge(request: ServerRequest): ServerResponse {

--- a/apps/epistola/src/main/resources/templates/fragments/changelog.html
+++ b/apps/epistola/src/main/resources/templates/fragments/changelog.html
@@ -17,22 +17,23 @@
             <div th:if="${versions == null or versions.isEmpty()}" class="changelog-empty">
                 <p>No changelog entries available.</p>
             </div>
-            <div th:if="${versions != null and !versions.isEmpty()}" class="changelog-layout">
+            <div th:if="${versions != null and !versions.isEmpty()}"
+                 id="changelog-layout"
+                 class="changelog-layout">
                 <nav class="changelog-version-list" aria-label="Versions">
                     <button th:each="v : ${versions}"
                             type="button"
                             class="changelog-version-item"
                             th:classappend="${v.version == selectedVersion} ? 'active'"
                             th:hx-get="@{/changelog(version=${v.version})}"
-                            hx-target="#changelog-detail"
-                            hx-swap="innerHTML"
-                            onclick="this.closest('.changelog-version-list').querySelectorAll('.changelog-version-item').forEach(b => { b.classList.remove('active'); b.removeAttribute('aria-current'); }); this.classList.add('active'); this.setAttribute('aria-current', 'true');"
+                            hx-target="#changelog-layout"
+                            hx-swap="outerHTML"
                             th:attr="aria-current=${v.version == selectedVersion} ? 'true'">
                         <span class="changelog-version-label" th:text="'v' + ${v.version}">v0.12.0</span>
                         <span class="changelog-version-date" th:text="${v.date}">2026-04-04</span>
                     </button>
                 </nav>
-                <div id="changelog-detail" class="changelog-detail changelog-content" aria-live="polite">
+                <div class="changelog-detail changelog-content" aria-live="polite">
                     <th:block th:each="entry : ${entries}">
                         <div th:utext="${entry.html}">Changelog content</div>
                     </th:block>
@@ -41,12 +42,29 @@
         </div>
     </th:block>
 
-    <!-- Version content fragment (HTMX partial swap) -->
-    <th:block th:fragment="version-content">
-        <th:block th:each="entry : ${entries}">
-            <div th:utext="${entry.html}">Changelog content</div>
-        </th:block>
-        <p th:if="${entries == null or entries.isEmpty()}" class="changelog-empty">Version not found.</p>
+    <!-- Layout fragment (HTMX partial swap on version change) -->
+    <th:block th:fragment="layout">
+        <div id="changelog-layout" class="changelog-layout">
+            <nav class="changelog-version-list" aria-label="Versions">
+                <button th:each="v : ${versions}"
+                        type="button"
+                        class="changelog-version-item"
+                        th:classappend="${v.version == selectedVersion} ? 'active'"
+                        th:hx-get="@{/changelog(version=${v.version})}"
+                        hx-target="#changelog-layout"
+                        hx-swap="outerHTML"
+                        th:attr="aria-current=${v.version == selectedVersion} ? 'true'">
+                    <span class="changelog-version-label" th:text="'v' + ${v.version}">v0.12.0</span>
+                    <span class="changelog-version-date" th:text="${v.date}">2026-04-04</span>
+                </button>
+            </nav>
+            <div class="changelog-detail changelog-content" aria-live="polite">
+                <th:block th:each="entry : ${entries}">
+                    <div th:utext="${entry.html}">Changelog content</div>
+                </th:block>
+                <p th:if="${entries == null or entries.isEmpty()}" class="changelog-empty">Version not found.</p>
+            </div>
+        </div>
     </th:block>
 
     <!-- Muted What's New card (returned after dismiss) -->

--- a/apps/epistola/src/main/resources/templates/fragments/changelog.html
+++ b/apps/epistola/src/main/resources/templates/fragments/changelog.html
@@ -26,6 +26,7 @@
                             th:hx-get="@{/changelog(version=${v.version})}"
                             hx-target="#changelog-detail"
                             hx-swap="innerHTML"
+                            onclick="this.closest('.changelog-version-list').querySelectorAll('.changelog-version-item').forEach(b => { b.classList.remove('active'); b.removeAttribute('aria-current'); }); this.classList.add('active'); this.setAttribute('aria-current', 'true');"
                             th:attr="aria-current=${v.version == selectedVersion} ? 'true'">
                         <span class="changelog-version-label" th:text="'v' + ${v.version}">v0.12.0</span>
                         <span class="changelog-version-date" th:text="${v.date}">2026-04-04</span>


### PR DESCRIPTION
## Summary

- Fixes the changelog version list not highlighting the selected version when clicking between versions
- Adds an `onclick` handler to toggle the `active` class and `aria-current` attribute client-side, since HTMX only swaps the content pane without re-rendering the version list

Closes #287

## Test plan

- [ ] Open the changelog dialog
- [ ] Click on different versions — the clicked version should be visually highlighted (bold + muted background)
- [ ] On initial open, the latest version should be highlighted