### PR TITLE
feat(editor): add subscript and superscript text marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Per-side border controls**: The editor now supports setting border width, style, and color independently per side (top, right, bottom, left). Replaces the previous all-or-nothing border controls. Backwards compatible with existing unified border styles.
 - **Separator component**: New horizontal rule block type for visually separating sections in templates. Renders as a styled line with configurable border and margin.
 - **Line height in PDF**: The `lineHeight` style property now renders correctly in generated PDFs. Resolved styles are passed to `TipTapConverter` via a single map, enabling future style properties without parameter changes.
+- **Subscript and superscript**: New text formatting marks for m², footnote markers, and legal references. Available in the bubble menu toolbar and rendered in PDF output.
 
 ### Fixed
 

--- a/modules/editor/src/main/typescript/prosemirror/bubble-menu.ts
+++ b/modules/editor/src/main/typescript/prosemirror/bubble-menu.ts
@@ -100,6 +100,28 @@ function createButtonDefs(schema: Schema): ButtonDef[] {
     });
   }
 
+  // Subscript
+  if (schema.marks.subscript) {
+    defs.push({
+      label: 'X₂',
+      title: 'Subscript',
+      className: 'pm-bubble-btn subscript',
+      isActive: (view) => markActive(view, schema.marks.subscript),
+      command: (view) => toggleMark(schema.marks.subscript)(view.state, view.dispatch, view),
+    });
+  }
+
+  // Superscript
+  if (schema.marks.superscript) {
+    defs.push({
+      label: 'X²',
+      title: 'Superscript',
+      className: 'pm-bubble-btn superscript',
+      isActive: (view) => markActive(view, schema.marks.superscript),
+      command: (view) => toggleMark(schema.marks.superscript)(view.state, view.dispatch, view),
+    });
+  }
+
   // Separator
   defs.push({
     label: '',

--- a/modules/editor/src/main/typescript/prosemirror/schema.ts
+++ b/modules/editor/src/main/typescript/prosemirror/schema.ts
@@ -70,6 +70,30 @@ const strikethroughMark: MarkSpec = {
 };
 
 // ---------------------------------------------------------------------------
+// Subscript mark
+// ---------------------------------------------------------------------------
+
+const subscriptMark: MarkSpec = {
+  excludes: 'superscript',
+  toDOM() {
+    return ['sub', 0];
+  },
+  parseDOM: [{ tag: 'sub' }, { style: 'vertical-align=sub' }],
+};
+
+// ---------------------------------------------------------------------------
+// Superscript mark
+// ---------------------------------------------------------------------------
+
+const superscriptMark: MarkSpec = {
+  excludes: 'subscript',
+  toDOM() {
+    return ['sup', 0];
+  },
+  parseDOM: [{ tag: 'sup' }, { style: 'vertical-align=super' }],
+};
+
+// ---------------------------------------------------------------------------
 // Schema assembly
 // ---------------------------------------------------------------------------
 
@@ -108,6 +132,8 @@ const allMarks: Record<string, MarkSpec> = {
   ...basicMarks,
   underline: underlineMark,
   strikethrough: strikethroughMark,
+  subscript: subscriptMark,
+  superscript: superscriptMark,
 };
 
 /**
@@ -118,4 +144,4 @@ export const epistolaSchema = new Schema({
   marks: allMarks,
 });
 
-export { expressionNode, underlineMark, strikethroughMark };
+export { expressionNode, underlineMark, strikethroughMark, subscriptMark, superscriptMark };

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -280,6 +280,14 @@ class TipTapConverter(
                 "italic" -> isItalic = true
                 "underline" -> text.setUnderline()
                 "strike" -> text.setLineThrough()
+                "subscript" -> {
+                    text.setTextRise(-3f)
+                    text.setFontSize(renderingDefaults.baseFontSizePt * 0.75f)
+                }
+                "superscript" -> {
+                    text.setTextRise(5f)
+                    text.setFontSize(renderingDefaults.baseFontSizePt * 0.75f)
+                }
                 "link" -> { /* handled separately via Link element */ }
                 "textStyle" -> {
                     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## Summary

- **Subscript and superscript marks** added to the ProseMirror schema with mutual exclusion (can't have both on the same text)
- **Bubble menu buttons**: X₂ (subscript) and X² (superscript) in the text formatting toolbar
- **PDF rendering**: `setTextRise(-3/+5)` with 75% font size reduction in `TipTapConverter.applyMarks()`
- **Paste support**: Parses `<sub>`, `<sup>` tags and `vertical-align` CSS

## Test plan

- [ ] Select text, click X₂ — renders as subscript in editor
- [ ] Select text, click X² — renders as superscript in editor
- [ ] Can't apply both to same text (mutually exclusive)
- [ ] Generate PDF — sub/superscript renders correctly
- [ ] Paste HTML with `<sub>`/`<sup>` — marks preserved
- [ ] `pnpm --filter @epistola/editor test` — 1090 tests pass
- [ ] `./gradlew unitTest integrationTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)