### PR TITLE
feat(editor): add block block clipboard copy/paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **Helm chart release skill**: Added `/release-helm-chart` Claude Code skill for releasing new Helm chart versions, mirroring the app `/release` flow
 - **Separate Helm chart changelog**: Chart changes are now tracked in `charts/epistola/CHANGELOG.md`, independent of the app changelog
+- **Editor block clipboard copy/paste**: The template editor can now copy the selected block subtree to a dedicated clipboard payload and paste it before, after, or inside another target block using a placement dialog with slot selection for multi-slot containers.
 
 ### Changed
 

--- a/modules/editor/src/main/typescript/styles/editor-layout.css
+++ b/modules/editor/src/main/typescript/styles/editor-layout.css
@@ -248,6 +248,133 @@
     font-family: var(--ep-font-mono);
   }
 
+  .paste-dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.2);
+    z-index: 35;
+    animation: ep-insert-backdrop-in 140ms ease-out;
+  }
+
+  .paste-dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(30rem, 92vw);
+    border-radius: var(--ep-radius-md);
+    border: 1px solid var(--ep-gray-200);
+    background: var(--ep-white);
+    box-shadow: var(--ep-shadow-lg);
+    padding: var(--ep-space-3);
+    z-index: 36;
+    animation: ep-insert-dialog-in 180ms ease-out;
+  }
+
+  .paste-dialog-title {
+    font-size: var(--ep-text-sm);
+    font-weight: 700;
+    color: var(--ep-gray-900);
+  }
+
+  .paste-dialog-hint {
+    margin-top: var(--ep-space-1);
+    font-size: 11px;
+    font-family: var(--ep-font-mono);
+    color: var(--ep-gray-500);
+    background: var(--ep-gray-50);
+    border: 1px solid var(--ep-gray-100);
+    border-radius: var(--ep-radius-sm);
+    padding: 4px 6px;
+  }
+
+  .paste-dialog-context {
+    margin-top: var(--ep-space-1-5);
+    font-size: var(--ep-text-xs);
+    color: var(--ep-gray-600);
+  }
+
+  .paste-dialog-error {
+    margin-top: var(--ep-space-2);
+    font-size: var(--ep-text-xs);
+    color: var(--ep-red-700, #b91c1c);
+  }
+
+  .paste-dialog-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--ep-space-2);
+    margin-top: var(--ep-space-3);
+  }
+
+  .paste-dialog-action,
+  .paste-dialog-slot-option {
+    display: grid;
+    gap: 4px;
+    justify-items: start;
+    padding: 10px;
+    border-radius: var(--ep-radius-sm);
+    border: 1px solid var(--ep-gray-200);
+    background: var(--ep-gray-50);
+    color: var(--ep-gray-900);
+    text-align: left;
+    transition:
+      background-color var(--ep-transition-fast),
+      border-color var(--ep-transition-fast),
+      transform var(--ep-transition-fast);
+
+    &:hover:not(:disabled) {
+      background: var(--ep-blue-50, #eff6ff);
+      border-color: var(--ep-blue-300, #93c5fd);
+      transform: translateY(-1px);
+      cursor: pointer;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--ep-blue-300, #93c5fd);
+      outline-offset: 1px;
+    }
+
+    &:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+      transform: none;
+    }
+  }
+
+  .paste-dialog-action-index,
+  .paste-dialog-slot-index {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    min-width: 1.75rem;
+    font-size: 11px;
+    font-family: var(--ep-font-mono);
+    color: var(--ep-gray-800);
+    background: var(--ep-white);
+    border: 1px solid var(--ep-gray-200);
+    border-radius: var(--ep-radius-sm);
+    padding: 2px 6px;
+  }
+
+  .paste-dialog-action-label,
+  .paste-dialog-slot-label {
+    font-size: var(--ep-text-xs);
+    font-weight: 600;
+    color: var(--ep-gray-900);
+  }
+
+  .paste-dialog-action-detail {
+    font-size: 11px;
+    color: var(--ep-gray-500);
+  }
+
+  .paste-dialog-slot-list {
+    display: grid;
+    gap: var(--ep-space-1-5);
+    margin-top: var(--ep-space-3);
+  }
+
   @keyframes ep-insert-backdrop-in {
     from {
       opacity: 0;
@@ -282,12 +409,22 @@
   @media (prefers-reduced-motion: reduce) {
     .insert-dialog-backdrop,
     .insert-dialog,
-    .insert-dialog-stage {
+    .insert-dialog-stage,
+    .paste-dialog-backdrop,
+    .paste-dialog {
       animation: none;
     }
 
-    .insert-dialog-row {
+    .insert-dialog-row,
+    .paste-dialog-action,
+    .paste-dialog-slot-option {
       transition: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .paste-dialog-actions {
+      grid-template-columns: 1fr;
     }
   }
 

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.test.ts
@@ -1,0 +1,640 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { EpistolaEditor } from './EpistolaEditor.js';
+import {
+  createTestDocumentWithChildren,
+  nodeId,
+  resetCounter,
+  slotId,
+  testRegistry,
+} from '../engine/test-helpers.js';
+import type { TemplateDocument, NodeId, SlotId } from '../types/index.js';
+import {
+  BLOCK_CLIPBOARD_MIME,
+  extractBlockSubtree,
+  serializeBlockClipboard,
+} from './block-clipboard.js';
+
+function createClipboardData(store = new Map<string, string>()): DataTransfer {
+  return {
+    setData: (type: string, value: string) => {
+      store.set(type, value);
+    },
+    getData: (type: string) => store.get(type) ?? '',
+  } as unknown as DataTransfer;
+}
+
+function createMultiSlotDocument(): {
+  doc: TemplateDocument;
+  textNodeId: NodeId;
+  columnsNodeId: NodeId;
+  leftSlotId: SlotId;
+  rightSlotId: SlotId;
+} {
+  const rootId = nodeId('root');
+  const rootSlotId = slotId('root-slot');
+  const textNodeId = nodeId('text1');
+  const columnsNodeId = nodeId('columns1');
+  const leftSlotId = slotId('column-left');
+  const rightSlotId = slotId('column-right');
+
+  const doc: TemplateDocument = {
+    modelVersion: 1,
+    root: rootId,
+    nodes: {
+      [rootId]: { id: rootId, type: 'root', slots: [rootSlotId] },
+      [textNodeId]: { id: textNodeId, type: 'text', slots: [], props: { content: null } },
+      [columnsNodeId]: { id: columnsNodeId, type: 'columns', slots: [leftSlotId, rightSlotId] },
+    },
+    slots: {
+      [rootSlotId]: {
+        id: rootSlotId,
+        nodeId: rootId,
+        name: 'children',
+        children: [textNodeId, columnsNodeId],
+      },
+      [leftSlotId]: { id: leftSlotId, nodeId: columnsNodeId, name: 'left', children: [] },
+      [rightSlotId]: { id: rightSlotId, nodeId: columnsNodeId, name: 'right', children: [] },
+    },
+    themeRef: { type: 'inherit' },
+  };
+
+  return { doc, textNodeId, columnsNodeId, leftSlotId, rightSlotId };
+}
+
+beforeEach(() => {
+  resetCounter();
+});
+
+describe('EpistolaEditor block clipboard', () => {
+  it('writes the selected block to clipboard data', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _isCopyPasteEventInsideEditor: () => boolean;
+      _handleCopy: (e: ClipboardEvent) => void;
+    };
+    editorAny._selectedNodeId = textNodeId;
+    editorAny._isCopyPasteEventInsideEditor = () => true;
+
+    const store = new Map<string, string>();
+    let prevented = false;
+    const eventTarget = { closest: () => null } as unknown as EventTarget;
+
+    editorAny._handleCopy({
+      target: eventTarget,
+      clipboardData: createClipboardData(store),
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as ClipboardEvent);
+
+    expect(prevented).toBe(true);
+    expect(store.has(BLOCK_CLIPBOARD_MIME)).toBe(true);
+  });
+
+  it('ignores block copy when the event is outside the editor', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _handleCopy: (e: ClipboardEvent) => void;
+    };
+    editorAny._selectedNodeId = textNodeId;
+
+    const store = new Map<string, string>();
+    let prevented = false;
+
+    editorAny._handleCopy({
+      target: { closest: () => null } as unknown as EventTarget,
+      clipboardData: createClipboardData(store),
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as ClipboardEvent);
+
+    expect(prevented).toBe(false);
+    expect(store.has(BLOCK_CLIPBOARD_MIME)).toBe(false);
+  });
+
+  it('ignores block copy when an editable target is focused', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _isCopyPasteEventInsideEditor: () => boolean;
+      _handleCopy: (e: ClipboardEvent) => void;
+    };
+    editorAny._selectedNodeId = textNodeId;
+    editorAny._isCopyPasteEventInsideEditor = (): boolean => true;
+
+    const store = new Map<string, string>();
+    let prevented = false;
+    const editableTarget = {
+      nodeType: 1,
+      closest: () => ({}),
+      parentElement: null,
+    } as unknown as EventTarget;
+
+    editorAny._handleCopy({
+      target: editableTarget,
+      clipboardData: createClipboardData(store),
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as ClipboardEvent);
+
+    expect(prevented).toBe(false);
+    expect(store.has(BLOCK_CLIPBOARD_MIME)).toBe(false);
+  });
+
+  it('opens the paste dialog when editor clipboard data is present', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as {
+      _pasteDialogOpen: boolean;
+      _isCopyPasteEventInsideEditor: () => boolean;
+      _handlePaste: (e: ClipboardEvent) => void;
+    };
+    editorAny._isCopyPasteEventInsideEditor = () => true;
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const store = new Map<string, string>([
+      [BLOCK_CLIPBOARD_MIME, serializeBlockClipboard(subtree!)],
+    ]);
+    let prevented = false;
+    const eventTarget = { closest: () => null } as unknown as EventTarget;
+
+    editorAny._handlePaste({
+      target: eventTarget,
+      clipboardData: createClipboardData(store),
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as ClipboardEvent);
+
+    expect(prevented).toBe(true);
+    expect(editorAny._pasteDialogOpen).toBe(true);
+  });
+
+  it('ignores paste when clipboard data is not an editor block payload', () => {
+    const { doc } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as {
+      _pasteDialogOpen: boolean;
+      _isCopyPasteEventInsideEditor: () => boolean;
+      _handlePaste: (e: ClipboardEvent) => void;
+    };
+    editorAny._isCopyPasteEventInsideEditor = (): boolean => true;
+
+    let prevented = false;
+    editorAny._handlePaste({
+      target: { closest: () => null } as unknown as EventTarget,
+      clipboardData: createClipboardData(new Map([['text/plain', 'hello']])),
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as ClipboardEvent);
+
+    expect(prevented).toBe(false);
+    expect(editorAny._pasteDialogOpen).toBe(false);
+  });
+
+  it('ignores paste when an editable target is focused', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _pasteDialogOpen: boolean;
+      _isCopyPasteEventInsideEditor: () => boolean;
+      _handlePaste: (e: ClipboardEvent) => void;
+    };
+    editorAny._isCopyPasteEventInsideEditor = (): boolean => true;
+
+    let prevented = false;
+    const editableTarget = {
+      nodeType: 1,
+      closest: () => ({}),
+      parentElement: null,
+    } as unknown as EventTarget;
+    editorAny._handlePaste({
+      target: editableTarget,
+      clipboardData: createClipboardData(
+        new Map([[BLOCK_CLIPBOARD_MIME, serializeBlockClipboard(subtree!)]]),
+      ),
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as ClipboardEvent);
+
+    expect(prevented).toBe(false);
+    expect(editorAny._pasteDialogOpen).toBe(false);
+  });
+
+  it('renders numbered after, before, and inside paste actions', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _renderPasteDialog: () => unknown;
+    };
+    editorAny._openPasteDialog(subtree!);
+
+    const renderSource = String(editorAny._renderPasteDialog);
+
+    expect(renderSource).toContain('data-testid="paste-after"');
+    expect(renderSource).toContain('data-testid="paste-before"');
+    expect(renderSource).toContain('data-testid="paste-inside"');
+    expect(renderSource).toContain('Paste Block');
+    expect(renderSource).toContain('After');
+    expect(renderSource).toContain('Before');
+    expect(renderSource).toContain('Inside');
+  });
+
+  it('opens a slot picker when inside is chosen on a multi-slot block', () => {
+    const { doc, textNodeId, columnsNodeId } = createMultiSlotDocument();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _pasteDialogMode: 'placement' | 'slot';
+      _pasteDialogSlotOptions: Array<{ slotId: string; label: string }>;
+    };
+    editorAny._selectedNodeId = columnsNodeId;
+    editorAny._openPasteDialog(subtree!);
+
+    editorAny._handlePastePlacement('inside');
+
+    expect(editorAny._pasteDialogMode).toBe('slot');
+    expect(editorAny._pasteDialogSlotOptions).toHaveLength(2);
+  });
+
+  it('returns to placement mode on escape from the slot picker', () => {
+    const { doc, textNodeId, columnsNodeId } = createMultiSlotDocument();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _handlePasteDialogKeydown: (event: KeyboardEvent) => void;
+      _pasteDialogMode: 'placement' | 'slot';
+      _pasteDialogOpen: boolean;
+    };
+    editorAny._selectedNodeId = columnsNodeId;
+    editorAny._openPasteDialog(subtree!);
+    editorAny._handlePastePlacement('inside');
+
+    let prevented = false;
+    editorAny._handlePasteDialogKeydown({
+      key: 'Escape',
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as KeyboardEvent);
+
+    expect(prevented).toBe(true);
+    expect(editorAny._pasteDialogMode).toBe('placement');
+    expect(editorAny._pasteDialogOpen).toBe(true);
+  });
+
+  it('closes the paste dialog on escape from placement mode', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePasteDialogKeydown: (event: KeyboardEvent) => void;
+      _pasteDialogOpen: boolean;
+    };
+    editorAny._openPasteDialog(subtree!);
+
+    editorAny._handlePasteDialogKeydown({
+      key: 'Escape',
+      preventDefault: () => {},
+    } as KeyboardEvent);
+
+    expect(editorAny._pasteDialogOpen).toBe(false);
+  });
+
+  it('sets an error for an invalid slot number in slot mode', () => {
+    const { doc, textNodeId, columnsNodeId } = createMultiSlotDocument();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _handlePasteDialogKeydown: (event: KeyboardEvent) => void;
+      _pasteDialogError: string;
+    };
+    editorAny._selectedNodeId = columnsNodeId;
+    editorAny._openPasteDialog(subtree!);
+    editorAny._handlePastePlacement('inside');
+
+    editorAny._handlePasteDialogKeydown({
+      key: '9',
+      preventDefault: () => {},
+    } as KeyboardEvent);
+
+    expect(editorAny._pasteDialogError).toBe('Invalid slot number');
+  });
+
+  it('sets an error when inside paste has no valid slots', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _pasteDialogError: string;
+      _selectedNodeId: string | null;
+    };
+    editorAny._selectedNodeId = textNodeId;
+    editorAny._openPasteDialog(subtree!);
+
+    editorAny._handlePastePlacement('inside');
+
+    expect(editorAny._pasteDialogError).toBe('No valid inside slot for selected block');
+  });
+
+  it('sets an error when before or after paste has no valid target', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _getPasteTargetForPlacement: () => null;
+      _pasteDialogError: string;
+    };
+    editorAny._openPasteDialog(subtree!);
+    editorAny._getPasteTargetForPlacement = () => null;
+
+    editorAny._handlePastePlacement('after');
+    expect(editorAny._pasteDialogError).toBe('No valid after target');
+
+    editorAny._handlePastePlacement('before');
+    expect(editorAny._pasteDialogError).toBe('No valid before target');
+  });
+
+  it('sets an error when a chosen inside slot cannot produce a target', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePasteSlotSelection: (slotId: string) => void;
+      _buildInsideTargetFromSlot: () => null;
+      _pasteDialogError: string;
+    };
+    editorAny._openPasteDialog(subtree!);
+    editorAny._buildInsideTargetFromSlot = () => null;
+
+    editorAny._handlePasteSlotSelection('slot-1');
+
+    expect(editorAny._pasteDialogError).toBe('Cannot paste into selected slot');
+  });
+
+  it('sets an error when inserting a pasted subtree fails', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _insertPastedSubtreeAtTarget: (target: { slotId: SlotId; index: number }) => boolean;
+      _pasteDialogError: string;
+      _engine: { dispatch: () => { ok: false; error: string } };
+    };
+    editorAny._openPasteDialog(subtree!);
+    editorAny._engine.dispatch = () => ({ ok: false, error: 'Insert failed' });
+
+    const inserted = editorAny._insertPastedSubtreeAtTarget({
+      slotId: doc.nodes[doc.root].slots[0],
+      index: 0,
+    });
+
+    expect(inserted).toBe(false);
+    expect(editorAny._pasteDialogError).toBe('Insert failed');
+  });
+
+  it('pastes into the chosen slot after the slot picker opens', () => {
+    const { doc, textNodeId, columnsNodeId, rightSlotId } = createMultiSlotDocument();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _handlePasteSlotSelection: (slotId: string) => void;
+      _engine: { doc: TemplateDocument; selectedNodeId: string | null };
+      _pasteDialogOpen: boolean;
+    };
+    editorAny._selectedNodeId = columnsNodeId;
+    editorAny._openPasteDialog(subtree!);
+    editorAny._handlePastePlacement('inside');
+
+    editorAny._handlePasteSlotSelection(rightSlotId);
+
+    expect(editorAny._engine.doc.slots[rightSlotId].children).toHaveLength(1);
+    expect(editorAny._engine.doc.slots[rightSlotId].children[0]).not.toBe(textNodeId);
+    expect(editorAny._engine.selectedNodeId).toBe(
+      editorAny._engine.doc.slots[rightSlotId].children[0],
+    );
+    expect(editorAny._pasteDialogOpen).toBe(false);
+  });
+
+  it('pastes inside immediately when only one valid slot exists', () => {
+    const { doc, textNodeId, containerNodeId, containerSlotId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _pasteDialogMode: 'placement' | 'slot';
+      _pasteDialogOpen: boolean;
+      _engine: { doc: TemplateDocument; selectedNodeId: string | null };
+    };
+    editorAny._selectedNodeId = containerNodeId;
+    editorAny._openPasteDialog(subtree!);
+
+    editorAny._handlePastePlacement('inside');
+
+    expect(editorAny._pasteDialogMode).toBe('placement');
+    expect(editorAny._pasteDialogOpen).toBe(false);
+    expect(editorAny._engine.doc.slots[containerSlotId].children).toHaveLength(1);
+    expect(editorAny._engine.doc.slots[containerSlotId].children[0]).not.toBe(textNodeId);
+    expect(editorAny._engine.selectedNodeId).toBe(
+      editorAny._engine.doc.slots[containerSlotId].children[0],
+    );
+  });
+
+  it('pastes at document end when no block is selected', () => {
+    const { doc, textNodeId } = createMultiSlotDocument();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const rootSlotId = doc.nodes[doc.root].slots[0];
+    const originalChildren = [...doc.slots[rootSlotId].children];
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _engine: { doc: TemplateDocument; selectedNodeId: string | null };
+    };
+    editorAny._selectedNodeId = null;
+    editorAny._openPasteDialog(subtree!);
+
+    editorAny._handlePastePlacement('after');
+
+    const nextChildren = editorAny._engine.doc.slots[rootSlotId].children;
+    expect(nextChildren).toHaveLength(originalChildren.length + 1);
+    expect(nextChildren.slice(0, originalChildren.length)).toEqual(originalChildren);
+    expect(nextChildren[nextChildren.length - 1]).not.toBe(textNodeId);
+    expect(editorAny._engine.selectedNodeId).toBe(nextChildren[nextChildren.length - 1]);
+  });
+
+  it('pastes at document start when no block is selected', () => {
+    const { doc, textNodeId } = createMultiSlotDocument();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const rootSlotId = doc.nodes[doc.root].slots[0];
+    const originalChildren = [...doc.slots[rootSlotId].children];
+    const editorAny = editor as unknown as {
+      _selectedNodeId: string | null;
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+      _engine: { doc: TemplateDocument; selectedNodeId: string | null };
+    };
+    editorAny._selectedNodeId = null;
+    editorAny._openPasteDialog(subtree!);
+
+    editorAny._handlePastePlacement('before');
+
+    const nextChildren = editorAny._engine.doc.slots[rootSlotId].children;
+    expect(nextChildren).toHaveLength(originalChildren.length + 1);
+    expect(nextChildren[0]).not.toBe(textNodeId);
+    expect(nextChildren.slice(1)).toEqual(originalChildren);
+    expect(editorAny._engine.selectedNodeId).toBe(nextChildren[0]);
+  });
+
+  it('routes placement hotkeys to the matching paste actions', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const calls: Array<'after' | 'before' | 'inside'> = [];
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePasteDialogKeydown: (event: KeyboardEvent) => void;
+      _handlePastePlacement: (placement: 'after' | 'before' | 'inside') => void;
+    };
+    editorAny._openPasteDialog(subtree!);
+    editorAny._handlePastePlacement = (placement: 'after' | 'before' | 'inside'): void => {
+      calls.push(placement);
+    };
+
+    for (const key of ['1', '2', '3']) {
+      editorAny._handlePasteDialogKeydown({
+        key,
+        preventDefault: (): void => {},
+      } as KeyboardEvent);
+    }
+
+    expect(calls).toEqual(['after', 'before', 'inside']);
+  });
+
+  it('closes the paste dialog when the backdrop is clicked', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const editorAny = editor as unknown as {
+      _openPasteDialog: (subtree: NonNullable<typeof subtree>) => void;
+      _handlePasteDialogBackdropClick: () => void;
+      _pasteDialogOpen: boolean;
+    };
+    editorAny._openPasteDialog(subtree!);
+
+    editorAny._handlePasteDialogBackdropClick();
+
+    expect(editorAny._pasteDialogOpen).toBe(false);
+  });
+});

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { keyed } from 'lit/directives/keyed.js';
-import type { TemplateDocument, NodeId, SlotId, Node, Slot } from '../types/index.js';
+import type { TemplateDocument, NodeId, SlotId } from '../types/index.js';
 import { EditorEngine } from '../engine/EditorEngine.js';
 import {
   createDefaultRegistry,
@@ -22,7 +22,6 @@ import type {
 } from '../plugins/types.js';
 import type { EpistolaSidebar } from './EpistolaSidebar.js';
 import type { EpistolaToolbar } from './EpistolaToolbar.js';
-import { nanoid } from 'nanoid';
 import { EDITOR_SHORTCUTS_CONFIG } from '../shortcuts-config.js';
 import {
   getAllLeaderIdleTokens,
@@ -43,6 +42,13 @@ import {
 } from '../shortcuts/resolver.js';
 import { LeaderModeController, type LeaderModeState } from '../shortcuts/leader-controller.js';
 import { validateCoreShortcutRegistriesOnStartup } from '../shortcuts/startup-validation.js';
+import {
+  extractBlockSubtree,
+  readBlockClipboardData,
+  rekeyBlockSubtree,
+  writeBlockClipboardData,
+  type BlockSubtree,
+} from './block-clipboard.js';
 
 import './EpistolaSidebar.js';
 import './EpistolaCanvas.js';
@@ -51,6 +57,10 @@ import './EpistolaPreview.js';
 import './EpistolaResizeHandle.js';
 
 type InsertMode = 'after' | 'before' | 'inside' | 'start' | 'end';
+type PasteDialogMode = 'placement' | 'slot';
+type ClosestCapableTarget = {
+  closest(selector: string): Element | null;
+};
 
 interface InsertSlotOption {
   slotId: SlotId;
@@ -66,6 +76,28 @@ interface InsertTarget {
 const INSERT_DIALOG_SHORTCUTS = INSERT_DIALOG_KEYS;
 
 const EDITABLE_TARGET_SELECTOR = 'input, textarea, select, [contenteditable="true"], .ProseMirror';
+
+function isClosestCapableTarget(value: unknown): value is ClosestCapableTarget {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'closest' in value &&
+    typeof value.closest === 'function'
+  );
+}
+
+function getClosestCapableTarget(target: EventTarget | null): ClosestCapableTarget | null {
+  if (isClosestCapableTarget(target)) {
+    return target;
+  }
+
+  if (!target || typeof target !== 'object' || !('parentElement' in target)) {
+    return null;
+  }
+
+  const parentElement = target.parentElement;
+  return isClosestCapableTarget(parentElement) ? parentElement : null;
+}
 
 /**
  * <epistola-editor> — Root editor element.
@@ -88,6 +120,8 @@ export class EpistolaEditor extends LitElement {
   private _saveService?: SaveService;
   private _pluginDisposers: PluginDisposeFn[] = [];
   private _onKeydown = this._handleKeydown.bind(this);
+  private _onCopy = this._handleCopy.bind(this);
+  private _onPaste = this._handlePaste.bind(this);
   private _onBeforeUnload = this._handleBeforeUnload.bind(this);
   private readonly _shortcutResolver = new ShortcutResolver<unknown>(
     mergeRegistries(getEditorShortcutRegistry(), getInsertDialogShortcutRegistry()),
@@ -131,8 +165,13 @@ export class EpistolaEditor extends LitElement {
   @state() private _insertDialogQuery = '';
   @state() private _insertDialogHighlight = 0;
   @state() private _insertDialogError = '';
+  @state() private _pasteDialogOpen = false;
+  @state() private _pasteDialogMode: PasteDialogMode = 'placement';
+  @state() private _pasteDialogSlotOptions: InsertSlotOption[] = [];
+  @state() private _pasteDialogError = '';
 
   private _insertTarget: InsertTarget | null = null;
+  private _pasteSubtree: BlockSubtree | null = null;
 
   private static readonly PREVIEW_OPEN_KEY = 'ep:preview-open';
   private static readonly CLEAN_MODE_KEY = 'ep:clean-mode';
@@ -231,6 +270,8 @@ export class EpistolaEditor extends LitElement {
     super.connectedCallback();
     validateCoreShortcutRegistriesOnStartup();
     window.addEventListener('keydown', this._onKeydown);
+    window.addEventListener('copy', this._onCopy);
+    window.addEventListener('paste', this._onPaste);
     this.addEventListener('toggle-preview', this._handleTogglePreview);
     this.addEventListener('toggle-clean-mode', this._handleToggleCleanMode);
     this.addEventListener('force-save', this._handleForceSave);
@@ -247,6 +288,8 @@ export class EpistolaEditor extends LitElement {
 
   override disconnectedCallback(): void {
     window.removeEventListener('keydown', this._onKeydown);
+    window.removeEventListener('copy', this._onCopy);
+    window.removeEventListener('paste', this._onPaste);
     this.removeEventListener('toggle-preview', this._handleTogglePreview);
     this.removeEventListener('toggle-clean-mode', this._handleToggleCleanMode);
     this.removeEventListener('force-save', this._handleForceSave);
@@ -264,8 +307,48 @@ export class EpistolaEditor extends LitElement {
   // Keyboard Handling
   // ---------------------------------------------------------------------------
 
-  private _isShortcutEditingTarget(target: HTMLElement | null): boolean {
-    return !!target?.closest(EDITABLE_TARGET_SELECTOR);
+  private _isShortcutEditingTarget(target: ClosestCapableTarget | null): boolean {
+    return !!target && !!target.closest(EDITABLE_TARGET_SELECTOR);
+  }
+
+  private _isCopyPasteEventInsideEditor(target: EventTarget | null): boolean {
+    const targetElement = getClosestCapableTarget(target);
+    const ownerDocument = this.ownerDocument;
+    const defaultView = ownerDocument ? ownerDocument.defaultView : null;
+    const nodeCtor = defaultView ? defaultView.Node : null;
+    if (targetElement && nodeCtor && target instanceof nodeCtor && this.contains(target)) {
+      return true;
+    }
+
+    const active = globalThis.document ? globalThis.document.activeElement : null;
+    return !!active && this.contains(active);
+  }
+
+  private _handleCopy(e: ClipboardEvent): void {
+    if (!this._engine || !this._doc) return;
+    if (!this._isCopyPasteEventInsideEditor(e.target)) return;
+    if (this._isShortcutEditingTarget(getClosestCapableTarget(e.target))) return;
+
+    const selectedNodeId = this._selectedNodeId;
+    if (!selectedNodeId || selectedNodeId === this._doc.root) return;
+
+    const subtree = extractBlockSubtree(this._doc, selectedNodeId);
+    if (!subtree) return;
+    if (!writeBlockClipboardData(e.clipboardData, subtree)) return;
+
+    e.preventDefault();
+  }
+
+  private _handlePaste(e: ClipboardEvent): void {
+    if (!this._engine || !this._doc) return;
+    if (!this._isCopyPasteEventInsideEditor(e.target)) return;
+    if (this._isShortcutEditingTarget(getClosestCapableTarget(e.target))) return;
+
+    const subtree = readBlockClipboardData(e.clipboardData);
+    if (!subtree) return;
+
+    e.preventDefault();
+    this._openPasteDialog(subtree);
   }
 
   private _canDeleteSelectedBlock(): boolean {
@@ -337,6 +420,11 @@ export class EpistolaEditor extends LitElement {
   private _handleKeydown(e: KeyboardEvent): void {
     if (!this._engine) return;
 
+    if (this._pasteDialogOpen) {
+      this._handlePasteDialogKeydown(e);
+      return;
+    }
+
     const inInsertDialog = this._insertDialogOpen;
     const activeContexts = inInsertDialog
       ? (['insertDialog'] as const)
@@ -398,8 +486,12 @@ export class EpistolaEditor extends LitElement {
   }
 
   private _focusCanvasBlock(nodeId: NodeId | null): void {
-    if (!nodeId) return;
-    requestAnimationFrame(() => {
+    if (!nodeId || typeof this.querySelector !== 'function') return;
+    const schedule =
+      globalThis.requestAnimationFrame ??
+      ((callback: FrameRequestCallback) => setTimeout(callback, 0));
+
+    schedule(() => {
       const block = this.querySelector<HTMLElement>(`.canvas-block[data-node-id="${nodeId}"]`);
       block?.focus({ preventScroll: true });
     });
@@ -484,6 +576,186 @@ export class EpistolaEditor extends LitElement {
       return true;
     }
     return false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Paste Dialog
+  // ---------------------------------------------------------------------------
+
+  private _openPasteDialog(subtree: BlockSubtree): void {
+    this._pasteSubtree = subtree;
+    this._pasteDialogOpen = true;
+    this._pasteDialogMode = 'placement';
+    this._pasteDialogSlotOptions = [];
+    this._pasteDialogError = '';
+  }
+
+  private _closePasteDialog(): void {
+    this._pasteDialogOpen = false;
+    this._pasteDialogMode = 'placement';
+    this._pasteDialogSlotOptions = [];
+    this._pasteDialogError = '';
+    this._pasteSubtree = null;
+  }
+
+  private _returnToPastePlacement(): void {
+    this._pasteDialogMode = 'placement';
+    this._pasteDialogSlotOptions = [];
+    this._pasteDialogError = '';
+  }
+
+  private _handlePasteDialogKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      if (this._pasteDialogMode === 'slot') {
+        this._returnToPastePlacement();
+      } else {
+        this._closePasteDialog();
+      }
+      return;
+    }
+
+    if (!/^[1-9]$/.test(e.key)) {
+      return;
+    }
+
+    e.preventDefault();
+    const index = Number(e.key);
+
+    if (this._pasteDialogMode === 'slot') {
+      const slot = this._pasteDialogSlotOptions[index - 1];
+      if (!slot) {
+        this._pasteDialogError = 'Invalid slot number';
+        return;
+      }
+      this._handlePasteSlotSelection(slot.slotId);
+      return;
+    }
+
+    if (index === 1) {
+      this._handlePastePlacement('after');
+      return;
+    }
+    if (index === 2) {
+      this._handlePastePlacement('before');
+      return;
+    }
+    if (index === 3) {
+      this._handlePastePlacement('inside');
+    }
+  }
+
+  private _handlePastePlacement(placement: 'after' | 'before' | 'inside'): void {
+    this._pasteDialogError = '';
+
+    if (placement === 'inside') {
+      const slotOptions = this._getInsertSlotOptionsForInside();
+      if (slotOptions.length === 0) {
+        this._pasteDialogError = 'No valid inside slot for selected block';
+        return;
+      }
+
+      if (slotOptions.length === 1) {
+        this._handlePasteSlotSelection(slotOptions[0].slotId);
+        return;
+      }
+
+      this._pasteDialogMode = 'slot';
+      this._pasteDialogSlotOptions = slotOptions;
+      return;
+    }
+
+    const target = this._getPasteTargetForPlacement(placement);
+    if (!target) {
+      this._pasteDialogError = `No valid ${placement} target`;
+      return;
+    }
+
+    this._insertPastedSubtreeAtTarget(target);
+  }
+
+  private _handlePasteSlotSelection(slotId: SlotId): void {
+    const target = this._buildInsideTargetFromSlot(slotId);
+    if (!target) {
+      this._pasteDialogError = 'Cannot paste into selected slot';
+      return;
+    }
+
+    this._insertPastedSubtreeAtTarget(target);
+  }
+
+  private _getPasteTargetForPlacement(placement: 'after' | 'before'): InsertTarget | null {
+    if (placement === 'after') {
+      return this._isDocumentInsertContext()
+        ? this._getInsertTargetDocumentEnd()
+        : this._getInsertTargetAfterSelected();
+    }
+
+    return this._isDocumentInsertContext()
+      ? this._getInsertTargetDocumentStart()
+      : this._getInsertTargetBeforeSelected();
+  }
+
+  private _canPastePlacement(placement: 'after' | 'before'): boolean {
+    return this._getPasteTargetForPlacement(placement) !== null;
+  }
+
+  private _canPasteInside(): boolean {
+    return this._getInsertSlotOptionsForInside().length > 0;
+  }
+
+  private _getPasteDialogHint(): string {
+    if (this._pasteDialogMode === 'slot') {
+      return '1-9=Choose slot  Esc=Back';
+    }
+
+    return '1=After  2=Before  3=Inside  Esc=Close';
+  }
+
+  private _getPasteDialogContext(): string {
+    if (this._pasteDialogMode === 'slot') {
+      return `Choose a slot inside ${this._selectedNodeLabel()}`;
+    }
+
+    return this._isDocumentInsertContext()
+      ? 'Paste into the document'
+      : `Paste relative to ${this._selectedNodeLabel()}`;
+  }
+
+  private _getPastePlacementDetail(placement: 'after' | 'before' | 'inside'): string {
+    if (this._isDocumentInsertContext()) {
+      if (placement === 'after') return 'document end';
+      if (placement === 'before') return 'document start';
+      return 'document body';
+    }
+
+    if (placement === 'after') return `after ${this._selectedNodeLabel()}`;
+    if (placement === 'before') return `before ${this._selectedNodeLabel()}`;
+    return `inside ${this._selectedNodeLabel()}`;
+  }
+
+  private _insertPastedSubtreeAtTarget(target: InsertTarget): boolean {
+    if (!this._engine || !this._pasteSubtree) return false;
+
+    const cloned = rekeyBlockSubtree(this._pasteSubtree);
+    const result = this._engine.dispatch({
+      type: 'InsertNode',
+      node: cloned.node,
+      slots: cloned.slots,
+      targetSlotId: target.slotId,
+      index: target.index,
+      _restoreNodes: cloned.extraNodes,
+    });
+
+    if (!result.ok) {
+      this._pasteDialogError = result.error;
+      return false;
+    }
+
+    this._engine.selectNode(cloned.node.id);
+    this._focusCanvasBlock(cloned.node.id);
+    this._closePasteDialog();
+    return true;
   }
 
   // ---------------------------------------------------------------------------
@@ -1005,7 +1277,10 @@ export class EpistolaEditor extends LitElement {
     const index = parentSlot.children.indexOf(nodeId);
     if (index < 0) return false;
 
-    const clone = this._cloneSubtree(nodeId);
+    const source = extractBlockSubtree(this._doc, nodeId);
+    if (!source) return false;
+
+    const clone = rekeyBlockSubtree(source);
     if (!clone) return false;
 
     const result = this._engine.dispatch({
@@ -1023,68 +1298,6 @@ export class EpistolaEditor extends LitElement {
       return true;
     }
     return false;
-  }
-
-  private _cloneSubtree(nodeId: NodeId): { node: Node; slots: Slot[]; extraNodes?: Node[] } | null {
-    const doc = this._doc;
-    if (!doc) return null;
-
-    const nodeIds: NodeId[] = [];
-    const slotIds: SlotId[] = [];
-    const visit = (currentId: NodeId) => {
-      nodeIds.push(currentId);
-      const node = doc.nodes[currentId];
-      if (!node) return;
-      for (const slotId of node.slots) {
-        slotIds.push(slotId);
-        const slot = doc.slots[slotId];
-        if (!slot) continue;
-        for (const childId of slot.children) {
-          visit(childId);
-        }
-      }
-    };
-    visit(nodeId);
-
-    const nodeIdMap = new Map<NodeId, NodeId>();
-    const slotIdMap = new Map<SlotId, SlotId>();
-    for (const id of nodeIds) {
-      nodeIdMap.set(id, nanoid() as NodeId);
-    }
-    for (const id of slotIds) {
-      slotIdMap.set(id, nanoid() as SlotId);
-    }
-
-    const clonedNodes: Node[] = nodeIds.map((id) => {
-      const node = doc.nodes[id];
-      const mappedSlots = node.slots.map((slotId) => slotIdMap.get(slotId)!);
-      return {
-        ...structuredClone(node),
-        id: nodeIdMap.get(id)!,
-        slots: mappedSlots,
-      };
-    });
-
-    const clonedSlots: Slot[] = slotIds.map((id) => {
-      const slot = doc.slots[id];
-      const mappedChildren = slot.children.map((childId) => nodeIdMap.get(childId)!);
-      return {
-        ...structuredClone(slot),
-        id: slotIdMap.get(id)!,
-        nodeId: nodeIdMap.get(slot.nodeId)!,
-        children: mappedChildren,
-      };
-    });
-
-    const rootNode = clonedNodes.find((n) => n.id === nodeIdMap.get(nodeId));
-    if (!rootNode) return null;
-    const extraNodes = clonedNodes.filter((n) => n.id !== rootNode.id);
-
-    return {
-      node: rootNode,
-      slots: clonedSlots,
-      extraNodes: extraNodes.length > 0 ? extraNodes : undefined,
-    };
   }
 
   private _handleTogglePreview = () => {
@@ -1118,6 +1331,98 @@ export class EpistolaEditor extends LitElement {
     if (this._saveService?.isDirtyOrSaving) {
       e.preventDefault();
     }
+  }
+
+  private _handlePasteDialogBackdropClick = (): void => {
+    this._closePasteDialog();
+  };
+
+  private _buildPasteSlotClickHandler(slotId: SlotId): () => void {
+    return (): void => {
+      this._handlePasteSlotSelection(slotId);
+    };
+  }
+
+  private _renderPasteDialog(): unknown {
+    if (!this._pasteDialogOpen) return nothing;
+
+    return html`
+      <div class="paste-dialog-backdrop" @click=${this._handlePasteDialogBackdropClick}></div>
+      <div class="paste-dialog" data-testid="paste-dialog" role="dialog" aria-label="Paste block">
+        <div class="paste-dialog-title">Paste Block</div>
+        <div class="paste-dialog-hint">${this._getPasteDialogHint()}</div>
+        <div class="paste-dialog-context">${this._getPasteDialogContext()}</div>
+
+        ${this._pasteDialogError
+          ? html`<div class="paste-dialog-error">${this._pasteDialogError}</div>`
+          : nothing}
+        ${this._pasteDialogMode === 'slot'
+          ? html`
+              <div class="paste-dialog-slot-list">
+                ${this._pasteDialogSlotOptions.map(
+                  (slot, index) => html`
+                    <button
+                      class="paste-dialog-slot-option"
+                      data-testid=${`paste-slot-${index + 1}`}
+                      type="button"
+                      ?autofocus=${index === 0}
+                      @click=${this._buildPasteSlotClickHandler(slot.slotId)}
+                    >
+                      <span class="paste-dialog-slot-index">${index + 1}</span>
+                      <span class="paste-dialog-slot-label">${slot.label}</span>
+                    </button>
+                  `,
+                )}
+              </div>
+            `
+          : html`
+              <div class="paste-dialog-actions">
+                <button
+                  class="paste-dialog-action"
+                  data-testid="paste-after"
+                  type="button"
+                  ?disabled=${!this._canPastePlacement('after')}
+                  autofocus
+                  @click=${() => this._handlePastePlacement('after')}
+                >
+                  <span class="paste-dialog-action-index">1</span>
+                  <span class="paste-dialog-action-label">After</span>
+                  <span class="paste-dialog-action-detail"
+                    >${this._getPastePlacementDetail('after')}</span
+                  >
+                </button>
+
+                <button
+                  class="paste-dialog-action"
+                  data-testid="paste-before"
+                  type="button"
+                  ?disabled=${!this._canPastePlacement('before')}
+                  @click=${() => this._handlePastePlacement('before')}
+                >
+                  <span class="paste-dialog-action-index">2</span>
+                  <span class="paste-dialog-action-label">Before</span>
+                  <span class="paste-dialog-action-detail"
+                    >${this._getPastePlacementDetail('before')}</span
+                  >
+                </button>
+
+                <button
+                  class="paste-dialog-action"
+                  data-testid="paste-inside"
+                  type="button"
+                  ?disabled=${!this._canPasteInside()}
+                  @click=${() => this._handlePastePlacement('inside')}
+                >
+                  <span class="paste-dialog-action-index">3</span>
+                  <span class="paste-dialog-action-label">Inside</span>
+                  <span class="paste-dialog-action-detail"
+                    >${this._getPastePlacementDetail('inside')}</span
+                  >
+                </button>
+              </div>
+            `}
+      </div>
+    `;
   }
 
   // ---------------------------------------------------------------------------
@@ -1267,6 +1572,7 @@ export class EpistolaEditor extends LitElement {
               </div>
             `
           : nothing}
+        ${this._renderPasteDialog()}
       </div>
     `;
   }

--- a/modules/editor/src/main/typescript/ui/block-clipboard.test.ts
+++ b/modules/editor/src/main/typescript/ui/block-clipboard.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  nodeId,
+  slotId,
+  resetCounter,
+  createTestDocumentWithChildren,
+} from '../engine/test-helpers.js';
+import type { Node, SlotId } from '../types/index.js';
+import {
+  BLOCK_CLIPBOARD_MIME,
+  extractBlockSubtree,
+  parseBlockClipboard,
+  readBlockClipboardData,
+  rekeyBlockSubtree,
+  serializeBlockClipboard,
+  writeBlockClipboardData,
+} from './block-clipboard.js';
+
+beforeEach(() => {
+  resetCounter();
+});
+
+describe('block clipboard helpers', () => {
+  it('extracts the selected subtree including descendants', () => {
+    const { doc, containerNodeId, containerSlotId } = createTestDocumentWithChildren();
+    const childNodeId = nodeId('child');
+
+    const childNode: Node = {
+      id: childNodeId,
+      type: 'text',
+      slots: [],
+      props: { content: null },
+    };
+    doc.nodes[childNodeId] = childNode;
+    doc.slots[containerSlotId].children.push(childNodeId);
+
+    const subtree = extractBlockSubtree(doc, containerNodeId);
+
+    expect(subtree).not.toBeNull();
+    expect(subtree?.node.id).toBe(containerNodeId);
+    expect(subtree?.slots).toHaveLength(1);
+    expect(subtree?.slots[0].children).toEqual([childNodeId]);
+    expect(subtree?.extraNodes?.map((node) => node.id)).toEqual([childNodeId]);
+  });
+
+  it('rekeys nodes and slots on paste', () => {
+    const { doc, containerNodeId } = createTestDocumentWithChildren();
+    const subtree = extractBlockSubtree(doc, containerNodeId);
+    expect(subtree).not.toBeNull();
+
+    const rekeyed = rekeyBlockSubtree(subtree!);
+
+    expect(rekeyed.node.id).not.toBe(subtree!.node.id);
+    expect(rekeyed.slots[0].id).not.toBe(subtree!.slots[0].id);
+    expect(rekeyed.node.slots).toEqual([rekeyed.slots[0].id]);
+    expect(rekeyed.slots[0].nodeId).toBe(rekeyed.node.id);
+  });
+
+  it('rekeys a subtree with descendants and extra nodes', () => {
+    const { doc, containerNodeId, containerSlotId } = createTestDocumentWithChildren();
+    const childNodeId = nodeId('child');
+
+    doc.nodes[childNodeId] = {
+      id: childNodeId,
+      type: 'text',
+      slots: [],
+      props: { content: null },
+    };
+    doc.slots[containerSlotId].children.push(childNodeId);
+
+    const subtree = extractBlockSubtree(doc, containerNodeId);
+    expect(subtree).not.toBeNull();
+
+    const rekeyed = rekeyBlockSubtree(subtree!);
+
+    expect(rekeyed.extraNodes).toHaveLength(1);
+    expect(rekeyed.extraNodes?.[0].id).not.toBe(childNodeId);
+    expect(rekeyed.slots[0].children).toEqual([rekeyed.extraNodes?.[0].id]);
+  });
+
+  it('throws when rekeying a malformed subtree with missing slot mappings', () => {
+    expect(() =>
+      rekeyBlockSubtree({
+        node: {
+          id: nodeId('broken-root'),
+          type: 'container',
+          slots: [slotId('missing-slot')],
+        },
+        slots: [],
+      }),
+    ).toThrow(/Missing slot id mapping/);
+  });
+
+  it('serializes and parses clipboard payloads', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const serialized = serializeBlockClipboard(subtree!);
+    const parsed = parseBlockClipboard(serialized);
+
+    expect(parsed).toEqual(subtree);
+  });
+
+  it('writes and reads clipboard data using the custom mime type', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    const store = new Map<string, string>();
+    const clipboardData = {
+      setData: (type: string, value: string) => {
+        store.set(type, value);
+      },
+      getData: (type: string) => store.get(type) ?? '',
+    } as unknown as DataTransfer;
+
+    const wrote = writeBlockClipboardData(clipboardData, subtree!);
+    const read = readBlockClipboardData(clipboardData);
+
+    expect(wrote).toBe(true);
+    expect(store.has(BLOCK_CLIPBOARD_MIME)).toBe(true);
+    expect(read).toEqual(subtree);
+  });
+
+  it('returns false when clipboard data is unavailable for writes', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const subtree = extractBlockSubtree(doc, textNodeId);
+    expect(subtree).not.toBeNull();
+
+    expect(writeBlockClipboardData(null, subtree!)).toBe(false);
+  });
+
+  it('returns null when clipboard data is unavailable for reads', () => {
+    expect(readBlockClipboardData(null)).toBeNull();
+  });
+
+  it('returns null when extracting a missing node subtree', () => {
+    const { doc } = createTestDocumentWithChildren();
+
+    expect(extractBlockSubtree(doc, nodeId('missing-node'))).toBeNull();
+  });
+
+  it('skips missing child nodes and missing slots while extracting', () => {
+    const { doc, containerNodeId, containerSlotId } = createTestDocumentWithChildren();
+    const missingSlotId = slotId('missing-slot') as SlotId;
+    const missingChildId = nodeId('missing-child');
+
+    doc.nodes[containerNodeId].slots.push(missingSlotId);
+    doc.slots[containerSlotId].children.push(missingChildId);
+
+    const subtree = extractBlockSubtree(doc, containerNodeId);
+    expect(subtree).not.toBeNull();
+
+    expect(subtree!.slots).toHaveLength(1);
+    expect(subtree!.extraNodes).toBeUndefined();
+  });
+
+  it('rejects malformed clipboard data', () => {
+    const clipboardData = {
+      getData: (type: string) => (type === BLOCK_CLIPBOARD_MIME ? '{"kind":"wrong"}' : ''),
+    } as unknown as DataTransfer;
+
+    expect(readBlockClipboardData(clipboardData)).toBeNull();
+  });
+
+  it('returns null for invalid JSON payloads', () => {
+    expect(parseBlockClipboard('{not-json')).toBeNull();
+  });
+
+  it('rejects payloads with invalid subtree shapes', () => {
+    expect(
+      parseBlockClipboard(
+        JSON.stringify({
+          kind: 'epistola/block',
+          version: 1,
+          content: {
+            node: { id: 'node-1', type: 'text', slots: [123] },
+            slots: [],
+          },
+        }),
+      ),
+    ).toBeNull();
+
+    expect(
+      parseBlockClipboard(
+        JSON.stringify({
+          kind: 'epistola/block',
+          version: 1,
+          content: {
+            node: { id: 'node-1', type: 'text', slots: [] },
+            slots: [{ id: 'slot-1', nodeId: 'node-1', name: 'children', children: [123] }],
+          },
+        }),
+      ),
+    ).toBeNull();
+
+    expect(
+      parseBlockClipboard(
+        JSON.stringify({
+          kind: 'epistola/block',
+          version: 1,
+          content: {
+            node: { id: 'node-1', type: 'text', slots: [] },
+            slots: [],
+            extraNodes: {},
+          },
+        }),
+      ),
+    ).toBeNull();
+
+    expect(
+      parseBlockClipboard(
+        JSON.stringify({
+          kind: 'epistola/block',
+          version: 1,
+          content: {
+            node: null,
+            slots: [],
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('throws when rekeying a subtree without a root node', () => {
+    expect(() =>
+      rekeyBlockSubtree({
+        node: null,
+        slots: [],
+      } as unknown as Parameters<typeof rekeyBlockSubtree>[0]),
+    ).toThrow(/missing a root node/i);
+  });
+});

--- a/modules/editor/src/main/typescript/ui/block-clipboard.ts
+++ b/modules/editor/src/main/typescript/ui/block-clipboard.ts
@@ -1,0 +1,231 @@
+import { nanoid } from 'nanoid';
+import type { TemplateDocument, Node, Slot, NodeId, SlotId } from '../types/index.js';
+
+export const BLOCK_CLIPBOARD_KIND = 'epistola/block';
+export const BLOCK_CLIPBOARD_MIME = 'application/x.epistola-block+json';
+export const BLOCK_CLIPBOARD_TEXT_LABEL = 'Epistola block';
+
+const BLOCK_CLIPBOARD_VERSION = 1;
+
+export interface BlockSubtree {
+  node: Node;
+  slots: Slot[];
+  extraNodes?: Node[];
+}
+
+interface BlockClipboardEnvelope {
+  kind: typeof BLOCK_CLIPBOARD_KIND;
+  version: typeof BLOCK_CLIPBOARD_VERSION;
+  content: BlockSubtree;
+}
+
+function isNodeLike(value: unknown): value is Node {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Partial<Node>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.type === 'string' &&
+    Array.isArray(candidate.slots) &&
+    candidate.slots.every((slotId) => typeof slotId === 'string')
+  );
+}
+
+function isSlotLike(value: unknown): value is Slot {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Partial<Slot>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.nodeId === 'string' &&
+    typeof candidate.name === 'string' &&
+    Array.isArray(candidate.children) &&
+    candidate.children.every((childId) => typeof childId === 'string')
+  );
+}
+
+function isBlockSubtree(value: unknown): value is BlockSubtree {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Partial<BlockSubtree>;
+  if (!isNodeLike(candidate.node)) return false;
+  if (!Array.isArray(candidate.slots) || !candidate.slots.every((slot) => isSlotLike(slot))) {
+    return false;
+  }
+  if (
+    'extraNodes' in candidate &&
+    (!Array.isArray(candidate.extraNodes) ||
+      !candidate.extraNodes.every((node) => isNodeLike(node)))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isBlockClipboardEnvelope(value: unknown): value is BlockClipboardEnvelope {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Partial<BlockClipboardEnvelope>;
+  return (
+    candidate.kind === BLOCK_CLIPBOARD_KIND &&
+    candidate.version === BLOCK_CLIPBOARD_VERSION &&
+    isBlockSubtree(candidate.content)
+  );
+}
+
+function getRequiredMapValue<TKey, TValue>(
+  map: Map<TKey, TValue>,
+  key: TKey,
+  label: string,
+): TValue {
+  const value = map.get(key);
+  if (value === null || typeof value === 'undefined') {
+    throw new Error(`Missing ${label}`);
+  }
+  return value;
+}
+
+export function extractBlockSubtree(doc: TemplateDocument, nodeId: NodeId): BlockSubtree | null {
+  const rootNode = doc.nodes[nodeId];
+  if (!rootNode) return null;
+
+  const nodeIds: NodeId[] = [];
+  const slotIds: SlotId[] = [];
+
+  const visit = (currentId: NodeId): void => {
+    const node = doc.nodes[currentId];
+    if (!node) return;
+
+    nodeIds.push(currentId);
+    for (const slotId of node.slots) {
+      const slot = doc.slots[slotId];
+      if (!slot) continue;
+      slotIds.push(slotId);
+      for (const childId of slot.children) {
+        visit(childId);
+      }
+    }
+  };
+
+  visit(nodeId);
+
+  const nodeCopies = nodeIds
+    .map((id) => doc.nodes[id])
+    .filter((node): node is Node => !!node)
+    .map((node) => structuredClone(node));
+  const slotCopies = slotIds
+    .map((id) => doc.slots[id])
+    .filter((slot): slot is Slot => !!slot)
+    .map((slot) => structuredClone(slot));
+
+  const [node, ...extraNodes] = nodeCopies;
+  if (!node) return null;
+
+  if (extraNodes.length === 0) {
+    return {
+      node,
+      slots: slotCopies,
+    };
+  }
+
+  return {
+    node,
+    slots: slotCopies,
+    extraNodes,
+  };
+}
+
+export function rekeyBlockSubtree(subtree: BlockSubtree): BlockSubtree {
+  if (!isNodeLike(subtree.node)) {
+    throw new Error('Re-keyed block subtree is missing a root node');
+  }
+
+  const sourceNodes = [subtree.node, ...(subtree.extraNodes ?? [])];
+  const nodeIdMap = new Map<NodeId, NodeId>();
+  const slotIdMap = new Map<SlotId, SlotId>();
+
+  for (const node of sourceNodes) {
+    nodeIdMap.set(node.id, nanoid());
+  }
+  for (const slot of subtree.slots) {
+    slotIdMap.set(slot.id, nanoid());
+  }
+
+  const clonedNodes = sourceNodes.map((node) => {
+    const clonedNode = structuredClone(node);
+    clonedNode.id = getRequiredMapValue(nodeIdMap, node.id, `node id mapping for ${node.id}`);
+    clonedNode.slots = node.slots.map((slotId) =>
+      getRequiredMapValue(slotIdMap, slotId, `slot id mapping for ${slotId}`),
+    );
+    return clonedNode;
+  });
+  const clonedSlots = subtree.slots.map((slot) => {
+    const clonedSlot = structuredClone(slot);
+    clonedSlot.id = getRequiredMapValue(slotIdMap, slot.id, `slot id mapping for ${slot.id}`);
+    clonedSlot.nodeId = getRequiredMapValue(
+      nodeIdMap,
+      slot.nodeId,
+      `node id mapping for ${slot.nodeId}`,
+    );
+    clonedSlot.children = slot.children.map((childId) =>
+      getRequiredMapValue(nodeIdMap, childId, `child node id mapping for ${childId}`),
+    );
+    return clonedSlot;
+  });
+
+  const [node, ...extraNodes] = clonedNodes;
+  if (!node) {
+    throw new Error('Re-keyed block subtree is missing a root node');
+  }
+
+  if (extraNodes.length === 0) {
+    return {
+      node,
+      slots: clonedSlots,
+    };
+  }
+
+  return {
+    node,
+    slots: clonedSlots,
+    extraNodes,
+  };
+}
+
+export function serializeBlockClipboard(subtree: BlockSubtree): string {
+  const payload: BlockClipboardEnvelope = {
+    kind: BLOCK_CLIPBOARD_KIND,
+    version: BLOCK_CLIPBOARD_VERSION,
+    content: structuredClone(subtree),
+  };
+  return JSON.stringify(payload);
+}
+
+export function parseBlockClipboard(raw: string): BlockSubtree | null {
+  try {
+    const payload = JSON.parse(raw) as unknown;
+    if (!isBlockClipboardEnvelope(payload)) {
+      return null;
+    }
+    return payload.content;
+  } catch {
+    return null;
+  }
+}
+
+export function writeBlockClipboardData(
+  clipboardData: DataTransfer | null,
+  subtree: BlockSubtree,
+): boolean {
+  if (!clipboardData) return false;
+
+  clipboardData.setData(BLOCK_CLIPBOARD_MIME, serializeBlockClipboard(subtree));
+  clipboardData.setData('text/plain', BLOCK_CLIPBOARD_TEXT_LABEL);
+  return true;
+}
+
+export function readBlockClipboardData(clipboardData: DataTransfer | null): BlockSubtree | null {
+  if (!clipboardData) return null;
+  return parseBlockClipboard(clipboardData.getData(BLOCK_CLIPBOARD_MIME));
+}


### PR DESCRIPTION
## Description

Adds block-level clipboard copy/paste support to the editor.

This PR introduces a dedicated block clipboard payload, lets users copy the currently selected block subtree, and adds a paste flow with placement selection so pasted content can be inserted before, after, or inside the current target. 

## Related Issue(s)

Closes #274

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

Not applicable.

## Additional Notes
