### PR TITLE
feat(editor): add separator (horizontal rule) component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Clean stacktraces in logs**: Added a custom Logback converter that collapses framework frames (Spring, Tomcat, reflection, etc.) in stacktraces, keeping only application-relevant frames for readability.
 - **UI exception filter**: Replaced `AuthorizationExceptionFilter` with a generic `UiExceptionFilter` that catches all UI request exceptions, maps known domain exceptions to appropriate HTTP status codes, and returns a generic 500 for unknown errors — preventing Tomcat from rendering raw stacktraces.
 - **Per-side border controls**: The editor now supports setting border width, style, and color independently per side (top, right, bottom, left). Replaces the previous all-or-nothing border controls. Backwards compatible with existing unified border styles.
+- **Separator component**: New horizontal rule block type for visually separating sections in templates. Renders as a styled line with configurable border and margin.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,7 @@ To add tests to a new module: `testImplementation(project(":modules:testing"))` 
 6. **Update CHANGELOG.md** - For notable changes under `[Unreleased]`. Helm chart changes go in `charts/epistola/CHANGELOG.md`; all other changes go in the root `CHANGELOG.md`.
 7. **Update documentation** - Check if changes require updates to docs in `docs/`, KDoc comments, or CLAUDE.md. Search for references to changed conventions, APIs, or patterns.
 8. **Small commits** - Commit logical units of work separately
+9. **Bump demo catalog version** - When modifying demo templates/stencils/themes in `modules/epistola-core/src/main/resources/demo/catalog/`, bump `release.version` in `catalog.json` and update the resource's `updatedAt`. The demo loader only reimports when the version changes.
 
 ## Don'ts
 

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -441,12 +441,37 @@ export function createDefaultRegistry(): ComponentRegistry {
     category: 'content',
     slots: [],
     allowedChildren: { mode: 'none' },
-    applicableStyles: ['margin', 'border', 'borderRadius'],
-    inspector: [],
+    applicableStyles: ['margin'],
+    inspector: [
+      { key: 'thickness', label: 'Thickness', type: 'unit', units: ['pt'], defaultValue: '1pt' },
+      {
+        key: 'width',
+        label: 'Width',
+        type: 'unit',
+        units: ['%'],
+        defaultValue: '100%',
+      },
+      { key: 'color', label: 'Color', type: 'color' },
+      {
+        key: 'style',
+        label: 'Style',
+        type: 'select',
+        options: [
+          { label: 'Solid', value: 'solid' },
+          { label: 'Dashed', value: 'dashed' },
+          { label: 'Dotted', value: 'dotted' },
+        ],
+      },
+    ],
     defaultStyles: {
-      borderBottom: '1pt solid #d1d5db',
       marginTop: '1.5sp',
       marginBottom: '1.5sp',
+    },
+    defaultProps: {
+      thickness: '1pt',
+      width: '100%',
+      color: '#d1d5db',
+      style: 'solid',
     },
   });
 

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -435,9 +435,25 @@ export function createDefaultRegistry(): ComponentRegistry {
   });
 
   registry.register({
+    type: 'separator',
+    label: 'Separator',
+    icon: 'minus',
+    category: 'content',
+    slots: [],
+    allowedChildren: { mode: 'none' },
+    applicableStyles: ['margin', 'border', 'borderRadius'],
+    inspector: [],
+    defaultStyles: {
+      borderBottom: '1pt solid #d1d5db',
+      marginTop: '1.5sp',
+      marginBottom: '1.5sp',
+    },
+  });
+
+  registry.register({
     type: 'pagebreak',
     label: 'Page Break',
-    icon: 'minus',
+    icon: 'file-break',
     category: 'page',
     slots: [],
     allowedChildren: { mode: 'none' },

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
@@ -498,6 +498,13 @@ export class EpistolaCanvas extends LitElement {
           ></epistola-text-editor>
         `;
       }
+      case 'separator': {
+        const resolvedStyles = this.engine!.getResolvedNodeStyles(nodeId);
+        const def = this.engine!.registry.get(node.type);
+        const filteredStyles = filterByApplicableStyles(resolvedStyles, def?.applicableStyles);
+        const separatorStyle = toStyleMap(filteredStyles);
+        return html`<div class="canvas-separator" style=${styleMap(separatorStyle)}></div>`;
+      }
       case 'pagebreak':
         return html`<div class="canvas-pagebreak">
           <div class="canvas-pagebreak-line"></div>

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
@@ -502,8 +502,25 @@ export class EpistolaCanvas extends LitElement {
         const resolvedStyles = this.engine!.getResolvedNodeStyles(nodeId);
         const def = this.engine!.registry.get(node.type);
         const filteredStyles = filterByApplicableStyles(resolvedStyles, def?.applicableStyles);
-        const separatorStyle = toStyleMap(filteredStyles);
-        return html`<div class="canvas-separator" style=${styleMap(separatorStyle)}></div>`;
+        const wrapperStyle = toStyleMap(filteredStyles);
+        const props = node.props ?? {};
+        const thickness = (props.thickness as string) || '1pt';
+        const width = (props.width as string) || '100%';
+        const color = (props.color as string) || '#d1d5db';
+        const lineStyle = (props.style as string) || 'solid';
+        return html`<div
+          class="canvas-separator"
+          style=${styleMap({ ...wrapperStyle, 'text-align': 'center' })}
+        >
+          <hr
+            style=${styleMap({
+              width,
+              border: 'none',
+              'border-top': `${thickness} ${lineStyle} ${color}`,
+              margin: '0 auto',
+            })}
+          />
+        </div>`;
       }
       case 'pagebreak':
         return html`<div class="canvas-pagebreak">

--- a/modules/editor/src/main/typescript/ui/icons.ts
+++ b/modules/editor/src/main/typescript/ui/icons.ts
@@ -31,6 +31,8 @@ const ICONS = {
   repeat:
     '<path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/>',
   minus: '<path d="M5 12h14"/>',
+  'file-break':
+    '<path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M4 7V4a2 2 0 0 1 2-2h8l6 6v4"/><path d="M4 12H2"/><path d="M22 12h-2"/><path d="M4 12a1 1 0 0 0-1 1v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6a1 1 0 0 0-1-1"/><path d="M8 12h8"/>',
   'panel-top': '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/>',
   'panel-bottom': '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 15h18"/>',
   box: '<path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>',

--- a/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/epistola-app"
   },
   "release": {
-    "version": "4.2",
-    "releasedAt": "2026-04-14T00:00:00Z"
+    "version": "4.3",
+    "releasedAt": "2026-04-17T00:00:00Z"
   },
   "resources": [
     {
@@ -59,7 +59,7 @@
       "slug": "simple-letter",
       "name": "Simple Letter",
       "description": "A basic letter template with sender, recipient, subject, and body.",
-      "updatedAt": "2026-04-03T00:00:00Z",
+      "updatedAt": "2026-04-17T00:00:00Z",
       "detailUrl": "./resources/templates/simple-letter.json"
     },
     {

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
@@ -155,6 +155,17 @@
             }
           }
         },
+        "n-separator": {
+          "id": "n-separator",
+          "type": "separator",
+          "slots": [],
+          "props": {
+            "thickness": "1pt",
+            "width": "100%",
+            "color": "#d1d5db",
+            "style": "solid"
+          }
+        },
         "n-body": {
           "id": "n-body",
           "type": "text",
@@ -179,7 +190,7 @@
           "id": "s-root-children",
           "nodeId": "n-root",
           "name": "children",
-          "children": ["n-sender", "n-recipient", "n-date", "n-subject", "n-body"]
+          "children": ["n-sender", "n-recipient", "n-date", "n-separator", "n-subject", "n-body"]
         }
       }
     },

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
@@ -420,6 +420,7 @@ class DirectPdfRenderer(
                 "datatable-column" to DatatableColumnNodeRenderer(),
                 "image" to ImageNodeRenderer(),
                 "qrcode" to QrCodeNodeRenderer(),
+                "separator" to SeparatorNodeRenderer(),
                 "pagebreak" to PageBreakNodeRenderer(),
                 "pageheader" to PageHeaderNodeRenderer(),
                 "pagefooter" to PageFooterNodeRenderer(),

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderingDefaults.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderingDefaults.kt
@@ -92,6 +92,11 @@ data class RenderingDefaults(
                 "datatable" to mapOf("marginBottom" to "1.5sp"),
                 "image" to mapOf("marginBottom" to "1.5sp"),
                 "qrcode" to mapOf("marginBottom" to "1.5sp"),
+                "separator" to mapOf(
+                    "marginTop" to "1.5sp",
+                    "marginBottom" to "1.5sp",
+                    "borderBottom" to "1pt solid #d1d5db",
+                ),
             ),
             headingSizes = mapOf(
                 1 to 24f,

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderingDefaults.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderingDefaults.kt
@@ -95,7 +95,6 @@ data class RenderingDefaults(
                 "separator" to mapOf(
                     "marginTop" to "1.5sp",
                     "marginBottom" to "1.5sp",
-                    "borderBottom" to "1pt solid #d1d5db",
                 ),
             ),
             headingSizes = mapOf(

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
@@ -1,0 +1,34 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.TemplateDocument
+import com.itextpdf.layout.element.Div
+import com.itextpdf.layout.element.IElement
+
+/**
+ * Renders a "separator" node as a zero-height div with a bottom border,
+ * producing a horizontal line in the PDF output.
+ */
+class SeparatorNodeRenderer : NodeRenderer {
+    override fun render(
+        node: Node,
+        document: TemplateDocument,
+        context: RenderContext,
+        registry: NodeRendererRegistry,
+    ): List<IElement> {
+        val div = Div()
+        StyleApplicator.applyStylesWithPreset(
+            div,
+            node.styles?.filterNonNullValues(),
+            node.stylePreset,
+            context.blockStylePresets,
+            context.documentStyles,
+            context.fontCache,
+            context.renderingDefaults.componentDefaults("separator"),
+            context.renderingDefaults.baseFontSizePt,
+            context.spacingUnit,
+        )
+        div.setHeight(0f)
+        return listOf(div)
+    }
+}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
@@ -28,7 +28,8 @@ class SeparatorNodeRenderer : NodeRenderer {
             context.renderingDefaults.baseFontSizePt,
             context.spacingUnit,
         )
-        div.setHeight(0f)
+        // Minimal height so iText renders the border
+        div.setHeight(0.5f)
         return listOf(div)
     }
 }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
@@ -15,12 +15,17 @@ import com.itextpdf.layout.properties.UnitValue
  * Renders a "separator" node as a centered horizontal line.
  *
  * Props:
- * - `thickness`: line thickness (e.g. "1pt", default 1pt)
+ * - `thickness`: line thickness (e.g. "1pt", "0.5sp", default 1pt)
  * - `width`: line width as percentage (e.g. "100%", default 100%)
- * - `color`: line color (e.g. "#d1d5db", default gray)
+ * - `color`: line color (e.g. "#d1d5db", "#fff", "rgb(100,100,100)", default gray)
  * - `style`: line style ("solid", "dashed", "dotted", default solid)
  */
 class SeparatorNodeRenderer : NodeRenderer {
+
+    companion object {
+        private val DEFAULT_COLOR = DeviceRgb(209, 213, 219) // #d1d5db
+    }
+
     override fun render(
         node: Node,
         document: TemplateDocument,
@@ -28,12 +33,18 @@ class SeparatorNodeRenderer : NodeRenderer {
         registry: NodeRendererRegistry,
     ): List<IElement> {
         val props = node.props ?: emptyMap()
-        val thickness = parseThickness(props["thickness"] as? String)
-        val widthPercent = parseWidthPercent(props["width"] as? String)
-        val color = parseColor(props["color"] as? String)
-        val lineStyle = props["style"] as? String ?: "solid"
 
-        val border = when (lineStyle) {
+        val thickness = (props["thickness"] as? String)?.let {
+            StyleApplicator.parseSize(it, context.renderingDefaults.baseFontSizePt, context.spacingUnit)
+        } ?: 1f
+
+        val widthPercent = parseWidthPercent(props["width"] as? String)
+
+        val color = (props["color"] as? String)?.let {
+            StyleApplicator.parseColor(it)
+        } ?: DEFAULT_COLOR
+
+        val border = when (props["style"] as? String) {
             "dashed" -> DashedBorder(color, thickness)
             "dotted" -> DottedBorder(color, thickness)
             else -> SolidBorder(color, thickness)
@@ -42,7 +53,7 @@ class SeparatorNodeRenderer : NodeRenderer {
         // Inner div is the actual line
         val line = Div()
         line.setWidth(UnitValue.createPercentValue(widthPercent))
-        line.setHeight(0f)
+        line.setHeight(0.5f)
         line.setBorderTop(border)
         line.setHorizontalAlignment(HorizontalAlignment.CENTER)
 
@@ -65,28 +76,8 @@ class SeparatorNodeRenderer : NodeRenderer {
         return listOf(wrapper)
     }
 
-    private fun parseThickness(value: String?): Float {
-        if (value == null) return 1f
-        val match = Regex("""([\d.]+)""").find(value)
-        return match?.groupValues?.get(1)?.toFloatOrNull() ?: 1f
-    }
-
     private fun parseWidthPercent(value: String?): Float {
-        if (value == null) return 100f
-        val match = Regex("""([\d.]+)%?""").find(value)
-        return match?.groupValues?.get(1)?.toFloatOrNull() ?: 100f
-    }
-
-    private fun parseColor(value: String?): DeviceRgb {
-        if (value == null || !value.startsWith("#")) return DeviceRgb(209, 213, 219) // #d1d5db
-        return try {
-            val hex = value.removePrefix("#")
-            val r = hex.substring(0, 2).toInt(16)
-            val g = hex.substring(2, 4).toInt(16)
-            val b = hex.substring(4, 6).toInt(16)
-            DeviceRgb(r, g, b)
-        } catch (_: Exception) {
-            DeviceRgb(209, 213, 219)
-        }
+        if (value == null || !value.endsWith("%")) return 100f
+        return value.removeSuffix("%").toFloatOrNull() ?: 100f
     }
 }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
@@ -2,12 +2,23 @@ package app.epistola.generation.pdf
 
 import app.epistola.template.model.Node
 import app.epistola.template.model.TemplateDocument
+import com.itextpdf.kernel.colors.DeviceRgb
+import com.itextpdf.layout.borders.DashedBorder
+import com.itextpdf.layout.borders.DottedBorder
+import com.itextpdf.layout.borders.SolidBorder
 import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IElement
+import com.itextpdf.layout.properties.HorizontalAlignment
+import com.itextpdf.layout.properties.UnitValue
 
 /**
- * Renders a "separator" node as a zero-height div with a bottom border,
- * producing a horizontal line in the PDF output.
+ * Renders a "separator" node as a centered horizontal line.
+ *
+ * Props:
+ * - `thickness`: line thickness (e.g. "1pt", default 1pt)
+ * - `width`: line width as percentage (e.g. "100%", default 100%)
+ * - `color`: line color (e.g. "#d1d5db", default gray)
+ * - `style`: line style ("solid", "dashed", "dotted", default solid)
  */
 class SeparatorNodeRenderer : NodeRenderer {
     override fun render(
@@ -16,9 +27,29 @@ class SeparatorNodeRenderer : NodeRenderer {
         context: RenderContext,
         registry: NodeRendererRegistry,
     ): List<IElement> {
-        val div = Div()
+        val props = node.props ?: emptyMap()
+        val thickness = parseThickness(props["thickness"] as? String)
+        val widthPercent = parseWidthPercent(props["width"] as? String)
+        val color = parseColor(props["color"] as? String)
+        val lineStyle = props["style"] as? String ?: "solid"
+
+        val border = when (lineStyle) {
+            "dashed" -> DashedBorder(color, thickness)
+            "dotted" -> DottedBorder(color, thickness)
+            else -> SolidBorder(color, thickness)
+        }
+
+        // Inner div is the actual line
+        val line = Div()
+        line.setWidth(UnitValue.createPercentValue(widthPercent))
+        line.setHeight(0f)
+        line.setBorderTop(border)
+        line.setHorizontalAlignment(HorizontalAlignment.CENTER)
+
+        // Outer div carries margins from styles
+        val wrapper = Div()
         StyleApplicator.applyStylesWithPreset(
-            div,
+            wrapper,
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
@@ -28,8 +59,34 @@ class SeparatorNodeRenderer : NodeRenderer {
             context.renderingDefaults.baseFontSizePt,
             context.spacingUnit,
         )
-        // Minimal height so iText renders the border
-        div.setHeight(0.5f)
-        return listOf(div)
+        wrapper.add(line)
+        wrapper.setHorizontalAlignment(HorizontalAlignment.CENTER)
+
+        return listOf(wrapper)
+    }
+
+    private fun parseThickness(value: String?): Float {
+        if (value == null) return 1f
+        val match = Regex("""([\d.]+)""").find(value)
+        return match?.groupValues?.get(1)?.toFloatOrNull() ?: 1f
+    }
+
+    private fun parseWidthPercent(value: String?): Float {
+        if (value == null) return 100f
+        val match = Regex("""([\d.]+)%?""").find(value)
+        return match?.groupValues?.get(1)?.toFloatOrNull() ?: 100f
+    }
+
+    private fun parseColor(value: String?): DeviceRgb {
+        if (value == null || !value.startsWith("#")) return DeviceRgb(209, 213, 219) // #d1d5db
+        return try {
+            val hex = value.removePrefix("#")
+            val r = hex.substring(0, 2).toInt(16)
+            val g = hex.substring(2, 4).toInt(16)
+            val b = hex.substring(4, 6).toInt(16)
+            DeviceRgb(r, g, b)
+        } catch (_: Exception) {
+            DeviceRgb(209, 213, 219)
+        }
     }
 }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -252,7 +252,7 @@ object StyleApplicator {
         }
     }
 
-    private fun parseSize(size: String, baseFontSizePt: Float = 12f, spacingUnit: Float = SpacingScale.DEFAULT_BASE_UNIT): Float? {
+    internal fun parseSize(size: String, baseFontSizePt: Float = 12f, spacingUnit: Float = SpacingScale.DEFAULT_BASE_UNIT): Float? {
         // Try spacing token first (e.g., "2sp" → 8pt with default base unit)
         SpacingScale.parseSp(size, spacingUnit)?.let { return it }
 
@@ -263,7 +263,7 @@ object StyleApplicator {
         }
     }
 
-    private fun parseColor(color: String): DeviceRgb? = try {
+    internal fun parseColor(color: String): DeviceRgb? = try {
         when {
             color.startsWith("#") -> {
                 val hex = color.removePrefix("#")

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/RenderingDefaultsTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/RenderingDefaultsTest.kt
@@ -52,7 +52,7 @@ class RenderingDefaultsTest {
 
     @Test
     fun `V1 component spacing contains entries for all block types`() {
-        val expectedTypes = setOf("text", "container", "columns", "table", "datatable", "image", "qrcode")
+        val expectedTypes = setOf("text", "container", "columns", "table", "datatable", "image", "qrcode", "separator")
         assertEquals(expectedTypes, RenderingDefaults.V1.componentSpacing.keys)
     }
 

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/SeparatorNodeRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/SeparatorNodeRendererTest.kt
@@ -1,0 +1,133 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.Slot
+import app.epistola.template.model.TemplateDocument
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SeparatorNodeRendererTest {
+
+    private val renderer = DirectPdfRenderer()
+
+    private fun documentWithSeparator(props: Map<String, Any?> = emptyMap(), styles: Map<String, Any>? = null): TemplateDocument {
+        val rootNodeId = "root-1"
+        val rootSlotId = "slot-root"
+        val separatorNodeId = "sep-1"
+
+        return TemplateDocument(
+            root = rootNodeId,
+            nodes = mapOf(
+                rootNodeId to Node(id = rootNodeId, type = "root", slots = listOf(rootSlotId)),
+                separatorNodeId to Node(id = separatorNodeId, type = "separator", props = props, styles = styles),
+            ),
+            slots = mapOf(
+                rootSlotId to Slot(
+                    id = rootSlotId,
+                    nodeId = rootNodeId,
+                    name = "children",
+                    children = listOf(separatorNodeId),
+                ),
+            ),
+        )
+    }
+
+    private fun renderToPdf(document: TemplateDocument): ByteArray {
+        val output = ByteArrayOutputStream()
+        renderer.render(document, emptyMap(), output)
+        return output.toByteArray()
+    }
+
+    @Test
+    fun `renders separator with default props`() {
+        val pdf = renderToPdf(documentWithSeparator())
+        assertTrue(pdf.isNotEmpty())
+        assertTrue(pdf.decodeToString(0, 5).startsWith("%PDF"))
+    }
+
+    @Test
+    fun `renders separator with custom thickness`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("thickness" to "3pt")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with sp thickness unit`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("thickness" to "2sp")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with custom width percentage`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("width" to "50%")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with custom color`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("color" to "#ff0000")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with 3-digit hex color`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("color" to "#f00")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with rgb color`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("color" to "rgb(255, 0, 0)")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with dashed style`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("style" to "dashed")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with dotted style`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("style" to "dotted")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with custom margins`() {
+        val pdf = renderToPdf(
+            documentWithSeparator(
+                styles = mapOf("marginTop" to "3sp", "marginBottom" to "3sp"),
+            ),
+        )
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with all custom props`() {
+        val pdf = renderToPdf(
+            documentWithSeparator(
+                mapOf(
+                    "thickness" to "2pt",
+                    "width" to "75%",
+                    "color" to "#333333",
+                    "style" to "dashed",
+                ),
+            ),
+        )
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with invalid width falls back to 100 percent`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("width" to "invalid")))
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders separator with invalid color falls back to default`() {
+        val pdf = renderToPdf(documentWithSeparator(mapOf("color" to "not-a-color")))
+        assertTrue(pdf.isNotEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

- **Separator component**: New block type that renders a centered horizontal line with configurable properties:
  - Thickness (pt/sp)
  - Width (%, always centered)
  - Color (hex, rgb)
  - Style (solid/dashed/dotted)
- **PDF rendering**: `SeparatorNodeRenderer` using shared `StyleApplicator.parseSize()` and `parseColor()` utilities
- **Demo template**: Added separator to `simple-letter` between date and subject
- **13 unit tests** covering all props, unit formats, color formats, and edge cases

## Test plan

- [ ] Insert separator in editor — shows horizontal line on canvas
- [ ] Change thickness, width, color, style via inspector — canvas updates
- [ ] Generate PDF — separator renders correctly
- [ ] Set width to 50% — line is centered in PDF
- [ ] Set dashed/dotted style — renders correctly in both editor and PDF
- [ ] Load simple-letter demo — separator visible between date and subject
- [ ] `pnpm --filter @epistola/editor test` — 1090 tests pass
- [ ] `./gradlew unitTest` — all tests pass including 13 new separator tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)