### PR TITLE
feat: implement line height in PDF with pt/sp units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **UI exception filter**: Replaced `AuthorizationExceptionFilter` with a generic `UiExceptionFilter` that catches all UI request exceptions, maps known domain exceptions to appropriate HTTP status codes, and returns a generic 500 for unknown errors — preventing Tomcat from rendering raw stacktraces.
 - **Per-side border controls**: The editor now supports setting border width, style, and color independently per side (top, right, bottom, left). Replaces the previous all-or-nothing border controls. Backwards compatible with existing unified border styles.
 - **Separator component**: New horizontal rule block type for visually separating sections in templates. Renders as a styled line with configurable border and margin.
+- **Line height in PDF**: The `lineHeight` style property now renders correctly in generated PDFs. Resolved styles are passed to `TipTapConverter` via a single map, enabling future style properties without parameter changes.
 
 ### Fixed
 

--- a/modules/editor/src/main/typescript/engine/style-registry.ts
+++ b/modules/editor/src/main/typescript/engine/style-registry.ts
@@ -50,8 +50,9 @@ export const defaultStyleRegistry: StyleRegistry = {
         {
           key: 'lineHeight',
           label: 'Line Height',
-          type: 'number',
+          type: 'unit',
           inheritable: true,
+          units: ['pt', 'sp'],
         },
         {
           key: 'letterSpacing',

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -34,7 +34,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("4.2")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("4.3")
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -325,9 +325,13 @@ class TipTapConverter(
      * Apply resolved text styles (lineHeight, etc.) to a paragraph.
      * This is the single place to add new style properties that affect TipTap paragraphs/headings.
      */
+    /**
+     * Apply pre-resolved text styles to a paragraph.
+     * Values in the map should already be in points (resolved by the caller).
+     */
     private fun applyTextStyles(paragraph: Paragraph, resolvedStyles: Map<String, Any>) {
-        (resolvedStyles["lineHeight"])?.toString()?.toFloatOrNull()?.let {
-            paragraph.setMultipliedLeading(it)
+        (resolvedStyles["lineHeight"] as? Float)?.let {
+            paragraph.setFixedLeading(it)
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -38,18 +38,24 @@ class TipTapConverter(
     /**
      * Converts TipTap JSON content to a list of iText block elements.
      */
+    /**
+     * @param resolvedStyles Resolved style cascade for the parent text node.
+     *   TipTapConverter reads properties like `lineHeight` from this map
+     *   and applies them to generated paragraphs/headings.
+     */
     fun convert(
         content: Map<String, Any>?,
         data: Map<String, Any?>,
         loopContext: Map<String, Any?> = emptyMap(),
         fontCache: app.epistola.generation.pdf.FontCache,
+        resolvedStyles: Map<String, Any> = emptyMap(),
     ): kotlin.collections.List<IBlockElement> {
         if (content == null) return emptyList()
 
         @Suppress("UNCHECKED_CAST")
         val nodes = content["content"] as? kotlin.collections.List<Map<String, Any>> ?: return emptyList()
 
-        return nodes.mapNotNull { node -> convertNode(node, data, loopContext, fontCache) }
+        return nodes.mapNotNull { node -> convertNode(node, data, loopContext, fontCache, resolvedStyles) }
     }
 
     private fun convertNode(
@@ -57,12 +63,13 @@ class TipTapConverter(
         data: Map<String, Any?>,
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
+        resolvedStyles: Map<String, Any>,
     ): IBlockElement? {
         val type = node["type"] as? String ?: return null
 
         return when (type) {
-            "paragraph" -> convertParagraph(node, data, loopContext, fontCache)
-            "heading" -> convertHeading(node, data, loopContext, fontCache)
+            "paragraph" -> convertParagraph(node, data, loopContext, fontCache, resolvedStyles)
+            "heading" -> convertHeading(node, data, loopContext, fontCache, resolvedStyles)
             "bulletList" -> convertBulletList(node, data, loopContext, fontCache)
             "orderedList" -> convertOrderedList(node, data, loopContext, fontCache)
             else -> null
@@ -74,9 +81,11 @@ class TipTapConverter(
         data: Map<String, Any?>,
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
+        resolvedStyles: Map<String, Any>,
     ): Paragraph {
         val paragraph = Paragraph()
         paragraph.setMarginBottom(renderingDefaults.paragraphMarginBottom)
+        applyTextStyles(paragraph, resolvedStyles)
 
         @Suppress("UNCHECKED_CAST")
         val content = node["content"] as? kotlin.collections.List<Map<String, Any>>
@@ -92,6 +101,7 @@ class TipTapConverter(
         data: Map<String, Any?>,
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
+        resolvedStyles: Map<String, Any>,
     ): Paragraph {
         @Suppress("UNCHECKED_CAST")
         val attrs = node["attrs"] as? Map<String, Any>
@@ -99,6 +109,7 @@ class TipTapConverter(
 
         val paragraph = Paragraph()
         paragraph.setFont(fontCache.bold)
+        applyTextStyles(paragraph, resolvedStyles)
 
         // Set font size based on heading level
         val fontSize = renderingDefaults.headingFontSize(level)
@@ -307,6 +318,16 @@ class TipTapConverter(
             val attrs = linkMark["attrs"] as? Map<String, Any> ?: return null
             val href = attrs["href"] as? String
             return href?.takeIf { it.isNotBlank() }
+        }
+    }
+
+    /**
+     * Apply resolved text styles (lineHeight, etc.) to a paragraph.
+     * This is the single place to add new style properties that affect TipTap paragraphs/headings.
+     */
+    private fun applyTextStyles(paragraph: Paragraph, resolvedStyles: Map<String, Any>) {
+        (resolvedStyles["lineHeight"])?.toString()?.toFloatOrNull()?.let {
+            paragraph.setMultipliedLeading(it)
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -212,7 +212,15 @@ object StyleApplicator {
             parseSize(radius, baseFontSizePt, spacingUnit)?.let { element.setBorderRadius(BorderRadius(it)) }
         }
 
-        // Note: lineHeight is handled differently in iText - skipping for now
+        // Line height: applied as multiplied leading on Paragraph elements.
+        // For Div containers, this is a no-op — line height is applied by TipTapConverter
+        // on individual paragraphs where it actually takes effect.
+        (styles["lineHeight"] as? Any)?.let { v ->
+            val value = v.toString().toFloatOrNull()
+            if (value != null && element is com.itextpdf.layout.element.Paragraph) {
+                element.setMultipliedLeading(value)
+            }
+        }
     }
 
     private fun createBorder(style: String, width: Float, color: DeviceRgb): com.itextpdf.layout.borders.Border = when (style) {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -212,13 +212,13 @@ object StyleApplicator {
             parseSize(radius, baseFontSizePt, spacingUnit)?.let { element.setBorderRadius(BorderRadius(it)) }
         }
 
-        // Line height: applied as multiplied leading on Paragraph elements.
+        // Line height: applied as fixed leading on Paragraph elements.
         // For Div containers, this is a no-op — line height is applied by TipTapConverter
         // on individual paragraphs where it actually takes effect.
         (styles["lineHeight"] as? Any)?.let { v ->
-            val value = v.toString().toFloatOrNull()
-            if (value != null && element is com.itextpdf.layout.element.Paragraph) {
-                element.setMultipliedLeading(value)
+            val pts = parseSize(v.toString(), baseFontSizePt, spacingUnit)
+            if (pts != null && element is com.itextpdf.layout.element.Paragraph) {
+                element.setFixedLeading(pts)
             }
         }
     }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
@@ -33,10 +33,20 @@ class TextNodeRenderer : NodeRenderer {
             context.spacingUnit,
         )
 
+        // Resolve the full style cascade for the text node — passed to TipTapConverter
+        // so it can apply properties like lineHeight, textIndent, etc. to paragraphs.
+        val resolvedStyles = buildMap<String, Any> {
+            // Inheritable document styles (lowest priority)
+            context.documentStyles?.filterKeys { it in StyleApplicator.INHERITABLE_KEYS }?.let { putAll(it) }
+            // Preset + inline styles (higher priority)
+            StyleApplicator.resolveBlockStyles(context.blockStylePresets, node.stylePreset, node.styles?.filterNonNullValues())
+                ?.let { putAll(it) }
+        }
+
         // Convert TipTap content to iText elements
         @Suppress("UNCHECKED_CAST")
         val content = node.props?.get("content") as? Map<String, Any>
-        val elements = context.tipTapConverter.convert(content, context.effectiveData, context.loopContext, context.fontCache)
+        val elements = context.tipTapConverter.convert(content, context.effectiveData, context.loopContext, context.fontCache, resolvedStyles)
 
         for (element in elements) {
             div.add(element)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
@@ -33,14 +33,18 @@ class TextNodeRenderer : NodeRenderer {
             context.spacingUnit,
         )
 
-        // Resolve the full style cascade for the text node — passed to TipTapConverter
-        // so it can apply properties like lineHeight, textIndent, etc. to paragraphs.
-        val resolvedStyles = buildMap<String, Any> {
-            // Inheritable document styles (lowest priority)
+        // Resolve the full style cascade, then parse size values to points.
+        // TipTapConverter receives pre-resolved values — it doesn't parse units.
+        val rawStyles = buildMap<String, Any> {
             context.documentStyles?.filterKeys { it in StyleApplicator.INHERITABLE_KEYS }?.let { putAll(it) }
-            // Preset + inline styles (higher priority)
             StyleApplicator.resolveBlockStyles(context.blockStylePresets, node.stylePreset, node.styles?.filterNonNullValues())
                 ?.let { putAll(it) }
+        }
+        val resolvedStyles = buildMap<String, Any> {
+            rawStyles["lineHeight"]?.toString()?.let { v ->
+                StyleApplicator.parseSize(v, context.renderingDefaults.baseFontSizePt, context.spacingUnit)
+                    ?.let { put("lineHeight", it) }
+            }
         }
 
         // Convert TipTap content to iText elements


### PR DESCRIPTION
## Summary

- **Line height now renders in PDF**: The `lineHeight` style property uses pt/sp units (not a unitless multiplier) and renders via `setFixedLeading()` in generated PDFs
- **Resolved styles map pattern**: `TextNodeRenderer` resolves the full style cascade and parses values to points. `TipTapConverter` receives a pre-resolved `Map<String, Float>` — no unit parsing, no spacing unit knowledge. Adding future text-level properties (like `textIndent`) only requires reading from the map in `applyTextStyles()`.
- **StyleApplicator.parseSize/parseColor made internal**: Shared utilities for reuse by other renderers

Related: #312 (future architectural direction for text blocks)

## Test plan

- [ ] Set lineHeight (e.g. 18pt) on a text block in editor, generate PDF — spacing changes visibly
- [ ] Set lineHeight in sp units — converts correctly
- [ ] Set lineHeight via theme document styles — all text blocks inherit it
- [ ] `./gradlew unitTest integrationTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)