### PR TITLE
feat(editor): list numbering, hard break fix, lineHeight fix, demo template fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Subscript and superscript**: New text formatting marks for m², footnote markers, and legal references. Available in the bubble menu toolbar and rendered in PDF output.
 - **Keep-together / keep-with-next**: New page flow style properties that prevent page breaks from splitting a block or separating it from the next block. Available as checkboxes in the inspector's Page Flow section.
 - **Widow/orphan control**: PDF paragraphs and headings now enforce a minimum of 2 lines at the top and bottom of each page, preventing single isolated lines.
+- **List numbering formats**: Ordered lists now support decimal, lower/upper alpha (a,b,c / A,B,C), and lower/upper roman (i,ii,iii / I,II,III) numbering. Toggle format via the # button in the bubble menu. Custom start numbers are also supported.
 
 ### Fixed
 

--- a/modules/editor/src/main/typescript/engine/style-registry.ts
+++ b/modules/editor/src/main/typescript/engine/style-registry.ts
@@ -50,9 +50,8 @@ export const defaultStyleRegistry: StyleRegistry = {
         {
           key: 'lineHeight',
           label: 'Line Height',
-          type: 'unit',
+          type: 'number',
           inheritable: true,
-          units: ['pt', 'sp'],
         },
         {
           key: 'letterSpacing',

--- a/modules/editor/src/main/typescript/prosemirror/bubble-menu.ts
+++ b/modules/editor/src/main/typescript/prosemirror/bubble-menu.ts
@@ -9,11 +9,24 @@ import { Plugin, PluginKey } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 import type { Schema, MarkType, NodeType } from 'prosemirror-model';
 import { toggleMark, setBlockType } from 'prosemirror-commands';
-import { wrapInList } from 'prosemirror-schema-list';
+import { wrapInList, liftListItem } from 'prosemirror-schema-list';
 import { computePosition, offset, flip, shift } from '@floating-ui/dom';
 import { TEXT_SHORTCUT_COMMAND_IDS, getTextBubbleTitle } from '../shortcuts/text-runtime.js';
 
 const BUBBLE_MENU_KEY = new PluginKey('bubbleMenu');
+
+/** Convert a list from one type to another (e.g., bullet → ordered) by changing the node type. */
+function convertListType(view: EditorView, fromType: NodeType, toType: NodeType): void {
+  const { $from } = view.state.selection;
+  for (let d = $from.depth; d > 0; d--) {
+    const node = $from.node(d);
+    if (node.type === fromType) {
+      const tr = view.state.tr.setNodeMarkup($from.before(d), toType, node.attrs);
+      view.dispatch(tr);
+      return;
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Mark / block active helpers
@@ -160,52 +173,78 @@ function createButtonDefs(schema: Schema): ButtonDef[] {
     command: () => {},
   });
 
-  // Bullet list
-  if (schema.nodes.bullet_list) {
+  // Bullet list (toggle: wrap if not in list, lift if already bullet, convert if ordered)
+  if (schema.nodes.bullet_list && schema.nodes.list_item) {
     defs.push({
       label: 'UL',
       title: 'Bullet List',
       className: 'pm-bubble-btn',
       isActive: (view) => blockActive(view, schema.nodes.bullet_list),
-      command: (view) => wrapInList(schema.nodes.bullet_list)(view.state, view.dispatch, view),
+      command: (view) => {
+        if (blockActive(view, schema.nodes.bullet_list)) {
+          liftListItem(schema.nodes.list_item)(view.state, view.dispatch, view);
+        } else if (blockActive(view, schema.nodes.ordered_list)) {
+          convertListType(view, schema.nodes.ordered_list, schema.nodes.bullet_list);
+        } else {
+          wrapInList(schema.nodes.bullet_list)(view.state, view.dispatch, view);
+        }
+      },
     });
   }
 
-  // Ordered list
-  if (schema.nodes.ordered_list) {
+  // Ordered list (toggle: wrap if not in list, lift if already ordered, convert if bullet)
+  if (schema.nodes.ordered_list && schema.nodes.list_item) {
     defs.push({
       label: 'OL',
       title: 'Ordered List',
       className: 'pm-bubble-btn',
       isActive: (view) => blockActive(view, schema.nodes.ordered_list),
-      command: (view) => wrapInList(schema.nodes.ordered_list)(view.state, view.dispatch, view),
+      command: (view) => {
+        if (blockActive(view, schema.nodes.ordered_list)) {
+          liftListItem(schema.nodes.list_item)(view.state, view.dispatch, view);
+        } else if (blockActive(view, schema.nodes.bullet_list)) {
+          convertListType(view, schema.nodes.bullet_list, schema.nodes.ordered_list);
+        } else {
+          wrapInList(schema.nodes.ordered_list)(view.state, view.dispatch, view);
+        }
+      },
     });
+  }
 
-    // List numbering format (only active when inside an ordered list)
-    const listTypes = [
-      { label: '1,2,3', value: 'decimal' },
-      { label: 'a,b,c', value: 'lower-alpha' },
-      { label: 'A,B,C', value: 'upper-alpha' },
-      { label: 'i,ii,iii', value: 'lower-roman' },
-      { label: 'I,II,III', value: 'upper-roman' },
-    ];
+  // List style cycling: # button cycles through styles within the current list type
+  if (schema.nodes.ordered_list || schema.nodes.bullet_list) {
+    const olStyles = ['decimal', 'lower-alpha', 'upper-alpha', 'lower-roman', 'upper-roman'];
+    const ulStyles = ['disc', 'circle', 'square', 'dash'];
+
     defs.push({
       label: '#',
-      title: 'List numbering format',
+      title: 'Cycle list style',
       className: 'pm-bubble-btn list-type-btn',
       isActive: () => false,
       command: (view) => {
-        // Cycle through list types
         const { $from } = view.state.selection;
         for (let d = $from.depth; d > 0; d--) {
           const node = $from.node(d);
+
           if (node.type === schema.nodes.ordered_list) {
-            const currentType = (node.attrs.listType as string) || 'decimal';
-            const currentIndex = listTypes.findIndex((t) => t.value === currentType);
-            const nextType = listTypes[(currentIndex + 1) % listTypes.length];
+            const current = (node.attrs.listType as string) || 'decimal';
+            const idx = olStyles.indexOf(current);
+            const next = olStyles[(idx + 1) % olStyles.length];
             const tr = view.state.tr.setNodeMarkup($from.before(d), undefined, {
               ...node.attrs,
-              listType: nextType.value,
+              listType: next,
+            });
+            view.dispatch(tr);
+            break;
+          }
+
+          if (node.type === schema.nodes.bullet_list) {
+            const current = (node.attrs.listStyle as string) || 'disc';
+            const idx = ulStyles.indexOf(current);
+            const next = ulStyles[(idx + 1) % ulStyles.length];
+            const tr = view.state.tr.setNodeMarkup($from.before(d), undefined, {
+              ...node.attrs,
+              listStyle: next,
             });
             view.dispatch(tr);
             break;

--- a/modules/editor/src/main/typescript/prosemirror/bubble-menu.ts
+++ b/modules/editor/src/main/typescript/prosemirror/bubble-menu.ts
@@ -180,6 +180,39 @@ function createButtonDefs(schema: Schema): ButtonDef[] {
       isActive: (view) => blockActive(view, schema.nodes.ordered_list),
       command: (view) => wrapInList(schema.nodes.ordered_list)(view.state, view.dispatch, view),
     });
+
+    // List numbering format (only active when inside an ordered list)
+    const listTypes = [
+      { label: '1,2,3', value: 'decimal' },
+      { label: 'a,b,c', value: 'lower-alpha' },
+      { label: 'A,B,C', value: 'upper-alpha' },
+      { label: 'i,ii,iii', value: 'lower-roman' },
+      { label: 'I,II,III', value: 'upper-roman' },
+    ];
+    defs.push({
+      label: '#',
+      title: 'List numbering format',
+      className: 'pm-bubble-btn list-type-btn',
+      isActive: () => false,
+      command: (view) => {
+        // Cycle through list types
+        const { $from } = view.state.selection;
+        for (let d = $from.depth; d > 0; d--) {
+          const node = $from.node(d);
+          if (node.type === schema.nodes.ordered_list) {
+            const currentType = (node.attrs.listType as string) || 'decimal';
+            const currentIndex = listTypes.findIndex((t) => t.value === currentType);
+            const nextType = listTypes[(currentIndex + 1) % listTypes.length];
+            const tr = view.state.tr.setNodeMarkup($from.before(d), undefined, {
+              ...node.attrs,
+              listType: nextType.value,
+            });
+            view.dispatch(tr);
+            break;
+          }
+        }
+      },
+    });
   }
 
   // Separator

--- a/modules/editor/src/main/typescript/prosemirror/schema.ts
+++ b/modules/editor/src/main/typescript/prosemirror/schema.ts
@@ -125,7 +125,38 @@ const baseNodes: Record<string, NodeSpec> = {
 // addListNodes expects an OrderedMap — we create a temp Schema to get one.
 const tempSchema = new Schema({ nodes: baseNodes, marks: {} });
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const withListNodes = addListNodes(tempSchema.spec.nodes as any, 'paragraph block*', 'block');
+let withListNodes = addListNodes(tempSchema.spec.nodes as any, 'paragraph block*', 'block');
+
+// Extend ordered_list with a listType attribute for numbering format
+const olSpec = withListNodes.get('ordered_list')!;
+withListNodes = withListNodes.update('ordered_list', {
+  ...olSpec,
+  attrs: {
+    ...(olSpec.attrs as Record<string, unknown>),
+    listType: { default: 'decimal' },
+  },
+  parseDOM: [
+    {
+      tag: 'ol',
+      getAttrs(dom) {
+        const el = dom as HTMLElement;
+        return {
+          order: el.hasAttribute('start') ? +el.getAttribute('start')! : 1,
+          listType: el.getAttribute('data-list-type') || 'decimal',
+        };
+      },
+    },
+  ],
+  toDOM(node) {
+    const attrs: Record<string, string> = {};
+    if (node.attrs.order !== 1) attrs.start = String(node.attrs.order);
+    if (node.attrs.listType !== 'decimal') {
+      attrs['data-list-type'] = node.attrs.listType;
+      attrs.style = `list-style-type: ${node.attrs.listType}`;
+    }
+    return Object.keys(attrs).length ? ['ol', attrs, 0] : ['ol', 0];
+  },
+});
 
 // Combine marks: basic (strong, em, code, link) + underline + strikethrough
 const allMarks: Record<string, MarkSpec> = {

--- a/modules/editor/src/main/typescript/prosemirror/schema.ts
+++ b/modules/editor/src/main/typescript/prosemirror/schema.ts
@@ -158,6 +158,39 @@ withListNodes = withListNodes.update('ordered_list', {
   },
 });
 
+// Extend bullet_list with a listStyle attribute for bullet style
+const ulSpec = withListNodes.get('bullet_list')!;
+withListNodes = withListNodes.update('bullet_list', {
+  ...ulSpec,
+  attrs: {
+    listStyle: { default: 'disc' },
+  },
+  parseDOM: [
+    {
+      tag: 'ul',
+      getAttrs(dom) {
+        const el = dom as HTMLElement;
+        return {
+          listStyle: el.getAttribute('data-list-style') || 'disc',
+        };
+      },
+    },
+  ],
+  toDOM(node) {
+    if (node.attrs.listStyle !== 'disc') {
+      return [
+        'ul',
+        {
+          'data-list-style': node.attrs.listStyle,
+          style: `list-style-type: ${node.attrs.listStyle === 'dash' ? '"– "' : node.attrs.listStyle}`,
+        },
+        0,
+      ];
+    }
+    return ['ul', 0];
+  },
+});
+
 // Combine marks: basic (strong, em, code, link) + underline + strikethrough
 const allMarks: Record<string, MarkSpec> = {
   ...basicMarks,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/tenants/commands/CreateTenant.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/tenants/commands/CreateTenant.kt
@@ -82,7 +82,7 @@ class CreateTenantHandler(
                 "fontFamily" to "Helvetica, Arial, sans-serif",
                 "fontSize" to "11pt",
                 "color" to "#333333",
-                "lineHeight" to "1.5",
+                "lineHeight" to 1.5,
             )
             val pageSettings = PageSettings(
                 format = PageFormat.A4,

--- a/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/epistola-app"
   },
   "release": {
-    "version": "4.3",
-    "releasedAt": "2026-04-17T00:00:00Z"
+    "version": "4.7",
+    "releasedAt": "2026-04-18T00:00:00Z"
   },
   "resources": [
     {
@@ -59,7 +59,7 @@
       "slug": "simple-letter",
       "name": "Simple Letter",
       "description": "A basic letter template with sender, recipient, subject, and body.",
-      "updatedAt": "2026-04-17T00:00:00Z",
+      "updatedAt": "2026-04-18T00:00:00Z",
       "detailUrl": "./resources/templates/simple-letter.json"
     },
     {

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/demo-invoice.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/demo-invoice.json
@@ -322,7 +322,8 @@
       "modelVersion": 1,
       "root": "n-root",
       "themeRef": {
-        "type": "inherit"
+        "type": "override",
+        "themeId": "corporate"
       },
       "pageSettingsOverride": {
         "format": "A4",
@@ -337,8 +338,7 @@
       "documentStylesOverride": {
         "fontFamily": "Helvetica",
         "fontSize": "10pt",
-        "color": "#333333",
-        "lineHeight": "1.4"
+        "color": "#333333"
       },
       "nodes": {
         "n-root": {
@@ -424,8 +424,7 @@
           "slots": [],
           "styles": {
             "fontSize": "9pt",
-            "color": "#666666",
-            "lineHeight": "1.5"
+            "color": "#666666"
           },
           "props": {
             "content": {
@@ -512,8 +511,7 @@
           "slots": [],
           "styles": {
             "fontSize": "9pt",
-            "textAlign": "right",
-            "lineHeight": "1.6"
+            "textAlign": "right"
           },
           "props": {
             "content": {
@@ -612,8 +610,7 @@
           "type": "text",
           "slots": [],
           "styles": {
-            "fontSize": "10pt",
-            "lineHeight": "1.5"
+            "fontSize": "10pt"
           },
           "props": {
             "content": {
@@ -1259,8 +1256,7 @@
           "slots": [],
           "styles": {
             "fontSize": "8pt",
-            "color": "#9ca3af",
-            "lineHeight": "1.6"
+            "color": "#9ca3af"
           },
           "props": {
             "content": {

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/hello-world.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/hello-world.json
@@ -63,7 +63,7 @@
                   "attrs": { "level": 1 },
                   "content": [
                     { "type": "text", "text": "Hello, " },
-                    { "type": "expression", "attrs": { "expression": "name", "fallback": "World" } },
+                    { "type": "expression", "attrs": { "expression": "name" } },
                     { "type": "text", "text": "!" }
                   ]
                 }
@@ -82,7 +82,7 @@
                 {
                   "type": "paragraph",
                   "content": [
-                    { "type": "expression", "attrs": { "expression": "message", "fallback": "Welcome to Epistola!" } }
+                    { "type": "expression", "attrs": { "expression": "message" } }
                   ]
                 }
               ]

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
@@ -52,7 +52,8 @@
       "modelVersion": 1,
       "root": "n-root",
       "themeRef": {
-        "type": "inherit"
+        "type": "override",
+        "themeId": "corporate"
       },
       "pageSettingsOverride": {
         "format": "A4",
@@ -82,11 +83,11 @@
                 {
                   "type": "paragraph",
                   "content": [
-                    { "type": "expression", "attrs": { "expression": "sender.name", "fallback": "Sender Name" } },
-                    { "type": "hardBreak" },
-                    { "type": "expression", "attrs": { "expression": "sender.address", "fallback": "Address" } },
-                    { "type": "hardBreak" },
-                    { "type": "expression", "attrs": { "expression": "sender.city", "fallback": "City" } }
+                    { "type": "expression", "attrs": { "expression": "sender.name" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "sender.address" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "sender.city" } }
                   ]
                 }
               ]
@@ -105,11 +106,11 @@
                 {
                   "type": "paragraph",
                   "content": [
-                    { "type": "expression", "attrs": { "expression": "recipient.name", "fallback": "Recipient Name" } },
-                    { "type": "hardBreak" },
-                    { "type": "expression", "attrs": { "expression": "recipient.address", "fallback": "Address" } },
-                    { "type": "hardBreak" },
-                    { "type": "expression", "attrs": { "expression": "recipient.city", "fallback": "City" } }
+                    { "type": "expression", "attrs": { "expression": "recipient.name" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "recipient.address" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "recipient.city" } }
                   ]
                 }
               ]
@@ -128,7 +129,7 @@
                 {
                   "type": "paragraph",
                   "content": [
-                    { "type": "expression", "attrs": { "expression": "date", "fallback": "Date" } }
+                    { "type": "expression", "attrs": { "expression": "date" } }
                   ]
                 }
               ]
@@ -148,7 +149,7 @@
                   "type": "heading",
                   "attrs": { "level": 2 },
                   "content": [
-                    { "type": "expression", "attrs": { "expression": "subject", "fallback": "Subject" } }
+                    { "type": "expression", "attrs": { "expression": "subject" } }
                   ]
                 }
               ]
@@ -177,7 +178,43 @@
                 {
                   "type": "paragraph",
                   "content": [
-                    { "type": "expression", "attrs": { "expression": "body", "fallback": "Letter body text goes here." } }
+                    { "type": "expression", "attrs": { "expression": "body" } }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "n-attachments": {
+          "id": "n-attachments",
+          "type": "text",
+          "slots": [],
+          "styles": { "marginTop": "4sp" },
+          "props": {
+            "content": {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "text", "text": "Attachments:", "marks": [{ "type": "bold" }] }
+                  ]
+                },
+                {
+                  "type": "bullet_list",
+                  "content": [
+                    {
+                      "type": "list_item",
+                      "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Project proposal (PDF)" }] }]
+                    },
+                    {
+                      "type": "list_item",
+                      "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Budget overview (XLSX)" }] }]
+                    },
+                    {
+                      "type": "list_item",
+                      "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Timeline (PDF)" }] }]
+                    }
                   ]
                 }
               ]
@@ -190,7 +227,7 @@
           "id": "s-root-children",
           "nodeId": "n-root",
           "name": "children",
-          "children": ["n-sender", "n-recipient", "n-date", "n-separator", "n-subject", "n-body"]
+          "children": ["n-sender", "n-recipient", "n-date", "n-separator", "n-subject", "n-body", "n-attachments"]
         }
       }
     },

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/themes/corporate.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/themes/corporate.json
@@ -8,7 +8,7 @@
     "documentStyles": {
       "fontFamily": "Helvetica, Arial, sans-serif",
       "fontSize": "11pt",
-      "lineHeight": "1.5",
+      "lineHeight": 1.5,
       "color": "#333333"
     },
     "pageSettings": {

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -34,7 +34,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("4.3")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("4.7")
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -139,7 +139,18 @@ class TipTapConverter(
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
     ): List {
+        @Suppress("UNCHECKED_CAST")
+        val attrs = node["attrs"] as? Map<String, Any>
+        val listStyle = attrs?.get("listStyle") as? String ?: "disc"
+
         val list = List()
+        val symbol = when (listStyle) {
+            "circle" -> "\u25CB  " // ○
+            "square" -> "\u25A0  " // ■
+            "dash" -> "\u2013  " // –
+            else -> "\u2022  " // • (disc, default)
+        }
+        list.setListSymbol(symbol)
         list.setMarginBottom(renderingDefaults.listMarginBottom)
         list.setMarginLeft(renderingDefaults.listMarginLeft)
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -55,7 +55,7 @@ class TipTapConverter(
         @Suppress("UNCHECKED_CAST")
         val nodes = content["content"] as? kotlin.collections.List<Map<String, Any>> ?: return emptyList()
 
-        return nodes.mapNotNull { node -> convertNode(node, data, loopContext, fontCache, resolvedStyles) }
+        return nodes.flatMap { node -> convertNode(node, data, loopContext, fontCache, resolvedStyles) }
     }
 
     private fun convertNode(
@@ -64,38 +64,57 @@ class TipTapConverter(
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
         resolvedStyles: Map<String, Any>,
-    ): IBlockElement? {
-        val type = node["type"] as? String ?: return null
+    ): kotlin.collections.List<IBlockElement> {
+        val type = node["type"] as? String ?: return emptyList()
 
         return when (type) {
             "paragraph" -> convertParagraph(node, data, loopContext, fontCache, resolvedStyles)
             "heading" -> convertHeading(node, data, loopContext, fontCache, resolvedStyles)
-            "bulletList", "bullet_list" -> convertBulletList(node, data, loopContext, fontCache)
-            "orderedList", "ordered_list" -> convertOrderedList(node, data, loopContext, fontCache)
-            else -> null
+            "bulletList", "bullet_list" -> listOf(convertBulletList(node, data, loopContext, fontCache))
+            "orderedList", "ordered_list" -> listOf(convertOrderedList(node, data, loopContext, fontCache))
+            else -> emptyList()
         }
     }
 
+    /**
+     * Converts a paragraph node, splitting at hard breaks into separate Paragraph elements.
+     * Only the last paragraph gets marginBottom spacing.
+     */
     private fun convertParagraph(
         node: Map<String, Any>,
         data: Map<String, Any?>,
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
         resolvedStyles: Map<String, Any>,
-    ): Paragraph {
-        val paragraph = Paragraph()
-        paragraph.setMarginBottom(renderingDefaults.paragraphMarginBottom)
-        paragraph.setOrphansControl(com.itextpdf.layout.properties.ParagraphOrphansControl(2))
-        paragraph.setWidowsControl(com.itextpdf.layout.properties.ParagraphWidowsControl(2, 2, false))
-        applyTextStyles(paragraph, resolvedStyles)
-
+    ): kotlin.collections.List<Paragraph> {
         @Suppress("UNCHECKED_CAST")
-        val content = node["content"] as? kotlin.collections.List<Map<String, Any>>
-        if (content != null) {
-            addInlineContent(paragraph, content, data, loopContext, fontCache)
-        }
+        val content = node["content"] as? kotlin.collections.List<Map<String, Any>> ?: emptyList()
 
-        return paragraph
+        // Split content at hard breaks into segments
+        val segments = mutableListOf<kotlin.collections.List<Map<String, Any>>>()
+        var current = mutableListOf<Map<String, Any>>()
+        for (child in content) {
+            val childType = child["type"] as? String
+            if (childType == "hard_break" || childType == "hardBreak") {
+                segments.add(current)
+                current = mutableListOf()
+            } else {
+                current.add(child)
+            }
+        }
+        segments.add(current)
+
+        return segments.mapIndexed { index, segment ->
+            val paragraph = Paragraph()
+            applyTextStyles(paragraph, resolvedStyles)
+            if (index == segments.size - 1) {
+                paragraph.setMarginBottom(renderingDefaults.paragraphMarginBottom)
+            }
+            if (segment.isNotEmpty()) {
+                addInlineContent(paragraph, segment, data, loopContext, fontCache)
+            }
+            paragraph
+        }
     }
 
     private fun convertHeading(
@@ -104,33 +123,52 @@ class TipTapConverter(
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
         resolvedStyles: Map<String, Any>,
-    ): Paragraph {
+    ): kotlin.collections.List<Paragraph> {
         @Suppress("UNCHECKED_CAST")
         val attrs = node["attrs"] as? Map<String, Any>
         val level = (attrs?.get("level") as? Number)?.toInt() ?: 1
-
-        val paragraph = Paragraph()
-        paragraph.setFont(fontCache.bold)
-        paragraph.setOrphansControl(com.itextpdf.layout.properties.ParagraphOrphansControl(2))
-        paragraph.setWidowsControl(com.itextpdf.layout.properties.ParagraphWidowsControl(2, 2, false))
-        applyTextStyles(paragraph, resolvedStyles)
-
-        // Set font size based on heading level
         val fontSize = renderingDefaults.headingFontSize(level)
-        paragraph.setFontSize(fontSize)
-
-        // Set margins to match editor CSS (proportional to font size)
         val marginVertical = renderingDefaults.headingMargin(level)
-        paragraph.setMarginTop(marginVertical)
-        paragraph.setMarginBottom(marginVertical)
 
         @Suppress("UNCHECKED_CAST")
-        val content = node["content"] as? kotlin.collections.List<Map<String, Any>>
-        if (content != null) {
-            addInlineContent(paragraph, content, data, loopContext, fontCache)
-        }
+        val content = node["content"] as? kotlin.collections.List<Map<String, Any>> ?: emptyList()
 
-        return paragraph
+        // Split at hard breaks
+        val segments = mutableListOf<kotlin.collections.List<Map<String, Any>>>()
+        var current = mutableListOf<Map<String, Any>>()
+        for (child in content) {
+            val childType = child["type"] as? String
+            if (childType == "hard_break" || childType == "hardBreak") {
+                segments.add(current)
+                current = mutableListOf()
+            } else {
+                current.add(child)
+            }
+        }
+        segments.add(current)
+
+        return segments.mapIndexed { index, segment ->
+            val paragraph = Paragraph()
+            paragraph.setFont(fontCache.bold)
+            paragraph.setFontSize(fontSize)
+            applyTextStyles(paragraph, resolvedStyles)
+            when (index) {
+                0 -> {
+                    paragraph.setMarginTop(marginVertical)
+                    if (segments.size == 1) {
+                        paragraph.setMarginBottom(marginVertical)
+                    } else {
+                        paragraph.setMarginBottom(0f)
+                    }
+                }
+                segments.size - 1 -> paragraph.setMarginBottom(marginVertical)
+                else -> paragraph.setMarginBottom(0f)
+            }
+            if (segment.isNotEmpty()) {
+                addInlineContent(paragraph, segment, data, loopContext, fontCache)
+            }
+            paragraph
+        }
     }
 
     private fun convertBulletList(
@@ -274,7 +312,8 @@ class TipTapConverter(
                     paragraph.add(text)
                 }
                 "hard_break", "hardBreak" -> {
-                    paragraph.add(Text("\n"))
+                    // Hard breaks are handled by splitting paragraphs in convertParagraph/convertHeading.
+                    // This case should not be reached, but is kept as a safe fallback.
                 }
                 "expression" -> {
                     // Expression atom node
@@ -368,7 +407,7 @@ class TipTapConverter(
      */
     private fun applyTextStyles(paragraph: Paragraph, resolvedStyles: Map<String, Any>) {
         (resolvedStyles["lineHeight"] as? Float)?.let {
-            paragraph.setFixedLeading(it)
+            paragraph.setMultipliedLeading(it)
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -107,9 +107,12 @@ class TipTapConverter(
         return segments.mapIndexed { index, segment ->
             val paragraph = Paragraph()
             applyTextStyles(paragraph, resolvedStyles)
-            if (index == segments.size - 1) {
-                paragraph.setMarginBottom(renderingDefaults.paragraphMarginBottom)
-            }
+            // Hard break lines: no spacing between them, only the last gets paragraph margin
+            paragraph.setMarginTop(0f)
+            paragraph.setMarginBottom(if (index == segments.size - 1) renderingDefaults.paragraphMarginBottom else 0f)
+            paragraph.setPaddingTop(0f)
+            paragraph.setPaddingBottom(0f)
+            paragraph.setSpacingRatio(0f)
             if (segment.isNotEmpty()) {
                 addInlineContent(paragraph, segment, data, loopContext, fontCache)
             }
@@ -152,18 +155,12 @@ class TipTapConverter(
             paragraph.setFont(fontCache.bold)
             paragraph.setFontSize(fontSize)
             applyTextStyles(paragraph, resolvedStyles)
-            when (index) {
-                0 -> {
-                    paragraph.setMarginTop(marginVertical)
-                    if (segments.size == 1) {
-                        paragraph.setMarginBottom(marginVertical)
-                    } else {
-                        paragraph.setMarginBottom(0f)
-                    }
-                }
-                segments.size - 1 -> paragraph.setMarginBottom(marginVertical)
-                else -> paragraph.setMarginBottom(0f)
-            }
+            // Hard break lines: tight spacing, only first/last get heading margins
+            paragraph.setMarginTop(if (index == 0) marginVertical else 0f)
+            paragraph.setMarginBottom(if (index == segments.size - 1) marginVertical else 0f)
+            paragraph.setPaddingTop(0f)
+            paragraph.setPaddingBottom(0f)
+            paragraph.setSpacingRatio(0f)
             if (segment.isNotEmpty()) {
                 addInlineContent(paragraph, segment, data, loopContext, fontCache)
             }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -70,8 +70,8 @@ class TipTapConverter(
         return when (type) {
             "paragraph" -> convertParagraph(node, data, loopContext, fontCache, resolvedStyles)
             "heading" -> convertHeading(node, data, loopContext, fontCache, resolvedStyles)
-            "bulletList" -> convertBulletList(node, data, loopContext, fontCache)
-            "orderedList" -> convertOrderedList(node, data, loopContext, fontCache)
+            "bulletList", "bullet_list" -> convertBulletList(node, data, loopContext, fontCache)
+            "orderedList", "ordered_list" -> convertOrderedList(node, data, loopContext, fontCache)
             else -> null
         }
     }
@@ -158,7 +158,7 @@ class TipTapConverter(
         val items = node["content"] as? kotlin.collections.List<Map<String, Any>> ?: emptyList()
 
         for (item in items) {
-            if (item["type"] == "listItem") {
+            if (item["type"] == "listItem" || item["type"] == "list_item") {
                 val listItem = convertListItem(item, data, loopContext, fontCache)
                 list.add(listItem)
             }
@@ -195,7 +195,7 @@ class TipTapConverter(
         val items = node["content"] as? kotlin.collections.List<Map<String, Any>> ?: emptyList()
 
         for (item in items) {
-            if (item["type"] == "listItem") {
+            if (item["type"] == "listItem" || item["type"] == "list_item") {
                 val listItem = convertListItem(item, data, loopContext, fontCache)
                 list.add(listItem)
             }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -162,7 +162,21 @@ class TipTapConverter(
         loopContext: Map<String, Any?>,
         fontCache: app.epistola.generation.pdf.FontCache,
     ): List {
-        val list = List(ListNumberingType.DECIMAL)
+        @Suppress("UNCHECKED_CAST")
+        val attrs = node["attrs"] as? Map<String, Any>
+        val listTypeStr = attrs?.get("listType") as? String ?: "decimal"
+        val startNumber = (attrs?.get("order") as? Number)?.toInt() ?: 1
+
+        val numberingType = when (listTypeStr) {
+            "lower-alpha" -> ListNumberingType.ENGLISH_LOWER
+            "upper-alpha" -> ListNumberingType.ENGLISH_UPPER
+            "lower-roman" -> ListNumberingType.ROMAN_LOWER
+            "upper-roman" -> ListNumberingType.ROMAN_UPPER
+            else -> ListNumberingType.DECIMAL
+        }
+
+        val list = List(numberingType)
+        if (startNumber > 1) list.setItemStartIndex(startNumber)
         list.setMarginBottom(renderingDefaults.listMarginBottom)
         list.setMarginLeft(renderingDefaults.listMarginLeft)
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -212,13 +212,13 @@ object StyleApplicator {
             parseSize(radius, baseFontSizePt, spacingUnit)?.let { element.setBorderRadius(BorderRadius(it)) }
         }
 
-        // Line height: applied as fixed leading on Paragraph elements.
+        // Line height: applied as multiplied leading on Paragraph elements.
         // For Div containers, this is a no-op — line height is applied by TipTapConverter
         // on individual paragraphs where it actually takes effect.
         (styles["lineHeight"] as? Any)?.let { v ->
-            val pts = parseSize(v.toString(), baseFontSizePt, spacingUnit)
-            if (pts != null && element is com.itextpdf.layout.element.Paragraph) {
-                element.setFixedLeading(pts)
+            val value = v.toString().toFloatOrNull()
+            if (value != null && element is com.itextpdf.layout.element.Paragraph) {
+                element.setMultipliedLeading(value)
             }
         }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
@@ -41,9 +41,8 @@ class TextNodeRenderer : NodeRenderer {
                 ?.let { putAll(it) }
         }
         val resolvedStyles = buildMap<String, Any> {
-            rawStyles["lineHeight"]?.toString()?.let { v ->
-                StyleApplicator.parseSize(v, context.renderingDefaults.baseFontSizePt, context.spacingUnit)
-                    ?.let { put("lineHeight", it) }
+            rawStyles["lineHeight"]?.toString()?.toFloatOrNull()?.let {
+                put("lineHeight", it)
             }
         }
 

--- a/modules/generation/src/test/kotlin/app/epistola/generation/TipTapConverterTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/TipTapConverterTest.kt
@@ -729,4 +729,204 @@ class TipTapConverterTest {
         val paragraph = assertIs<Paragraph>(result[0])
         assertIs<Link>(paragraph.children[0])
     }
+
+    // -----------------------------------------------------------------------
+    // Snake_case node types (ProseMirror output format)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `converts bullet_list with snake_case type`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "bullet_list",
+                    "content" to listOf(
+                        mapOf(
+                            "type" to "list_item",
+                            "content" to listOf(
+                                mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to "Item"))),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(1, result.size)
+        assertTrue(result[0] is List)
+    }
+
+    @Test
+    fun `converts ordered_list with snake_case type`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "ordered_list",
+                    "content" to listOf(
+                        mapOf(
+                            "type" to "list_item",
+                            "content" to listOf(
+                                mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to "First"))),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(1, result.size)
+        assertTrue(result[0] is List)
+    }
+
+    // -----------------------------------------------------------------------
+    // List numbering formats
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `converts ordered list with lower-alpha numbering`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "ordered_list",
+                    "attrs" to mapOf("listType" to "lower-alpha", "order" to 1),
+                    "content" to listOf(
+                        mapOf(
+                            "type" to "list_item",
+                            "content" to listOf(
+                                mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to "Item"))),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(1, result.size)
+        assertTrue(result[0] is List)
+    }
+
+    @Test
+    fun `converts ordered list with custom start number`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "ordered_list",
+                    "attrs" to mapOf("order" to 5),
+                    "content" to listOf(
+                        mapOf(
+                            "type" to "list_item",
+                            "content" to listOf(
+                                mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to "Item"))),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(1, result.size)
+        assertTrue(result[0] is List)
+    }
+
+    // -----------------------------------------------------------------------
+    // Bullet list styles
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `converts bullet list with square style`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "bullet_list",
+                    "attrs" to mapOf("listStyle" to "square"),
+                    "content" to listOf(
+                        mapOf(
+                            "type" to "list_item",
+                            "content" to listOf(
+                                mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to "Item"))),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(1, result.size)
+        assertTrue(result[0] is List)
+    }
+
+    // -----------------------------------------------------------------------
+    // Hard break splitting
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `hard break splits paragraph into multiple paragraphs`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "paragraph",
+                    "content" to listOf(
+                        mapOf("type" to "text", "text" to "Line 1"),
+                        mapOf("type" to "hard_break"),
+                        mapOf("type" to "text", "text" to "Line 2"),
+                        mapOf("type" to "hard_break"),
+                        mapOf("type" to "text", "text" to "Line 3"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(3, result.size)
+        assertTrue(result.all { it is Paragraph })
+    }
+
+    @Test
+    fun `paragraph without hard breaks produces single paragraph`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "paragraph",
+                    "content" to listOf(
+                        mapOf("type" to "text", "text" to "No breaks here"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `hard break with camelCase type also works`() {
+        val content = mapOf(
+            "type" to "doc",
+            "content" to listOf(
+                mapOf(
+                    "type" to "paragraph",
+                    "content" to listOf(
+                        mapOf("type" to "text", "text" to "Line 1"),
+                        mapOf("type" to "hardBreak"),
+                        mapOf("type" to "text", "text" to "Line 2"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = converter.convert(content, emptyMap(), fontCache = fontCache)
+        assertEquals(2, result.size)
+    }
 }

--- a/modules/generation/src/test/resources/baselines/canonical-complex.baseline.txt
+++ b/modules/generation/src/test/resources/baselines/canonical-complex.baseline.txt
@@ -2,9 +2,9 @@
 Acme Corporation Report
 This is the introduction paragraph for the report.
 Details
-- First point
-- Second point
-- Third point
+•  First point
+•  Second point
+•  Third point
 1. Step one
 2. Step two
 3. Step three


### PR DESCRIPTION
## Summary

### List numbering
- **Multiple numbering formats**: decimal, lower/upper alpha, lower/upper roman
- **Bullet styles**: disc, circle, square, dash
- **# button** in bubble menu cycles through styles within current list type
- **OL/UL toggle**: wrap, unwrap, or convert between types
- **Snake_case fix**: `bullet_list`/`ordered_list`/`list_item` now accepted by PDF renderer (ProseMirror outputs snake_case, converter only matched camelCase)

### Hard breaks (Shift+Enter)
- `Text("\n")` never worked in iText — lines overlapped
- Fixed by splitting content at hard breaks into separate `Paragraph` objects with tight spacing

### Line height
- Changed back to unitless multiplier (e.g. `1.5`) using `setMultipliedLeading`
- Was broken when changed to pt/sp units — `"1.5"` parsed as 1.5pt

### Demo template fixes
- Remove unsupported `fallback` attrs (caused ProseMirror to reject content)
- Use snake_case node types (`hard_break` not `hardBreak`)
- Explicitly reference corporate theme via `themeRef` override
- Restore `lineHeight: 1.5` in default tenant theme and corporate theme
- Add bullet list attachments to simple-letter

## Test plan

- [ ] Create ordered list, click # — cycles through numbering formats
- [ ] Create bullet list, click # — cycles through bullet styles
- [ ] Click UL when in OL — converts to bullet list
- [ ] Shift+Enter in text — lines render without extra spacing in PDF
- [ ] Regular Enter — paragraphs render with normal spacing
- [ ] Demo templates render correctly in editor and PDF
- [ ] `./gradlew unitTest integrationTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)