### PR TITLE
feat(editor): add keep-together and keep-with-next page flow controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Separator component**: New horizontal rule block type for visually separating sections in templates. Renders as a styled line with configurable border and margin.
 - **Line height in PDF**: The `lineHeight` style property now renders correctly in generated PDFs. Resolved styles are passed to `TipTapConverter` via a single map, enabling future style properties without parameter changes.
 - **Subscript and superscript**: New text formatting marks for m², footnote markers, and legal references. Available in the bubble menu toolbar and rendered in PDF output.
+- **Keep-together / keep-with-next**: New page flow style properties that prevent page breaks from splitting a block or separating it from the next block. Available as checkboxes in the inspector's Page Flow section.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **Line height in PDF**: The `lineHeight` style property now renders correctly in generated PDFs. Resolved styles are passed to `TipTapConverter` via a single map, enabling future style properties without parameter changes.
 - **Subscript and superscript**: New text formatting marks for m², footnote markers, and legal references. Available in the bubble menu toolbar and rendered in PDF output.
 - **Keep-together / keep-with-next**: New page flow style properties that prevent page breaks from splitting a block or separating it from the next block. Available as checkboxes in the inspector's Page Flow section.
+- **Widow/orphan control**: PDF paragraphs and headings now enforce a minimum of 2 lines at the top and bottom of each page, preventing single isolated lines.
 
 ### Fixed
 

--- a/docs/editor-features.md
+++ b/docs/editor-features.md
@@ -1,0 +1,105 @@
+# Editor Features
+
+This document describes the components, styling, and rendering features available in the Epistola template editor.
+
+## Components
+
+### Separator
+
+A horizontal line for visually separating sections.
+
+**Properties (inspector):**
+
+| Property  | Type   | Default | Description                          |
+| --------- | ------ | ------- | ------------------------------------ |
+| thickness | pt     | 1pt     | Line thickness                       |
+| width     | %      | 100%    | Line width, always centered          |
+| color     | color  | #d1d5db | Line color (hex, rgb)                |
+| style     | select | solid   | Line style: solid, dashed, or dotted |
+
+**Styles:** margin only (no padding, background, or borders).
+
+**PDF rendering:** `SeparatorNodeRenderer` renders a centered div with a top border using iText `SolidBorder`/`DashedBorder`/`DottedBorder`. Default styles (margins) are in `RenderingDefaults.V1.componentSpacing["separator"]`.
+
+## Text Formatting
+
+### Inline Marks
+
+| Mark          | Toolbar | Shortcut | PDF Rendering                          |
+| ------------- | ------- | -------- | -------------------------------------- |
+| Bold          | B       | Ctrl+B   | Bold font variant                      |
+| Italic        | I       | Ctrl+I   | Italic font variant                    |
+| Underline     | U       | Ctrl+U   | `setUnderline()`                       |
+| Strikethrough | S       | —        | `setLineThrough()`                     |
+| Subscript     | X₂      | —        | `setTextRise(-3f)` + 75% font size     |
+| Superscript   | X²      | —        | `setTextRise(5f)` + 75% font size      |
+| Link          | —       | —        | Blue text with `PdfAction.createURI()` |
+| Expression    | {{}}    | —        | Evaluates and renders as text          |
+
+Subscript and superscript are mutually exclusive — applying one removes the other.
+
+## Styling
+
+### Per-Side Borders
+
+Borders are configured independently per side (top, right, bottom, left) using the `border` compound property type. Each side has:
+
+- **Width** (pt or sp)
+- **Style** (solid, dashed, dotted)
+- **Color** (hex picker + text input)
+
+A **link toggle** switches between editing all sides at once (linked) or independently (unlinked). When linked, changing any property applies to all four sides.
+
+**Storage format:** Per-side shorthand strings on the node's `styles` map:
+
+```json
+{
+  "borderTop": "2pt solid #333333",
+  "borderBottom": "1pt dashed #cccccc"
+}
+```
+
+**Architecture:** The `<epistola-border-input>` Lit component manages linked/unlinked state internally. The `COMPOUND_STYLE_TYPES` registry provides generic read/write for compound properties (spacing and border), eliminating hardcoded type checks in the inspector.
+
+### Page Flow
+
+| Property     | Type    | Description                                               |
+| ------------ | ------- | --------------------------------------------------------- |
+| keepTogether | boolean | Prevents a block from being split across page boundaries  |
+| keepWithNext | boolean | Prevents a page break between this block and the next one |
+
+These are style properties available on all block components (text, container, columns, table, datatable, conditional, loop). They appear as checkboxes in the inspector's "Page Flow" section.
+
+**PDF rendering:** Maps to iText's `setKeepTogether(true)` / `setKeepWithNext(true)` via `StyleApplicator`.
+
+### Line Height
+
+Line height is configured as a fixed value in pt or sp (not a multiplier). It's an inheritable property — setting it at the document or theme level applies to all text blocks.
+
+**PDF rendering:** `TextNodeRenderer` resolves the style cascade and parses the value to points. The resolved value is passed to `TipTapConverter` via a pre-resolved styles map. `TipTapConverter.applyTextStyles()` calls `paragraph.setFixedLeading(pts)`.
+
+## PDF Rendering Defaults
+
+### Widow/Orphan Control
+
+All paragraphs and headings have widow/orphan control enabled by default:
+
+- **Orphans:** minimum 2 lines at the bottom of a page
+- **Widows:** minimum 2 lines at the top of a page
+
+This prevents single isolated lines from appearing alone at page boundaries. No editor UI — applied as sensible defaults in `TipTapConverter`.
+
+### Component Default Spacing
+
+All block components have a default bottom margin defined in `RenderingDefaults.V1.componentSpacing`:
+
+| Component | marginBottom |
+| --------- | ------------ |
+| text      | 1.5sp (6pt)  |
+| container | 1.5sp (6pt)  |
+| columns   | 1.5sp (6pt)  |
+| table     | 1.5sp (6pt)  |
+| datatable | 1.5sp (6pt)  |
+| image     | 1.5sp (6pt)  |
+| qrcode    | 1.5sp (6pt)  |
+| separator | 1.5sp (6pt)  |

--- a/modules/editor/package.json
+++ b/modules/editor/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.7",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
-    "@epistola.app/epistola-model": "0.2.2",
+    "@epistola.app/epistola-model": "0.2.3",
     "@epistola/design-system": "workspace:*",
     "@floating-ui/dom": "^1.7.5",
     "jsonata": "^2.0.5",

--- a/modules/editor/package.json
+++ b/modules/editor/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "sbom": "mkdir -p build && npx --yes @cyclonedx/cdxgen --no-install-deps -o build/sbom.json"
+    "sbom": "mkdir -p build && npx --yes @cyclonedx/cdxgen --no-install-deps --spec-version 1.6 -o build/sbom.json"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.7",

--- a/modules/editor/src/main/typescript/components/columns/columns-registration.ts
+++ b/modules/editor/src/main/typescript/components/columns/columns-registration.ts
@@ -13,7 +13,15 @@ import { html } from 'lit';
 import { nanoid } from 'nanoid';
 
 /** Layout style properties available on columns nodes. */
-const LAYOUT_STYLES = ['padding', 'margin', 'backgroundColor', 'border', 'borderRadius'];
+const LAYOUT_STYLES = [
+  'padding',
+  'margin',
+  'backgroundColor',
+  'border',
+  'borderRadius',
+  'keepTogether',
+  'keepWithNext',
+];
 
 export function createColumnsDefinition(): ComponentDefinition {
   return {

--- a/modules/editor/src/main/typescript/components/datatable/datatable-registration.ts
+++ b/modules/editor/src/main/typescript/components/datatable/datatable-registration.ts
@@ -20,7 +20,15 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { icon } from '../../ui/icons.js';
 
 /** Layout style properties available on datatable nodes. */
-const LAYOUT_STYLES = ['padding', 'margin', 'backgroundColor', 'border', 'borderRadius'];
+const LAYOUT_STYLES = [
+  'padding',
+  'margin',
+  'backgroundColor',
+  'border',
+  'borderRadius',
+  'keepTogether',
+  'keepWithNext',
+];
 
 export function createDatatableDefinition(): ComponentDefinition {
   return {

--- a/modules/editor/src/main/typescript/components/table/table-registration.ts
+++ b/modules/editor/src/main/typescript/components/table/table-registration.ts
@@ -18,7 +18,15 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { findMergeAt, isCellCovered, type CellMerge, type CellSelection } from './table-utils.js';
 
 /** Layout style properties available on table nodes. */
-const LAYOUT_STYLES = ['padding', 'margin', 'backgroundColor', 'border', 'borderRadius'];
+const LAYOUT_STYLES = [
+  'padding',
+  'margin',
+  'backgroundColor',
+  'border',
+  'borderRadius',
+  'keepTogether',
+  'keepWithNext',
+];
 
 export const TABLE_DEFAULT_PROPS = {
   rows: 2,

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -348,7 +348,15 @@ export class ComponentRegistry {
 // ---------------------------------------------------------------------------
 
 /** Layout-oriented style properties (spacing + background + borders, no typography). */
-const LAYOUT_STYLES = ['padding', 'margin', 'backgroundColor', 'border', 'borderRadius'];
+const LAYOUT_STYLES = [
+  'padding',
+  'margin',
+  'backgroundColor',
+  'border',
+  'borderRadius',
+  'keepTogether',
+  'keepWithNext',
+];
 
 export function createDefaultRegistry(): ComponentRegistry {
   const registry = new ComponentRegistry();

--- a/modules/editor/src/main/typescript/engine/style-registry.ts
+++ b/modules/editor/src/main/typescript/engine/style-registry.ts
@@ -96,5 +96,13 @@ export const defaultStyleRegistry: StyleRegistry = {
         { key: 'borderRadius', label: 'Radius', type: 'unit', units: ['pt', 'sp'] },
       ],
     },
+    {
+      name: 'pageFlow',
+      label: 'Page Flow',
+      properties: [
+        { key: 'keepTogether', label: 'Keep Together', type: 'boolean' },
+        { key: 'keepWithNext', label: 'Keep With Next', type: 'boolean' },
+      ],
+    },
   ],
 };

--- a/modules/editor/src/main/typescript/styles/inspector.css
+++ b/modules/editor/src/main/typescript/styles/inspector.css
@@ -196,6 +196,15 @@
     gap: var(--ep-space-1);
   }
 
+  /* Boolean checkbox input */
+  .style-boolean-input {
+    display: flex;
+    align-items: center;
+    gap: var(--ep-space-1);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
   .style-border-label {
     font-size: 9px;
     color: var(--ep-gray-400);

--- a/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
@@ -232,6 +232,19 @@ function renderPresetStyleInput(
           @change=${(e: CustomEvent) => onChange(e.detail)}
         ></epistola-border-input>
       `;
+    case 'boolean':
+      return html`
+        <label class="style-boolean-input">
+          <input
+            type="checkbox"
+            id=${inputId}
+            .checked=${value === true || value === 'true'}
+            ?disabled=${readOnly}
+            @change=${(e: Event) => onChange((e.target as HTMLInputElement).checked || undefined)}
+          />
+          ${prop.label}
+        </label>
+      `;
     default:
       return html`
         <input

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -328,7 +328,9 @@ export class EpistolaInspector extends LitElement {
     const inputId = `inspector-style-${prop.key}`;
     return html`
       <div class="inspector-field">
-        <label class="inspector-field-label" for=${inputId}>${prop.label}</label>
+        ${prop.type !== 'boolean'
+          ? html`<label class="inspector-field-label" for=${inputId}>${prop.label}</label>`
+          : nothing}
         ${this._renderStyleInput(prop, value, onChange, inputId)}
       </div>
     `;
@@ -377,6 +379,21 @@ export class EpistolaInspector extends LitElement {
             .value=${String(value ?? '')}
             @change=${(e: Event) => onChange(Number((e.target as HTMLInputElement).value))}
           />
+        `;
+      case 'boolean':
+        return html`
+          <label class="style-boolean-input">
+            <input
+              type="checkbox"
+              id=${inputId}
+              .checked=${value === true || value === 'true'}
+              @change=${(e: Event) => {
+                const checked = (e.target as HTMLInputElement).checked;
+                onChange(checked || undefined);
+              }}
+            />
+            ${prop.label}
+          </label>
         `;
       case 'text':
       default:

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -85,6 +85,8 @@ class TipTapConverter(
     ): Paragraph {
         val paragraph = Paragraph()
         paragraph.setMarginBottom(renderingDefaults.paragraphMarginBottom)
+        paragraph.setOrphansControl(com.itextpdf.layout.properties.ParagraphOrphansControl(2))
+        paragraph.setWidowsControl(com.itextpdf.layout.properties.ParagraphWidowsControl(2, 2, false))
         applyTextStyles(paragraph, resolvedStyles)
 
         @Suppress("UNCHECKED_CAST")
@@ -109,6 +111,8 @@ class TipTapConverter(
 
         val paragraph = Paragraph()
         paragraph.setFont(fontCache.bold)
+        paragraph.setOrphansControl(com.itextpdf.layout.properties.ParagraphOrphansControl(2))
+        paragraph.setWidowsControl(com.itextpdf.layout.properties.ParagraphWidowsControl(2, 2, false))
         applyTextStyles(paragraph, resolvedStyles)
 
         // Set font size based on heading level

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -221,6 +221,14 @@ object StyleApplicator {
                 element.setFixedLeading(pts)
             }
         }
+
+        // Page flow: prevent page breaks from splitting or separating blocks
+        if (styles["keepTogether"] == true || styles["keepTogether"] == "true") {
+            element.setKeepTogether(true)
+        }
+        if (styles["keepWithNext"] == true || styles["keepWithNext"] == "true") {
+            element.setKeepWithNext(true)
+        }
     }
 
     private fun createBorder(style: String, width: Float, color: DeviceRgb): com.itextpdf.layout.borders.Border = when (style) {

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -1,9 +1,11 @@
 package app.epistola.generation.pdf
 
 import com.itextpdf.layout.element.Div
+import com.itextpdf.layout.properties.Property
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class StyleApplicatorTest {
 
@@ -185,5 +187,65 @@ class StyleApplicatorTest {
             documentStyles = null,
             fontCache = fontCache,
         )
+    }
+
+    // -----------------------------------------------------------------------
+    // keepTogether / keepWithNext
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `keepTogether true sets property on element`() {
+        val div = Div()
+        StyleApplicator.applyStylesWithPreset(
+            div,
+            blockInlineStyles = mapOf("keepTogether" to true),
+            blockStylePreset = null,
+            blockStylePresets = emptyMap(),
+            documentStyles = null,
+            fontCache = fontCache,
+        )
+        assertTrue(div.getProperty<Boolean>(Property.KEEP_TOGETHER) == true)
+    }
+
+    @Test
+    fun `keepTogether string true sets property on element`() {
+        val div = Div()
+        StyleApplicator.applyStylesWithPreset(
+            div,
+            blockInlineStyles = mapOf("keepTogether" to "true"),
+            blockStylePreset = null,
+            blockStylePresets = emptyMap(),
+            documentStyles = null,
+            fontCache = fontCache,
+        )
+        assertTrue(div.getProperty<Boolean>(Property.KEEP_TOGETHER) == true)
+    }
+
+    @Test
+    fun `keepWithNext true sets property on element`() {
+        val div = Div()
+        StyleApplicator.applyStylesWithPreset(
+            div,
+            blockInlineStyles = mapOf("keepWithNext" to true),
+            blockStylePreset = null,
+            blockStylePresets = emptyMap(),
+            documentStyles = null,
+            fontCache = fontCache,
+        )
+        assertTrue(div.getProperty<Boolean>(Property.KEEP_WITH_NEXT) == true)
+    }
+
+    @Test
+    fun `keepTogether absent does not set property`() {
+        val div = Div()
+        StyleApplicator.applyStylesWithPreset(
+            div,
+            blockInlineStyles = mapOf("marginBottom" to "4pt"),
+            blockStylePreset = null,
+            blockStylePresets = emptyMap(),
+            documentStyles = null,
+            fontCache = fontCache,
+        )
+        assertEquals(null, div.getProperty<Boolean>(Property.KEEP_TOGETHER))
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       '@epistola.app/epistola-model':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       '@epistola/design-system':
         specifier: workspace:*
         version: link:../design-system
@@ -260,8 +260,8 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
-  '@epistola.app/epistola-model@0.2.2':
-    resolution: {integrity: sha512-sh4cDVtiA0PeMEaSyJbCUc/3vnja2WB/QqBJTOPQDLC5NJmaLHD19Iw6aYolBaJNGUKp8GddqT6J/dVDmcxulA==}
+  '@epistola.app/epistola-model@0.2.3':
+    resolution: {integrity: sha512-Hi7v5+xj7m1V0UACXB0imQKFlmVudXULIXEjOGYrRzhDkpm+IW0xgjCASDFFeki5pseQXBLwlhM2/iWoLBdfHg==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -1908,7 +1908,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@epistola.app/epistola-model@0.2.2': {}
+  '@epistola.app/epistola-model@0.2.3': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true


### PR DESCRIPTION
## Summary

- **Keep-together**: Prevents a block from being split across page boundaries
- **Keep-with-next**: Prevents a page break between a block and the next one
- **Boolean style type**: New `boolean` input type renders as a checkbox in the inspector
- **Page Flow group**: New style group in the inspector containing both properties
- **PDF rendering**: Maps to iText's `setKeepTogether(true)` / `setKeepWithNext(true)`
- **Contract update**: `@epistola.app/epistola-model` updated to 0.2.3 (adds `boolean` to style property type enum)

## Test plan

- [ ] Select a container, check "Keep Together" — PDF keeps it on one page
- [ ] Check "Keep With Next" on a heading — PDF keeps heading with next paragraph
- [ ] Uncheck both — normal page break behavior resumes
- [ ] Theme presets with boolean properties work
- [ ] `pnpm --filter @epistola/editor test` — 1090 tests pass
- [ ] `./gradlew unitTest integrationTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)