### PR TITLE
feat(editor): add hide-on-first-page option for headers and footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Keep-together / keep-with-next**: New page flow style properties that prevent page breaks from splitting a block or separating it from the next block. Available as checkboxes in the inspector's Page Flow section.
 - **Widow/orphan control**: PDF paragraphs and headings now enforce a minimum of 2 lines at the top and bottom of each page, preventing single isolated lines.
 - **List numbering formats**: Ordered lists now support decimal, lower/upper alpha (a,b,c / A,B,C), and lower/upper roman (i,ii,iii / I,II,III) numbering. Toggle format via the # button in the bubble menu. Custom start numbers are also supported.
+- **First-page header/footer variation**: Page headers and footers now have a "Hide on first page" checkbox. When enabled, the header/footer is not rendered on the first page of the PDF.
 
 ### Fixed
 

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -504,6 +504,7 @@ export function createDefaultRegistry(): ComponentRegistry {
     applicableStyles: 'all',
     inspector: [
       { key: 'height', label: 'Height', type: 'unit', units: ['pt', 'sp'], defaultValue: '60pt' },
+      { key: 'hideOnFirstPage', label: 'Hide on first page', type: 'boolean' },
     ],
     maxInstancesPerDocument: 1,
   });
@@ -518,6 +519,7 @@ export function createDefaultRegistry(): ComponentRegistry {
     applicableStyles: 'all',
     inspector: [
       { key: 'height', label: 'Height', type: 'unit', units: ['pt', 'sp'], defaultValue: '60pt' },
+      { key: 'hideOnFirstPage', label: 'Hide on first page', type: 'boolean' },
     ],
     maxInstancesPerDocument: 1,
   });

--- a/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/epistola-app"
   },
   "release": {
-    "version": "4.7",
+    "version": "4.8",
     "releasedAt": "2026-04-18T00:00:00Z"
   },
   "resources": [

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
@@ -220,6 +220,37 @@
               ]
             }
           }
+        },
+        "n-footer": {
+          "id": "n-footer",
+          "type": "pagefooter",
+          "slots": ["s-footer-children"],
+          "props": {
+            "height": "30pt",
+            "hideOnFirstPage": true
+          }
+        },
+        "n-footer-text": {
+          "id": "n-footer-text",
+          "type": "text",
+          "slots": [],
+          "styles": { "fontSize": "9pt", "color": "#999999", "textAlign": "center" },
+          "props": {
+            "content": {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "text", "text": "Confidential — Page " },
+                    { "type": "expression", "attrs": { "expression": "sys.pages.current" } },
+                    { "type": "text", "text": " of " },
+                    { "type": "expression", "attrs": { "expression": "sys.pages.total" } }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "slots": {
@@ -227,7 +258,13 @@
           "id": "s-root-children",
           "nodeId": "n-root",
           "name": "children",
-          "children": ["n-sender", "n-recipient", "n-date", "n-separator", "n-subject", "n-body", "n-attachments"]
+          "children": ["n-footer", "n-sender", "n-recipient", "n-date", "n-separator", "n-subject", "n-body", "n-attachments"]
+        },
+        "s-footer-children": {
+          "id": "s-footer-children",
+          "nodeId": "n-footer",
+          "name": "children",
+          "children": ["n-footer-text"]
         }
       }
     },

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -34,7 +34,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("4.7")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("4.8")
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
@@ -51,6 +51,8 @@ class PageFooterEventHandler(
         // Render the footer node's slots with page-scoped system parameters
         if (footerNode != null) {
             val pageNumber = pdfDoc.getPageNumber(page)
+            val hideOnFirstPage = footerNode.props?.get("hideOnFirstPage") == true
+            if (hideOnFirstPage && pageNumber == 1) return
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
             val pageContext = context.withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(footerNode, document, pageContext)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
@@ -54,6 +54,8 @@ class PageHeaderEventHandler(
         // Render the header node's slots with page-scoped system parameters
         if (headerNode != null) {
             val pageNumber = pdfDoc.getPageNumber(page)
+            val hideOnFirstPage = headerNode.props?.get("hideOnFirstPage") == true
+            if (hideOnFirstPage && pageNumber == 1) return
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
             val pageContext = context.withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(headerNode, document, pageContext)

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/PageHeaderFooterTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/PageHeaderFooterTest.kt
@@ -1,0 +1,135 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.Slot
+import app.epistola.template.model.TemplateDocument
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class PageHeaderFooterTest {
+
+    private val renderer = DirectPdfRenderer()
+
+    private fun textNode(id: String, text: String) = Node(
+        id = id,
+        type = "text",
+        props = mapOf(
+            "content" to mapOf(
+                "type" to "doc",
+                "content" to listOf(
+                    mapOf(
+                        "type" to "paragraph",
+                        "content" to listOf(mapOf("type" to "text", "text" to text)),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private fun buildDocument(
+        headerProps: Map<String, Any?> = emptyMap(),
+        footerProps: Map<String, Any?> = emptyMap(),
+    ): TemplateDocument {
+        val rootSlotId = "slot-root"
+        val headerSlotId = "slot-header"
+        val footerSlotId = "slot-footer"
+
+        // Create enough content for 2+ pages
+        val longText = "This is a paragraph of text that is long enough to take up significant vertical space on the page. " +
+            "It contains multiple sentences to ensure that the content wraps across several lines in the PDF output. " +
+            "We need enough total content to push the document onto at least two pages for testing header and footer behavior."
+        val bodyNodes = (1..30).associate { i ->
+            "body-$i" to textNode("body-$i", "$longText (Paragraph $i)")
+        }
+
+        return TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
+                "header" to Node(
+                    id = "header",
+                    type = "pageheader",
+                    slots = listOf(headerSlotId),
+                    props = headerProps + mapOf("height" to "30pt"),
+                ),
+                "header-text" to textNode("header-text", "HEADER CONTENT"),
+                "footer" to Node(
+                    id = "footer",
+                    type = "pagefooter",
+                    slots = listOf(footerSlotId),
+                    props = footerProps + mapOf("height" to "30pt"),
+                ),
+                "footer-text" to textNode("footer-text", "FOOTER CONTENT"),
+            ) + bodyNodes,
+            slots = mapOf(
+                rootSlotId to Slot(
+                    id = rootSlotId,
+                    nodeId = "root",
+                    name = "children",
+                    children = listOf("header", "footer") + bodyNodes.keys.toList(),
+                ),
+                headerSlotId to Slot(id = headerSlotId, nodeId = "header", name = "children", children = listOf("header-text")),
+                footerSlotId to Slot(id = footerSlotId, nodeId = "footer", name = "children", children = listOf("footer-text")),
+            ),
+        )
+    }
+
+    private fun renderAndExtract(doc: TemplateDocument): String {
+        val output = ByteArrayOutputStream()
+        renderer.render(doc, emptyMap(), output)
+        return PdfContentExtractor.extract(output.toByteArray())
+    }
+
+    @Test
+    fun `header renders on all pages by default`() {
+        val doc = buildDocument()
+        val text = renderAndExtract(doc)
+
+        val headerCount = "HEADER CONTENT".toRegex().findAll(text).count()
+        assert(headerCount >= 2) { "Expected header on at least 2 pages, found $headerCount" }
+    }
+
+    @Test
+    fun `header hidden on first page when hideOnFirstPage is true`() {
+        val doc = buildDocument(headerProps = mapOf("hideOnFirstPage" to true))
+        val text = renderAndExtract(doc)
+
+        // Page 1 should NOT have header, page 2+ should
+        val pages = text.split("--- PAGE ")
+        val page1 = pages.getOrNull(1) ?: ""
+        val page2 = pages.getOrNull(2) ?: ""
+
+        assertFalse(page1.contains("HEADER CONTENT"), "Header should be hidden on page 1")
+        assertContains(page2, "HEADER CONTENT", message = "Header should be visible on page 2")
+    }
+
+    @Test
+    fun `footer hidden on first page when hideOnFirstPage is true`() {
+        val doc = buildDocument(footerProps = mapOf("hideOnFirstPage" to true))
+        val text = renderAndExtract(doc)
+
+        val pages = text.split("--- PAGE ")
+        val page1 = pages.getOrNull(1) ?: ""
+        val page2 = pages.getOrNull(2) ?: ""
+
+        assertFalse(page1.contains("FOOTER CONTENT"), "Footer should be hidden on page 1")
+        assertContains(page2, "FOOTER CONTENT", message = "Footer should be visible on page 2")
+    }
+
+    @Test
+    fun `header and footer both hidden on first page`() {
+        val doc = buildDocument(
+            headerProps = mapOf("hideOnFirstPage" to true),
+            footerProps = mapOf("hideOnFirstPage" to true),
+        )
+        val text = renderAndExtract(doc)
+
+        val pages = text.split("--- PAGE ")
+        val page1 = pages.getOrNull(1) ?: ""
+
+        assertFalse(page1.contains("HEADER CONTENT"), "Header should be hidden on page 1")
+        assertFalse(page1.contains("FOOTER CONTENT"), "Footer should be hidden on page 1")
+    }
+}


### PR DESCRIPTION
## Summary

- **hideOnFirstPage** property added to page header and page footer components
- Checkbox in the inspector under the existing Height field
- PDF rendering: event handlers check page number and skip rendering on page 1 when enabled

## Test plan

- [ ] Add page header, check "Hide on first page" — header absent on page 1, visible on page 2+
- [ ] Same for page footer
- [ ] Unchecked — header/footer renders on all pages (default)
- [ ] `pnpm --filter @epistola/editor test` — all tests pass
- [ ] `./gradlew unitTest integrationTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)