### PR TITLE
feat!: orthogonal Spring profiles and Helm chart fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- **DemoLoader fails on user ID scheme change**: Fixed `ON CONFLICT DO NOTHING` in user upsert to `DO UPDATE`, so existing users with changed deterministic UUIDs are updated instead of silently skipped (which caused FK violations on `tenant_memberships`).
 - **PDF preview blocked by CSP**: Added `frame-src blob:` to the Content Security Policy to allow blob URLs in iframes, fixing the PDF preview feature.
 - **DOM XSS in HTMX error banner**: Replaced `innerHTML` with safe DOM API (`textContent` + `createElement`) in the global HTMX error handler to prevent potential cross-site scripting via error messages.
 - **Catalog HTTP restriction**: Remote catalog fetching now requires HTTPS by default. Plain HTTP is only allowed when explicitly enabled via `epistola.catalog.allow-http=true` (set in the local profile).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,29 @@
 
 - **CodeQL static analysis**: New GitHub Actions workflow (`.github/workflows/codeql.yml`) that runs CodeQL SAST scanning on every push and PR to main, plus a weekly schedule. Scans both Java/Kotlin backend and JavaScript/TypeScript frontend with the `security-and-quality` query suite. Results appear in the GitHub Security tab under Code scanning.
 - **Content Security Policy headers**: CSP headers are now set on all UI responses, restricting script/style/font/image sources and blocking framing and plugin-based attacks.
+- **`localauth` profile**: New profile for form-based login with configurable users via environment variables. Allows staging/test environments to have form login with custom credentials alongside Keycloak.
 
 ### Fixed
 
 - **DOM XSS in HTMX error banner**: Replaced `innerHTML` with safe DOM API (`textContent` + `createElement`) in the global HTMX error handler to prevent potential cross-site scripting via error messages.
 - **Catalog HTTP restriction**: Remote catalog fetching now requires HTTPS by default. Plain HTTP is only allowed when explicitly enabled via `epistola.catalog.allow-http=true` (set in the local profile).
 - **Pagination bounds validation**: API pagination parameters (`page`, `size`) are now sanitized to prevent integer overflow and unbounded queries (max page size: 1000).
+- **Hardcoded credentials in login UI**: Removed hardcoded username/password hints from the login page.
 
 ### Changed
 
 - **GitHub Actions pinned to commit SHAs**: All GitHub Actions across all workflows are now pinned to immutable commit SHAs instead of mutable version tags, preventing supply chain attacks.
+- **BREAKING: Orthogonal profile restructuring**: Profiles are now single-concern and composable. Each profile controls exactly one axis (auth, data, dev, hardening). Migration:
+
+  | Before           | After                                        |
+  | ---------------- | -------------------------------------------- |
+  | `prod`           | `prod,keycloak`                              |
+  | `demo`           | `keycloak,demo` or `keycloak,demo,localauth` |
+  | `local`          | `local` (unchanged)                          |
+  | `local,keycloak` | `local,keycloak` (unchanged)                 |
+
+- **Demo data is now opt-in**: Base config defaults to `epistola.demo.enabled=false`. Activate via `demo` or `local` profile.
+- **`demo` profile no longer provides form login**: The `demo` profile only loads demo data. For form login, use `local` or `localauth` profile.
 
 ## [0.13.0] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- **PDF preview blocked by CSP**: Added `frame-src blob:` to the Content Security Policy to allow blob URLs in iframes, fixing the PDF preview feature.
 - **DOM XSS in HTMX error banner**: Replaced `innerHTML` with safe DOM API (`textContent` + `createElement`) in the global HTMX error handler to prevent potential cross-site scripting via error messages.
 - **Catalog HTTP restriction**: Remote catalog fetching now requires HTTPS by default. Plain HTTP is only allowed when explicitly enabled via `epistola.catalog.allow-http=true` (set in the local profile).
 - **Pagination bounds validation**: API pagination parameters (`page`, `size`) are now sanitized to prevent integer overflow and unbounded queries (max page size: 1000).

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/config/SecurityConfig.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/config/SecurityConfig.kt
@@ -202,6 +202,7 @@ class SecurityConfig(
                             "font-src 'self' https://fonts.gstatic.com; " +
                             "img-src 'self' data:; " +
                             "connect-src 'self'; " +
+                            "frame-src blob:; " +
                             "frame-ancestors 'none'; " +
                             "object-src 'none'; " +
                             "base-uri 'self'",

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoader.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoader.kt
@@ -26,6 +26,7 @@ import app.epistola.suite.environments.commands.CreateEnvironment
 import app.epistola.suite.mediator.Mediator
 import app.epistola.suite.mediator.MediatorContext
 import app.epistola.suite.metadata.AppMetadataService
+import app.epistola.suite.security.AuthProperties
 import app.epistola.suite.security.EpistolaPrincipal
 import app.epistola.suite.security.PlatformRole
 import app.epistola.suite.security.SecurityContext
@@ -64,7 +65,7 @@ import javax.imageio.ImageIO
 @ConditionalOnProperty(
     name = ["epistola.demo.enabled"],
     havingValue = "true",
-    matchIfMissing = true,
+    matchIfMissing = false,
 )
 class DemoLoader(
     private val mediator: Mediator,
@@ -75,6 +76,7 @@ class DemoLoader(
     private val apiKeyRepository: ApiKeyRepository,
     private val apiKeyService: ApiKeyService,
     private val jdbcClient: org.springframework.jdbc.core.simple.JdbcClient,
+    private val authProperties: AuthProperties,
 ) : ApplicationRunner {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -183,14 +185,32 @@ class DemoLoader(
      * Seeds local dev users into the database so that foreign key constraints
      * (e.g., feedback.created_by) are satisfied. These users match the in-memory
      * users defined in LocalUserDetailsService.
+     *
+     * Uses the same deterministic UUID generation as LocalUserDetailsService
+     * so that user IDs match between database records and authentication principals.
      */
     private fun seedLocalUsers(tenantKey: TenantKey) {
-        val users = listOf(
-            Triple(DEMO_ADMIN_USER_ID, "admin@local", "Local Admin"),
-            Triple(DEMO_MEMBER_USER_ID, "user@local", "Local User"),
-        )
+        val users = authProperties.localUsers.ifEmpty {
+            // Fallback defaults when no local-users are configured (demo without localauth)
+            listOf(
+                app.epistola.suite.security.LocalUserProperties(
+                    username = "admin@local",
+                    password = "unused",
+                    displayName = "Local Admin",
+                    tenant = tenantKey.value,
+                ),
+                app.epistola.suite.security.LocalUserProperties(
+                    username = "user@local",
+                    password = "unused",
+                    displayName = "Local User",
+                    tenant = tenantKey.value,
+                ),
+            )
+        }
 
-        for ((userId, email, displayName) in users) {
+        for (user in users) {
+            val userId = deterministicUserId(user.username)
+
             jdbcClient.sql(
                 """
                 INSERT INTO users (id, external_id, email, display_name, provider, enabled, created_at)
@@ -198,10 +218,10 @@ class DemoLoader(
                 ON CONFLICT (external_id, provider) DO NOTHING
                 """,
             )
-                .param(UserKey.of(userId).value)
-                .param(email)
-                .param(email)
-                .param(displayName)
+                .param(userId.value)
+                .param(user.username)
+                .param(user.username)
+                .param(user.displayName)
                 .update()
 
             jdbcClient.sql(
@@ -211,7 +231,7 @@ class DemoLoader(
                 ON CONFLICT DO NOTHING
                 """,
             )
-                .param(UserKey.of(userId).value)
+                .param(userId.value)
                 .param(tenantKey.value)
                 .update()
         }
@@ -509,19 +529,22 @@ class DemoLoader(
     }
 
     companion object {
-        private const val DEMO_VERSION = "15.0.1" // Bump this to reset demo tenant
+        private const val DEMO_VERSION = "16.0.0" // Bump this to reset demo tenant (changed user ID scheme)
         private const val DEMO_VERSION_KEY = "demo_version"
         private const val DEMO_TENANT_ID = "demo"
         private const val DEMO_TENANT_NAME = "Demo"
-        private const val DEMO_ADMIN_USER_ID = "00000000-0000-0000-0000-000000000001"
-        private const val DEMO_MEMBER_USER_ID = "00000000-0000-0000-0000-000000000002"
         private const val DEMO_LOGO_ASSET_ID = "00000000-0000-0000-0000-100000000001"
         private const val DEMO_API_KEY_ID = "00000000-0000-0000-0000-200000000001"
         const val DEMO_API_KEY = "epk_demo_000000000000000000000000000000000000"
 
+        /**
+         * Generates a deterministic UUID from a username, matching [LocalUserDetailsService].
+         */
+        fun deterministicUserId(username: String): UserKey = UserKey.of(java.util.UUID.nameUUIDFromBytes(username.toByteArray(java.nio.charset.StandardCharsets.UTF_8)))
+
         /** Bootstrap principal used by DemoLoader — has full access to all operations. */
         private val SYSTEM_PRINCIPAL = EpistolaPrincipal(
-            userId = UserKey.of(DEMO_ADMIN_USER_ID),
+            userId = deterministicUserId("system@epistola.app"),
             externalId = "system",
             email = "system@epistola.app",
             displayName = "System",

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoader.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoader.kt
@@ -215,7 +215,11 @@ class DemoLoader(
                 """
                 INSERT INTO users (id, external_id, email, display_name, provider, enabled, created_at)
                 VALUES (?, ?, ?, ?, 'LOCAL', true, NOW())
-                ON CONFLICT (external_id, provider) DO NOTHING
+                ON CONFLICT (external_id, provider) DO UPDATE SET
+                    id = EXCLUDED.id,
+                    email = EXCLUDED.email,
+                    display_name = EXCLUDED.display_name,
+                    enabled = EXCLUDED.enabled
                 """,
             )
                 .param(userId.value)
@@ -529,7 +533,7 @@ class DemoLoader(
     }
 
     companion object {
-        private const val DEMO_VERSION = "16.0.0" // Bump this to reset demo tenant (changed user ID scheme)
+        private const val DEMO_VERSION = "16.1.0" // Bump this to reset demo tenant (fix user upsert for ID changes)
         private const val DEMO_VERSION_KEY = "demo_version"
         private const val DEMO_TENANT_ID = "demo"
         private const val DEMO_TENANT_NAME = "Demo"

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoginMembershipResolver.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoginMembershipResolver.kt
@@ -1,7 +1,6 @@
 package app.epistola.suite.demo
 
 import app.epistola.suite.common.ids.TenantKey
-import app.epistola.suite.common.ids.UserKey
 import app.epistola.suite.mediator.Mediator
 import app.epistola.suite.security.EpistolaPrincipal
 import app.epistola.suite.security.LoginMembershipResolver
@@ -62,7 +61,7 @@ class DemoLoginMembershipResolver(
 
     companion object {
         private val SYSTEM_PRINCIPAL = EpistolaPrincipal(
-            userId = UserKey.of("00000000-0000-0000-0000-000000000001"),
+            userId = DemoLoader.deterministicUserId("system@epistola.app"),
             externalId = "system",
             email = "system@epistola.app",
             displayName = "System",

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/security/AuthProperties.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/security/AuthProperties.kt
@@ -25,6 +25,28 @@ data class AuthProperties(
      * OIDC settings for backchannel (server-to-server) communication.
      */
     val oidc: OidcProperties = OidcProperties(),
+
+    /**
+     * Local user accounts for form-based login (activated by `local` or `localauth` profile).
+     *
+     * Override credentials via environment variables for non-local environments.
+     */
+    val localUsers: List<LocalUserProperties> = emptyList(),
+)
+
+data class LocalUserProperties(
+    /** Login username (email). */
+    val username: String,
+    /** Login password (plain text, encoded at runtime). */
+    val password: String,
+    /** Display name shown in the UI. */
+    val displayName: String = username,
+    /** Tenant key to assign membership to. */
+    val tenant: String = "demo",
+    /** Tenant-scoped roles. */
+    val roles: Set<TenantRole> = emptySet(),
+    /** Platform-scoped roles. */
+    val platformRoles: Set<PlatformRole> = emptySet(),
 )
 
 data class OidcProperties(

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/security/AuthenticationSafetyValidator.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/security/AuthenticationSafetyValidator.kt
@@ -13,8 +13,8 @@ import org.springframework.stereotype.Component
  * Safety validator that fails fast on startup when the authentication configuration is invalid.
  *
  * Checks:
- * 1. **No production with in-memory users** — combining `local` or `demo` profile with `prod`
- *    would expose known passwords in a production environment.
+ * 1. **No production with in-memory users** — combining `local` or `localauth` profile with `prod`
+ *    would expose known/configurable passwords in a production environment.
  * 2. **At least one auth mechanism** — if neither [UserDetailsService] (form login) nor
  *    [ClientRegistrationRepository] (OAuth2) is present, the app would start but 403 everywhere.
  *
@@ -43,12 +43,12 @@ class AuthenticationSafetyValidator(
 
     private fun validateNoInMemoryUsersInProduction() {
         val isProd = environment.acceptsProfiles(Profiles.of("prod"))
-        val hasInMemoryUsers = environment.acceptsProfiles(Profiles.of("local", "demo"))
+        val hasInMemoryUsers = environment.acceptsProfiles(Profiles.of("local", "localauth"))
 
         if (isProd && hasInMemoryUsers) {
             throw IllegalStateException(
-                "SECURITY: Cannot combine 'local' or 'demo' profile with 'prod'. " +
-                    "In-memory users with known passwords must not run in production.",
+                "SECURITY: Cannot combine 'local' or 'localauth' profile with 'prod'. " +
+                    "In-memory users must not run in production.",
             )
         }
     }
@@ -57,8 +57,8 @@ class AuthenticationSafetyValidator(
         if (userDetailsService == null && clientRegistrationRepository == null) {
             throw IllegalStateException(
                 "No authentication mechanism configured. " +
-                    "Either activate a profile that provides a UserDetailsService (e.g., 'local', 'demo') " +
-                    "or configure OAuth2 client registrations (e.g., 'prod', 'keycloak').",
+                    "Either activate a profile that provides form login (e.g., 'local', 'localauth') " +
+                    "or configure OAuth2 client registrations (e.g., 'keycloak').",
             )
         }
     }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/security/LocalUserDetailsService.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/security/LocalUserDetailsService.kt
@@ -2,89 +2,60 @@ package app.epistola.suite.security
 
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.common.ids.UserKey
-import app.epistola.suite.security.PlatformRole
 import org.springframework.context.annotation.Profile
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.crypto.factory.PasswordEncoderFactories
 import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 /**
- * In-memory user details service for local development and demo environments.
+ * In-memory user details service for local development and non-production environments.
  *
- * Provides hardcoded test users without requiring external OAuth2 providers or database setup.
+ * Users are configured via `epistola.auth.local-users` properties, allowing credentials
+ * and roles to be overridden via environment variables for staging/test environments.
  *
- * Users:
- * - admin@local / admin - Admin user with access to demo (ADMIN role)
- * - user@local / user - Regular user with access to demo (MEMBER role)
- *
- * Active when 'local' or 'demo' profile is active.
+ * Active when 'local' or 'localauth' profile is active.
  */
 @Component
-@Profile("local | demo")
-class LocalUserDetailsService : UserDetailsService {
+@Profile("local | localauth")
+class LocalUserDetailsService(
+    authProperties: AuthProperties,
+) : UserDetailsService {
 
     private val passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder()
 
-    // In-memory users for local development
-    private val localUsers = mapOf(
-        "admin@local" to LocalUser(
-            userId = UserKey.of("00000000-0000-0000-0000-000000000001"),
-            email = "admin@local",
-            displayName = "Local Admin",
-            password = "admin",
-            tenantMemberships = mapOf(
-                TenantKey.of("demo") to setOf(TenantRole.READER, TenantRole.EDITOR, TenantRole.GENERATOR, TenantRole.MANAGER),
-            ),
-            globalRoles = TenantRole.entries.toSet(),
-            platformRoles = setOf(PlatformRole.TENANT_MANAGER),
-        ),
-        "user@local" to LocalUser(
-            userId = UserKey.of("00000000-0000-0000-0000-000000000002"),
-            email = "user@local",
-            displayName = "Local User",
-            password = "user",
-            tenantMemberships = mapOf(
-                TenantKey.of("demo") to setOf(TenantRole.READER, TenantRole.EDITOR, TenantRole.GENERATOR),
-            ),
-        ),
-    )
+    private val localUsers: Map<String, LocalUserProperties> =
+        authProperties.localUsers.associateBy { it.username }
 
     override fun loadUserByUsername(username: String): UserDetails {
         val localUser = localUsers[username]
             ?: throw UsernameNotFoundException("User not found: $username")
 
+        val userId = UserKey.of(deterministicUuid(localUser.username))
+
         val principal = EpistolaPrincipal(
-            userId = localUser.userId,
-            externalId = localUser.email,
-            email = localUser.email,
+            userId = userId,
+            externalId = localUser.username,
+            email = localUser.username,
             displayName = localUser.displayName,
-            tenantMemberships = localUser.tenantMemberships,
-            globalRoles = localUser.globalRoles,
+            tenantMemberships = mapOf(
+                TenantKey.of(localUser.tenant) to localUser.roles,
+            ),
+            globalRoles = localUser.roles,
             platformRoles = localUser.platformRoles,
-            currentTenantId = localUser.tenantMemberships.keys.firstOrNull(),
+            currentTenantId = TenantKey.of(localUser.tenant),
         )
 
         return LocalUserDetails(
-            username = localUser.email,
-            password = passwordEncoder.encode(localUser.password) ?: throw IllegalStateException("Password encoding failed"),
+            username = localUser.username,
+            password = passwordEncoder.encode(localUser.password)
+                ?: throw IllegalStateException("Password encoding failed"),
             epistolaPrincipal = principal,
         )
     }
-
-    /**
-     * Local user configuration.
-     */
-    private data class LocalUser(
-        val userId: UserKey,
-        val email: String,
-        val displayName: String,
-        val password: String,
-        val tenantMemberships: Map<TenantKey, Set<TenantRole>>,
-        val globalRoles: Set<TenantRole> = emptySet(),
-        val platformRoles: Set<PlatformRole> = emptySet(),
-    )
 
     /**
      * UserDetails implementation that holds EpistolaPrincipal.
@@ -106,7 +77,14 @@ class LocalUserDetailsService : UserDetailsService {
         override fun isAccountNonLocked() = true
 
         companion object {
-            private const val serialVersionUID: Long = 3L
+            private const val serialVersionUID: Long = 4L
         }
+    }
+
+    companion object {
+        /**
+         * Generates a deterministic UUID from a username so user IDs are stable across restarts.
+         */
+        private fun deterministicUuid(username: String): UUID = UUID.nameUUIDFromBytes(username.toByteArray(StandardCharsets.UTF_8))
     }
 }

--- a/apps/epistola/src/main/resources/application-demo.yaml
+++ b/apps/epistola/src/main/resources/application-demo.yaml
@@ -1,13 +1,10 @@
-# Demo profile: form-based login with in-memory users, suitable for K8s demo environments.
-# Users: admin@local / admin, user@local / user
-
-spring:
-  flyway:
-    clean-disabled: false
+# Demo profile: loads demo tenant, themes, and templates.
+# Does NOT affect authentication or database management.
+#
+# Combine with an auth profile:
+#   - keycloak,demo         -> OAuth2 + demo data
+#   - keycloak,demo,localauth -> OAuth2 + form login + demo data
 
 epistola:
-  auth:
-    auto-provision: false
-
   demo:
     enabled: true

--- a/apps/epistola/src/main/resources/application-keycloak.yaml
+++ b/apps/epistola/src/main/resources/application-keycloak.yaml
@@ -10,8 +10,13 @@
 #   docker compose -f apps/epistola/docker/keycloak/docker-compose.yaml up -d
 #   ./gradlew :apps:epistola:bootRun --args='--spring.profiles.active=local,keycloak'
 #
-# Override for production via environment variables:
-#   KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET, KEYCLOAK_ISSUER_URI
+# Override for production via Spring Boot env vars:
+#   SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTID
+#   SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET
+#   SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI
+#   SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
+#
+# The Helm chart maps keycloak.* values to these env vars automatically.
 
 spring:
   security:
@@ -19,24 +24,24 @@ spring:
       client:
         registration:
           keycloak:
-            client-id: ${KEYCLOAK_CLIENT_ID:epistola-suite}
-            client-secret: ${KEYCLOAK_CLIENT_SECRET:epistola-dev-secret}
+            client-id: epistola-suite
+            client-secret: epistola-dev-secret
             scope: openid,profile,email
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
         provider:
           keycloak:
-            issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/epistola}
+            issuer-uri: http://localhost:8080/realms/epistola
             user-name-attribute: preferred_username
       resourceserver:
         jwt:
-          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/epistola}
+          issuer-uri: http://localhost:8080/realms/epistola
 
 epistola:
   auth:
     auto-provision: true
   keycloak:
     admin-url: ${epistola.auth.oidc.backchannel-base-url:http://localhost:8080}
-    realm: ${KEYCLOAK_REALM:epistola}
-    client-id: ${KEYCLOAK_CLIENT_ID:epistola-suite}
-    client-secret: ${KEYCLOAK_CLIENT_SECRET:epistola-dev-secret}
+    realm: epistola
+    client-id: epistola-suite
+    client-secret: epistola-dev-secret

--- a/apps/epistola/src/main/resources/application-keycloak.yaml
+++ b/apps/epistola/src/main/resources/application-keycloak.yaml
@@ -1,18 +1,17 @@
-# Keycloak profile for OAuth2/OIDC testing
+# Keycloak profile: OAuth2/OIDC authentication via Keycloak.
 #
 # This profile is ADDITIVE - use it together with other profiles:
-#   - local,keycloak  -> Form login + OAuth2 (both options on login page)
-#   - keycloak        -> OAuth2 only
+#   - local,keycloak           -> Form login + OAuth2 (both options on login page)
+#   - keycloak,demo            -> OAuth2 + demo data (staging/test)
+#   - keycloak,demo,localauth  -> OAuth2 + form login + demo data (staging/test)
+#   - prod,keycloak            -> OAuth2 only (production)
 #
-# Start Keycloak:
+# For local development with Keycloak:
 #   docker compose -f apps/epistola/docker/keycloak/docker-compose.yaml up -d
-#
-# Run app:
 #   ./gradlew :apps:epistola:bootRun --args='--spring.profiles.active=local,keycloak'
 #
-# Keycloak test users:
-#   - admin@test / admin
-#   - user@test / user
+# Override for production via environment variables:
+#   KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET, KEYCLOAK_ISSUER_URI
 
 spring:
   security:
@@ -20,24 +19,24 @@ spring:
       client:
         registration:
           keycloak:
-            client-id: epistola-suite
-            client-secret: epistola-dev-secret
+            client-id: ${KEYCLOAK_CLIENT_ID:epistola-suite}
+            client-secret: ${KEYCLOAK_CLIENT_SECRET:epistola-dev-secret}
             scope: openid,profile,email
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
         provider:
           keycloak:
-            issuer-uri: http://localhost:8080/realms/epistola
+            issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/epistola}
             user-name-attribute: preferred_username
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8080/realms/epistola
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/epistola}
 
 epistola:
   auth:
     auto-provision: true
   keycloak:
     admin-url: ${epistola.auth.oidc.backchannel-base-url:http://localhost:8080}
-    realm: epistola
-    client-id: epistola-suite
+    realm: ${KEYCLOAK_REALM:epistola}
+    client-id: ${KEYCLOAK_CLIENT_ID:epistola-suite}
     client-secret: ${KEYCLOAK_CLIENT_SECRET:epistola-dev-secret}

--- a/apps/epistola/src/main/resources/application-local.yaml
+++ b/apps/epistola/src/main/resources/application-local.yaml
@@ -27,10 +27,6 @@ spring:
       enabled: true
       poll-interval: 2000ms
       quiet-period: 1000ms
-  security:
-    oauth2:
-      client:
-        registration: {} # Disable OAuth2 for local profile
   session:
     timeout: 1m # Longer session timeout for local development
 
@@ -48,8 +44,30 @@ management:
       enabled: false
 
 epistola:
+  demo:
+    enabled: true
   auth:
     auto-provision: false # Not needed for in-memory users
+    local-users:
+      - username: admin@local
+        password: admin
+        display-name: Local Admin
+        tenant: demo
+        roles:
+          - READER
+          - EDITOR
+          - GENERATOR
+          - MANAGER
+        platform-roles:
+          - TENANT_MANAGER
+      - username: user@local
+        password: user
+        display-name: Local User
+        tenant: demo
+        roles:
+          - READER
+          - EDITOR
+          - GENERATOR
   catalog:
     allow-http: true
   editor:

--- a/apps/epistola/src/main/resources/application-local.yaml
+++ b/apps/epistola/src/main/resources/application-local.yaml
@@ -30,19 +30,6 @@ spring:
   session:
     timeout: 1m # Longer session timeout for local development
 
-management:
-  otlp:
-    metrics:
-      export:
-        enabled: false
-  logging:
-    export:
-      otlp:
-        enabled: false
-  tracing:
-    export:
-      enabled: false
-
 epistola:
   demo:
     enabled: true

--- a/apps/epistola/src/main/resources/application-localauth.yaml
+++ b/apps/epistola/src/main/resources/application-localauth.yaml
@@ -1,0 +1,32 @@
+# Local auth profile: form-based login with configurable users.
+# Override credentials and roles via env vars for non-local environments.
+#
+# Usage:
+#   - local,keycloak,localauth  -> Form login + OAuth2 with custom credentials
+#   - keycloak,demo,localauth   -> Staging with both auth methods
+#
+# Override example:
+#   LOCAL_AUTH_ADMIN_USERNAME=admin@staging LOCAL_AUTH_ADMIN_PASSWORD=s3cret
+
+epistola:
+  auth:
+    local-users:
+      - username: ${LOCAL_AUTH_ADMIN_USERNAME:admin@local}
+        password: ${LOCAL_AUTH_ADMIN_PASSWORD:admin}
+        display-name: ${LOCAL_AUTH_ADMIN_DISPLAY_NAME:Local Admin}
+        tenant: ${LOCAL_AUTH_ADMIN_TENANT:demo}
+        roles:
+          - READER
+          - EDITOR
+          - GENERATOR
+          - MANAGER
+        platform-roles:
+          - TENANT_MANAGER
+      - username: ${LOCAL_AUTH_USER_USERNAME:user@local}
+        password: ${LOCAL_AUTH_USER_PASSWORD:user}
+        display-name: ${LOCAL_AUTH_USER_DISPLAY_NAME:Local User}
+        tenant: ${LOCAL_AUTH_USER_TENANT:demo}
+        roles:
+          - READER
+          - EDITOR
+          - GENERATOR

--- a/apps/epistola/src/main/resources/application-prod.yaml
+++ b/apps/epistola/src/main/resources/application-prod.yaml
@@ -1,24 +1,8 @@
-# Production configuration with OAuth2/OIDC authentication
+# Production hardening. Pair with 'keycloak' for OAuth2/OIDC authentication.
+#
+# Usage: spring.profiles.active=prod,keycloak
 
 spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          keycloak:
-            client-id: ${KEYCLOAK_CLIENT_ID:epistola-suite}
-            client-secret: ${KEYCLOAK_CLIENT_SECRET:}
-            scope: openid,profile,email
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            authorization-grant-type: authorization_code
-        provider:
-          keycloak:
-            issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/epistola}
-            user-name-attribute: preferred_username
-      resourceserver:
-        jwt:
-          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/epistola}
-
   flyway:
     clean-disabled: true # NEVER allow clean in production
 
@@ -27,12 +11,6 @@ spring:
     timeout: 8h
 
 epistola:
-  auth:
-    auto-provision: true
-
-  demo:
-    enabled: false # Disable demo loading in production
-
   # Document generation configuration
   generation:
     polling:

--- a/apps/epistola/src/main/resources/application.yaml
+++ b/apps/epistola/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ epistola:
   auth:
     auto-provision: false
   demo:
-    enabled: true # Set to false to disable demo loading
+    enabled: false # Opt-in: activate via 'demo' or 'local' profile
   generation:
     polling:
       enabled: true # Enable polling-based job execution

--- a/apps/epistola/src/main/resources/application.yaml
+++ b/apps/epistola/src/main/resources/application.yaml
@@ -87,3 +87,14 @@ management:
       enabled: true
     readinessState:
       enabled: true
+  otlp:
+    metrics:
+      export:
+        enabled: false
+    tracing:
+      export:
+        enabled: false
+  logging:
+    export:
+      otlp:
+        enabled: false

--- a/apps/epistola/src/main/resources/templates/login.html
+++ b/apps/epistola/src/main/resources/templates/login.html
@@ -37,7 +37,7 @@
                     <input th:if="${param.popup != null}" type="hidden" name="popup" value="true">
                     <div class="form-group">
                         <label for="username">Email</label>
-                        <input type="text" id="username" name="username" required autofocus placeholder="admin@local">
+                        <input type="text" id="username" name="username" required autofocus placeholder="Email">
                     </div>
                     <div class="form-group">
                         <label for="password">Password</label>
@@ -46,14 +46,6 @@
                     <button type="submit" class="btn btn-primary" style="width: 100%;">Sign In</button>
                 </form>
 
-                <div th:unless="${param.popup != null}" class="alert alert-warning" style="margin-top: var(--ep-space-6);">
-                    <div>
-                        <strong>Local Development Mode</strong><br>
-                        Test accounts:<br>
-                        &bull; admin@local / admin<br>
-                        &bull; user@local / user
-                    </div>
-                </div>
             </div>
 
             <!-- Divider when both login methods are available -->

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/security/AuthenticationSafetyValidatorTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/security/AuthenticationSafetyValidatorTest.kt
@@ -48,10 +48,36 @@ class AuthenticationSafetyValidatorTest {
     }
 
     @Test
-    fun `demo profile with prod throws`() {
+    fun `localauth profile with prod throws`() {
         val validator = AuthenticationSafetyValidator(
-            environment = envWith("demo", "prod"),
+            environment = envWith("localauth", "prod"),
             userDetailsService = mockUserDetailsService(),
+            clientRegistrationRepository = mockClientRegistrationRepository(),
+        )
+
+        assertThrows<IllegalStateException> {
+            validator.afterSingletonsInstantiated()
+        }
+    }
+
+    @Test
+    fun `demo profile with prod and keycloak passes`() {
+        val validator = AuthenticationSafetyValidator(
+            environment = envWith("demo", "prod", "keycloak"),
+            userDetailsService = null,
+            clientRegistrationRepository = mockClientRegistrationRepository(),
+        )
+
+        assertDoesNotThrow {
+            validator.afterSingletonsInstantiated()
+        }
+    }
+
+    @Test
+    fun `no auth beans throws`() {
+        val validator = AuthenticationSafetyValidator(
+            environment = envWith("default"),
+            userDetailsService = null,
             clientRegistrationRepository = null,
         )
 
@@ -61,9 +87,9 @@ class AuthenticationSafetyValidatorTest {
     }
 
     @Test
-    fun `no auth beans throws`() {
+    fun `demo alone without auth throws`() {
         val validator = AuthenticationSafetyValidator(
-            environment = envWith("default"),
+            environment = envWith("demo"),
             userDetailsService = null,
             clientRegistrationRepository = null,
         )
@@ -87,11 +113,24 @@ class AuthenticationSafetyValidatorTest {
     }
 
     @Test
-    fun `demo profile alone with UserDetailsService passes`() {
+    fun `demo with keycloak passes`() {
         val validator = AuthenticationSafetyValidator(
-            environment = envWith("demo"),
+            environment = envWith("demo", "keycloak"),
+            userDetailsService = null,
+            clientRegistrationRepository = mockClientRegistrationRepository(),
+        )
+
+        assertDoesNotThrow {
+            validator.afterSingletonsInstantiated()
+        }
+    }
+
+    @Test
+    fun `localauth with keycloak passes`() {
+        val validator = AuthenticationSafetyValidator(
+            environment = envWith("localauth", "keycloak"),
             userDetailsService = mockUserDetailsService(),
-            clientRegistrationRepository = null,
+            clientRegistrationRepository = mockClientRegistrationRepository(),
         )
 
         assertDoesNotThrow {

--- a/charts/epistola/templates/deployment.yaml
+++ b/charts/epistola/templates/deployment.yaml
@@ -61,17 +61,27 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.otlpEndpoint | quote }}
             {{- end }}
-            {{- /* Keycloak / OAuth2 */}}
+            {{- /* Keycloak / OAuth2 — set canonical Spring property env vars */}}
             {{- if .Values.keycloak.enabled }}
-            - name: KEYCLOAK_CLIENT_ID
+            {{- $issuerUri := required "keycloak.issuerUri is required when keycloak.enabled is true" .Values.keycloak.issuerUri }}
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTID
               value: {{ .Values.keycloak.clientId | quote }}
-            - name: KEYCLOAK_CLIENT_SECRET
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ required "keycloak.existingSecret is required when keycloak.enabled is true" .Values.keycloak.existingSecret }}
                   key: {{ .Values.keycloak.secretKey }}
-            - name: KEYCLOAK_ISSUER_URI
-              value: {{ required "keycloak.issuerUri is required when keycloak.enabled is true" .Values.keycloak.issuerUri | quote }}
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI
+              value: {{ $issuerUri | quote }}
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
+              value: {{ $issuerUri | quote }}
+            - name: EPISTOLA_KEYCLOAK_CLIENTID
+              value: {{ .Values.keycloak.clientId | quote }}
+            - name: EPISTOLA_KEYCLOAK_CLIENTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.existingSecret }}
+                  key: {{ .Values.keycloak.secretKey }}
             {{- if .Values.keycloak.backchannelBaseUrl }}
             - name: EPISTOLA_AUTH_OIDC_BACKCHANNELBASEURL
               value: {{ .Values.keycloak.backchannelBaseUrl | quote }}

--- a/charts/epistola/templates/deployment.yaml
+++ b/charts/epistola/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.keycloak.existingSecret }}
                   key: {{ .Values.keycloak.secretKey }}
+            {{- if .Values.keycloak.ensureGroups }}
+            - name: EPISTOLA_KEYCLOAK_ENSUREGROUPS
+              value: "true"
+            {{- end }}
             {{- if .Values.keycloak.backchannelBaseUrl }}
             - name: EPISTOLA_AUTH_OIDC_BACKCHANNELBASEURL
               value: {{ .Values.keycloak.backchannelBaseUrl | quote }}

--- a/charts/epistola/templates/deployment.yaml
+++ b/charts/epistola/templates/deployment.yaml
@@ -60,6 +60,12 @@ spec:
             {{- if .Values.observability.otlpEndpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.otlpEndpoint | quote }}
+            - name: MANAGEMENT_OTLP_METRICS_EXPORT_ENABLED
+              value: "true"
+            - name: MANAGEMENT_OTLP_TRACING_EXPORT_ENABLED
+              value: "true"
+            - name: MANAGEMENT_LOGGING_EXPORT_OTLP_ENABLED
+              value: "true"
             {{- end }}
             {{- /* Keycloak / OAuth2 — set canonical Spring property env vars */}}
             {{- if .Values.keycloak.enabled }}

--- a/charts/epistola/templates/deployment.yaml
+++ b/charts/epistola/templates/deployment.yaml
@@ -69,25 +69,49 @@ spec:
             {{- end }}
             {{- /* Keycloak / OAuth2 — set canonical Spring property env vars */}}
             {{- if .Values.keycloak.enabled }}
-            {{- $issuerUri := required "keycloak.issuerUri is required when keycloak.enabled is true" .Values.keycloak.issuerUri }}
+            {{- if .Values.keycloak.existingSecret }}
+            {{- /* All values from existing secret */}}
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTID
-              value: {{ .Values.keycloak.clientId | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.existingSecret }}
+                  key: {{ .Values.keycloak.secretKeys.clientId }}
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "keycloak.existingSecret is required when keycloak.enabled is true" .Values.keycloak.existingSecret }}
-                  key: {{ .Values.keycloak.secretKey }}
+                  name: {{ .Values.keycloak.existingSecret }}
+                  key: {{ .Values.keycloak.secretKeys.clientSecret }}
             - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI
-              value: {{ $issuerUri | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.existingSecret }}
+                  key: {{ .Values.keycloak.secretKeys.issuerUri }}
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
-              value: {{ $issuerUri | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.existingSecret }}
+                  key: {{ .Values.keycloak.secretKeys.issuerUri }}
             - name: EPISTOLA_KEYCLOAK_CLIENTID
-              value: {{ .Values.keycloak.clientId | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.existingSecret }}
+                  key: {{ .Values.keycloak.secretKeys.clientId }}
             - name: EPISTOLA_KEYCLOAK_CLIENTSECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.keycloak.existingSecret }}
-                  key: {{ .Values.keycloak.secretKey }}
+                  key: {{ .Values.keycloak.secretKeys.clientSecret }}
+            {{- else }}
+            {{- /* Plain values (dev/testing) */}}
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTID
+              value: {{ .Values.keycloak.clientId | quote }}
+            - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI
+              value: {{ required "keycloak.issuerUri is required when keycloak.enabled is true and no existingSecret is set" .Values.keycloak.issuerUri | quote }}
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
+              value: {{ .Values.keycloak.issuerUri | quote }}
+            - name: EPISTOLA_KEYCLOAK_CLIENTID
+              value: {{ .Values.keycloak.clientId | quote }}
+            {{- end }}
             {{- if .Values.keycloak.ensureGroups }}
             - name: EPISTOLA_KEYCLOAK_ENSUREGROUPS
               value: "true"

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -148,13 +148,18 @@ observability:
 # Keycloak / OAuth2 configuration (optional, requires config.profiles to include "keycloak")
 keycloak:
   enabled: false
+  # Plain values (used when existingSecret is empty)
   clientId: epistola-suite
-  # Name of existing secret containing the client secret
-  existingSecret: ""
-  # Key in the secret containing the client secret
-  secretKey: client-secret
-  # Keycloak issuer URI (e.g., https://keycloak.example.com/realms/epistola)
   issuerUri: ""
+  # Reference a pre-existing secret containing Keycloak credentials.
+  # When set, all values are read from the secret using the key names in secretKeys.
+  # When empty, plain values above are used (suitable for dev/testing).
+  existingSecret: ""
+  # Key names within the existing secret
+  secretKeys:
+    clientId: client-id
+    clientSecret: client-secret
+    issuerUri: issuer-uri
   # Ensure base group hierarchy (/epistola/tenants, /epistola/global/*, /epistola/platform/*) exists on startup
   ensureGroups: false
   # Internal base URL for server-to-server OIDC calls (token, JWK, userinfo).

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -155,6 +155,8 @@ keycloak:
   secretKey: client-secret
   # Keycloak issuer URI (e.g., https://keycloak.example.com/realms/epistola)
   issuerUri: ""
+  # Ensure base group hierarchy (/epistola/tenants, /epistola/global/*, /epistola/platform/*) exists on startup
+  ensureGroups: false
   # Internal base URL for server-to-server OIDC calls (token, JWK, userinfo).
   # Use when Keycloak is reachable at a different URL from within the cluster
   # than from the browser (e.g., http://keycloak-svc/auth vs https://auth.example.com/auth).

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -145,7 +145,7 @@ observability:
     datasourceName: "Prometheus"
     folder: "Epistola"
 
-# Keycloak / OAuth2 configuration (optional, requires config.profiles to include "prod")
+# Keycloak / OAuth2 configuration (optional, requires config.profiles to include "keycloak")
 keycloak:
   enabled: false
   clientId: epistola-suite
@@ -163,6 +163,8 @@ keycloak:
 # Application configuration
 config:
   # Spring profiles to activate
+  # Production:    "prod,keycloak"
+  # Staging/Test:  "keycloak,demo" or "keycloak,demo,localauth"
   profiles: ""
   # Additional environment variables
   env: {}

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -2,21 +2,43 @@
 
 Epistola Suite uses **bean-driven authentication** that adapts to the runtime environment based on which Spring beans are present:
 
-| Bean Present                   | Authentication Method                         | Provided By                                                                             |
-| ------------------------------ | --------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `UserDetailsService`           | Form-based login with in-memory users         | `LocalUserDetailsService` (`local` / `demo` profiles)                                   |
-| `ClientRegistrationRepository` | OAuth2/OIDC (Keycloak, etc.)                  | Spring Security auto-config from `application-prod.yaml` or `application-keycloak.yaml` |
-| Neither                        | **Startup failure** — safety validator blocks | —                                                                                       |
+| Bean Present                   | Authentication Method                         | Provided By                                                  |
+| ------------------------------ | --------------------------------------------- | ------------------------------------------------------------ |
+| `UserDetailsService`           | Form-based login with configurable users      | `LocalUserDetailsService` (`local` / `localauth` profiles)   |
+| `ClientRegistrationRepository` | OAuth2/OIDC (Keycloak, etc.)                  | Spring Security auto-config from `application-keycloak.yaml` |
+| Neither                        | **Startup failure** — safety validator blocks | —                                                            |
 
 ## How It Works
 
 Authentication methods are **not determined by profile name checks**. Instead:
 
-1. **`LocalUserDetailsService`** is annotated `@Profile("local | demo")` — it's the single source of truth for which profiles get form login.
+1. **`LocalUserDetailsService`** is annotated `@Profile("local | localauth")` — it's the single source of truth for which profiles get form login.
 2. **`SecurityConfig`** and **`LoginHandler`** check for `UserDetailsService` bean presence (not profile names).
 3. **`OAuth2UserProvisioningService`** uses `@ConditionalOnBean(ClientRegistrationRepository::class)` — only loaded when OAuth2 is configured.
 
 Adding a new form-login profile only requires updating `LocalUserDetailsService`'s `@Profile` annotation.
+
+## Profile Composition
+
+Profiles are orthogonal — each controls a single concern:
+
+| Profile     | Concern                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| `local`     | Dev experience: devtools, filesystem serving, editor watch. Implies form login + demo data. |
+| `localauth` | Form login with configurable users (env-var overridable)                                    |
+| `keycloak`  | OAuth2/OIDC authentication via Keycloak                                                     |
+| `demo`      | Load demo data only (no auth side effects)                                                  |
+| `prod`      | Production hardening: flyway clean disabled, tuned concurrency                              |
+
+### Environment Matrix
+
+| Environment  | Profiles                  | Auth         | Demo | DB Reset |
+| ------------ | ------------------------- | ------------ | ---- | -------- |
+| Local dev    | `local`                   | Form login   | yes  | yes      |
+| Local + KC   | `local,keycloak`          | Form + OAuth | yes  | yes      |
+| Test/Staging | `keycloak,demo`           | OAuth2 only  | yes  | yes      |
+| Test/Staging | `keycloak,demo,localauth` | Both         | yes  | yes      |
+| Production   | `prod,keycloak`           | OAuth2 only  | no   | no       |
 
 ## Safety Guards
 
@@ -24,7 +46,7 @@ Adding a new form-login profile only requires updating `LocalUserDetailsService`
 
 A `SmartInitializingSingleton` that runs at startup and fails fast if:
 
-- **In-memory users in production**: `local` or `demo` profile combined with `prod` → blocks startup (known passwords in production).
+- **In-memory users in production**: `local` or `localauth` profile combined with `prod` → blocks startup.
 - **No authentication configured**: Neither `UserDetailsService` nor `ClientRegistrationRepository` exists → blocks startup (all requests would 403).
 
 Skipped in `test` profile (tests use permit-all security).
@@ -41,19 +63,44 @@ Start the application with the `local` profile:
 ./gradlew :apps:epistola:bootRun --args='--spring.profiles.active=local'
 ```
 
-### Test Accounts
+Default test accounts (configured in `application-local.yaml`):
 
 | Username      | Password | Description                             |
 | ------------- | -------- | --------------------------------------- |
 | `admin@local` | `admin`  | Admin user with access to all tenants   |
 | `user@local`  | `user`   | Regular user with access to demo-tenant |
 
-## Demo Environment
+## Local Auth Profile
 
-The `demo` profile provides the same in-memory users as `local`, suitable for K8s demo environments:
+The `localauth` profile provides form-based login with **configurable** users, suitable for staging/test environments where you need form login alongside Keycloak:
 
 ```bash
-SPRING_PROFILES_ACTIVE=demo
+SPRING_PROFILES_ACTIVE=keycloak,demo,localauth
+```
+
+Override credentials via environment variables:
+
+| Variable                        | Default       |
+| ------------------------------- | ------------- |
+| `LOCAL_AUTH_ADMIN_USERNAME`     | `admin@local` |
+| `LOCAL_AUTH_ADMIN_PASSWORD`     | `admin`       |
+| `LOCAL_AUTH_ADMIN_DISPLAY_NAME` | `Local Admin` |
+| `LOCAL_AUTH_ADMIN_TENANT`       | `demo`        |
+| `LOCAL_AUTH_USER_USERNAME`      | `user@local`  |
+| `LOCAL_AUTH_USER_PASSWORD`      | `user`        |
+| `LOCAL_AUTH_USER_DISPLAY_NAME`  | `Local User`  |
+| `LOCAL_AUTH_USER_TENANT`        | `demo`        |
+
+## Demo Profile
+
+The `demo` profile **only** loads demo data (tenant, themes, templates). It does not affect authentication. Combine it with an auth profile:
+
+```bash
+# OAuth2 + demo data
+SPRING_PROFILES_ACTIVE=keycloak,demo
+
+# OAuth2 + form login + demo data
+SPRING_PROFILES_ACTIVE=keycloak,demo,localauth
 ```
 
 ## Production (OAuth2/OIDC)
@@ -70,22 +117,13 @@ export KEYCLOAK_CLIENT_SECRET=<your-secret>
 export KEYCLOAK_ISSUER_URI=https://keycloak.example.com/realms/epistola
 ```
 
-Or configure in `application-prod.yaml`:
+Activate profiles:
 
-```yaml
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          keycloak:
-            client-id: ${KEYCLOAK_CLIENT_ID}
-            client-secret: ${KEYCLOAK_CLIENT_SECRET}
-            scope: openid,profile,email
-        provider:
-          keycloak:
-            issuer-uri: ${KEYCLOAK_ISSUER_URI}
+```bash
+SPRING_PROFILES_ACTIVE=prod,keycloak
 ```
+
+The `keycloak` profile provides all OAuth2 configuration with env-var overrides. The `prod` profile provides production hardening (flyway clean disabled, tuned concurrency).
 
 ### AuthProvider Derivation
 
@@ -104,12 +142,12 @@ See [docs/keycloak-setup.md](keycloak-setup.md) for detailed Keycloak configurat
 
 ### Auto-Provisioning
 
-When a user logs in via OAuth2 for the first time, they are automatically created in the database if `auto-provision` is enabled:
+When a user logs in via OAuth2 for the first time, they are automatically created in the database. This is enabled by default in the `keycloak` profile:
 
 ```yaml
 epistola:
   auth:
-    auto-provision: true # Default in prod
+    auto-provision: true # Default in keycloak profile
 ```
 
 Disable this to require manual user creation before login.
@@ -283,12 +321,12 @@ class MyHandlerTest : CoreIntegrationTestBase() {
 
 No `UserDetailsService` or `ClientRegistrationRepository` bean was found. Either:
 
-- Activate a profile with form login: `--spring.profiles.active=local` or `demo`
-- Configure OAuth2 registrations: use `prod` or `keycloak` profile
+- Activate a profile with form login: `--spring.profiles.active=local` or `localauth`
+- Configure OAuth2 registrations: use `keycloak` profile
 
-### App Fails to Start with "Cannot combine 'local' or 'demo' profile with 'prod'"
+### App Fails to Start with "Cannot combine 'local' or 'localauth' profile with 'prod'"
 
-In-memory users with known passwords must not be used in production. Remove the `local`/`demo` profile from your production configuration.
+In-memory users must not be used in production. Remove the `local`/`localauth` profile from your production configuration.
 
 ### Session Lost After Restart
 


### PR DESCRIPTION
## Summary

- **Orthogonal profile restructuring**: Profiles are now single-concern and composable. Each controls one axis: `local` (dev experience), `localauth` (configurable form login), `keycloak` (OAuth2/OIDC), `demo` (data only), `prod` (hardening).
- **`localauth` profile**: Form-based login with env-var configurable users, passwords, and roles — suitable for staging/test alongside Keycloak.
- **Helm chart Keycloak fix**: Use canonical Spring Boot env vars instead of custom `KEYCLOAK_*` placeholders that weren't reliably resolved.
- **Helm chart `keycloak.ensureGroups`**: Exposes the group hierarchy initialization as a chart value.
- **OTLP disabled by default**: Prevents connection timeouts when no OTLP collector is configured.

### BREAKING CHANGE — Profile migration

| Before | After |
|--------|-------|
| `prod` | `prod,keycloak` |
| `demo` | `keycloak,demo` or `keycloak,demo,localauth` |
| `local` | `local` (unchanged) |
| `local,keycloak` | `local,keycloak` (unchanged) |

### Environment matrix

| Environment  | Profiles                  | Auth         | Demo | DB Reset |
|--------------|---------------------------|--------------|------|----------|
| Local dev    | `local`                   | Form login   | yes  | yes      |
| Local + KC   | `local,keycloak`          | Form + OAuth | yes  | yes      |
| Test/Staging | `keycloak,demo,localauth` | Both         | yes  | yes      |
| Test/Staging | `keycloak,demo`           | OAuth2 only  | yes  | yes      |
| Production   | `prod,keycloak`           | OAuth2 only  | no   | no       |

## Test plan

- [x] `./gradlew unitTest` — AuthenticationSafetyValidatorTest passes
- [x] `./gradlew integrationTest` — all integration tests pass
- [ ] Manual: `local` profile starts with form login + demo data
- [ ] Manual: `local,keycloak` provides both auth methods
- [ ] Manual: `keycloak,demo` provides OAuth2 only + demo data
- [ ] Manual: `prod,keycloak` blocks demo and DB reset
- [ ] Manual: `localauth,prod` blocked by safety validator
- [ ] Helm: deploy with `keycloak.enabled=true` and verify issuer URI is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)