### PR TITLE
feat(editor): add data list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Widow/orphan control**: PDF paragraphs and headings now enforce a minimum of 2 lines at the top and bottom of each page, preventing single isolated lines.
 - **List numbering formats**: Ordered lists now support decimal, lower/upper alpha (a,b,c / A,B,C), and lower/upper roman (i,ii,iii / I,II,III) numbering. Toggle format via the # button in the bubble menu. Custom start numbers are also supported.
 - **First-page header/footer variation**: Page headers and footers now have a "Hide on first page" checkbox. When enabled, the header/footer is not rendered on the first page of the PDF.
+- **Data list component**: New block that loops over a data expression and renders items as a formatted list (bullet, numbered, alpha, roman, or no marker). Combines the iteration of loop blocks with proper list formatting.
 
 ### Fixed
 

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -443,6 +443,42 @@ export function createDefaultRegistry(): ComponentRegistry {
   });
 
   registry.register({
+    type: 'datalist',
+    label: 'Data List',
+    icon: 'list',
+    category: 'logic',
+    slots: [{ name: 'item-template' }],
+    allowedChildren: { mode: 'all' },
+    applicableStyles: LAYOUT_STYLES,
+    inspector: [
+      { key: 'expression.raw', label: 'Data Source', type: 'expression' },
+      { key: 'itemAlias', label: 'Item Variable', type: 'text', defaultValue: 'item' },
+      { key: 'indexAlias', label: 'Index Variable', type: 'text' },
+      {
+        key: 'listType',
+        label: 'List Type',
+        type: 'select',
+        options: [
+          { label: 'Bullet', value: 'bullet' },
+          { label: 'Numbered', value: 'decimal' },
+          { label: 'Letters (a, b, c)', value: 'lower-alpha' },
+          { label: 'Letters (A, B, C)', value: 'upper-alpha' },
+          { label: 'Roman (i, ii, iii)', value: 'lower-roman' },
+          { label: 'Roman (I, II, III)', value: 'upper-roman' },
+          { label: 'No marker', value: 'none' },
+        ],
+      },
+    ],
+    defaultProps: {
+      expression: { raw: '', language: 'jsonata' },
+      itemAlias: 'item',
+      indexAlias: undefined,
+      listType: 'bullet',
+    },
+    scopeProvider: buildIterationScope,
+  });
+
+  registry.register({
     type: 'separator',
     label: 'Separator',
     icon: 'minus',

--- a/modules/editor/src/main/typescript/engine/scoped-fields.test.ts
+++ b/modules/editor/src/main/typescript/engine/scoped-fields.test.ts
@@ -106,7 +106,7 @@ describe('buildIterationScope', () => {
     const scope = buildIterationScope(node, { schemaFieldPaths })!;
 
     const paths = scope.variables.map((fp) => fp.path);
-    expect(paths).toEqual(['expensive_index', 'expensive_first', 'expensive_last']);
+    expect(paths).toEqual(['expensive', 'expensive_index', 'expensive_first', 'expensive_last']);
   });
 
   it('returns evaluation data with first array item', () => {

--- a/modules/editor/src/main/typescript/engine/scoped-fields.ts
+++ b/modules/editor/src/main/typescript/engine/scoped-fields.ts
@@ -64,7 +64,15 @@ function buildAliasedFieldPaths(
   const paths: FieldPath[] = [];
   const arrayPathPrefix = `${arrayExpression}[].`;
 
-  // Map array item sub-properties to aliased paths
+  // Add the item alias itself (for simple arrays and direct reference)
+  paths.push({
+    path: itemAlias,
+    type: 'string',
+    scope: itemAlias,
+    description: 'Current iteration item',
+  });
+
+  // Map array item sub-properties to aliased paths (for object arrays)
   for (const fp of schemaFieldPaths) {
     if (fp.path.startsWith(arrayPathPrefix)) {
       const subPath = fp.path.slice(arrayPathPrefix.length);

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -701,7 +701,8 @@ export class EpistolaInspector extends LitElement {
 
     // For loop/datatable expressions, highlight array-type fields
     const isLoopExpr =
-      (node.type === 'loop' || node.type === 'datatable') && key === 'expression.raw';
+      (node.type === 'loop' || node.type === 'datatable' || node.type === 'datalist') &&
+      key === 'expression.raw';
     const isConditionalExpr = node.type === 'conditional' && key === 'condition.raw';
     const placeholder = isLoopExpr
       ? 'e.g. items'

--- a/modules/editor/src/main/typescript/ui/icons.ts
+++ b/modules/editor/src/main/typescript/ui/icons.ts
@@ -30,6 +30,7 @@ const ICONS = {
     '<line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>',
   repeat:
     '<path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/>',
+  list: '<line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/>',
   minus: '<path d="M5 12h14"/>',
   'file-break':
     '<path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M4 7V4a2 2 0 0 1 2-2h8l6 6v4"/><path d="M4 12H2"/><path d="M22 12h-2"/><path d="M4 12a1 1 0 0 0-1 1v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6a1 1 0 0 0-1-1"/><path d="M8 12h8"/>',

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DataListNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DataListNodeRenderer.kt
@@ -1,0 +1,100 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.TemplateDocument
+import com.itextpdf.layout.element.IBlockElement
+import com.itextpdf.layout.element.IElement
+import com.itextpdf.layout.element.Image
+import com.itextpdf.layout.element.List
+import com.itextpdf.layout.element.ListItem
+import com.itextpdf.layout.properties.ListNumberingType
+
+/**
+ * Renders a "datalist" node as a formatted list (bulleted/numbered) driven by data.
+ *
+ * Similar to [LoopNodeRenderer] but wraps each iteration's content in a [ListItem]
+ * inside an iText [List], producing proper bullet/numbering markers.
+ *
+ * Props:
+ * - `expression`: Expression object (with "raw" and optional "language" keys)
+ * - `itemAlias`: String (defaults to "item")
+ * - `indexAlias`: String (optional)
+ * - `listType`: String (bullet, decimal, lower-alpha, upper-alpha, lower-roman, upper-roman, none)
+ */
+class DataListNodeRenderer : NodeRenderer {
+    override fun render(
+        node: Node,
+        document: TemplateDocument,
+        context: RenderContext,
+        registry: NodeRendererRegistry,
+    ): kotlin.collections.List<IElement> {
+        val expression = extractExpression(node.props?.get("expression"), context.defaultExpressionLanguage)
+            ?: return emptyList()
+
+        val iterable = context.expressionEvaluator.evaluateIterable(
+            expression,
+            context.effectiveData,
+            context.loopContext,
+        )
+
+        if (iterable.isEmpty()) return emptyList()
+
+        val itemAlias = node.props?.get("itemAlias") as? String ?: "item"
+        val indexAlias = node.props?.get("indexAlias") as? String
+        val listType = node.props?.get("listType") as? String ?: "bullet"
+
+        val list = createList(listType)
+        list.setMarginBottom(context.renderingDefaults.listMarginBottom)
+        list.setMarginLeft(context.renderingDefaults.listMarginLeft)
+
+        // Apply block styles (margins, background, etc.)
+        StyleApplicator.applyStylesWithPreset(
+            list,
+            node.styles?.filterNonNullValues(),
+            node.stylePreset,
+            context.blockStylePresets,
+            context.documentStyles,
+            context.fontCache,
+            context.renderingDefaults.componentDefaults("datalist"),
+            context.renderingDefaults.baseFontSizePt,
+            context.spacingUnit,
+        )
+
+        for ((index, item) in iterable.withIndex()) {
+            val itemContext = context.loopContext.toMutableMap()
+            itemContext[itemAlias] = item
+            itemContext["${itemAlias}_index"] = index
+            itemContext["${itemAlias}_first"] = (index == 0)
+            itemContext["${itemAlias}_last"] = (index == iterable.size - 1)
+            if (indexAlias != null) {
+                itemContext[indexAlias] = index
+            }
+
+            val childContext = context.copy(loopContext = itemContext)
+            val childElements = registry.renderSlots(node, document, childContext)
+
+            val listItem = ListItem()
+            listItem.setMarginBottom(context.renderingDefaults.listItemMarginBottom)
+            for (element in childElements) {
+                when (element) {
+                    is IBlockElement -> listItem.add(element)
+                    is Image -> listItem.add(element)
+                    else -> Unit
+                }
+            }
+            list.add(listItem)
+        }
+
+        return listOf(list)
+    }
+
+    private fun createList(listType: String): List = when (listType) {
+        "decimal" -> List(ListNumberingType.DECIMAL)
+        "lower-alpha" -> List(ListNumberingType.ENGLISH_LOWER)
+        "upper-alpha" -> List(ListNumberingType.ENGLISH_UPPER)
+        "lower-roman" -> List(ListNumberingType.ROMAN_LOWER)
+        "upper-roman" -> List(ListNumberingType.ROMAN_UPPER)
+        "none" -> List().apply { setListSymbol("") }
+        else -> List() // bullet (default)
+    }
+}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
@@ -416,6 +416,7 @@ class DirectPdfRenderer(
                 "table" to TableNodeRenderer(),
                 "conditional" to ConditionalNodeRenderer(),
                 "loop" to LoopNodeRenderer(),
+                "datalist" to DataListNodeRenderer(),
                 "datatable" to DatatableNodeRenderer(),
                 "datatable-column" to DatatableColumnNodeRenderer(),
                 "image" to ImageNodeRenderer(),

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DataListNodeRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DataListNodeRendererTest.kt
@@ -1,0 +1,140 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.Slot
+import app.epistola.template.model.TemplateDocument
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DataListNodeRendererTest {
+
+    private val renderer = DirectPdfRenderer()
+
+    private fun textNode(id: String, text: String) = Node(
+        id = id,
+        type = "text",
+        props = mapOf(
+            "content" to mapOf(
+                "type" to "doc",
+                "content" to listOf(
+                    mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to text))),
+                ),
+            ),
+        ),
+    )
+
+    private fun documentWithDataList(
+        listProps: Map<String, Any?>,
+        data: Map<String, Any?> = emptyMap(),
+    ): Pair<TemplateDocument, Map<String, Any?>> {
+        val rootSlotId = "slot-root"
+        val itemSlotId = "slot-item"
+
+        val doc = TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
+                "datalist" to Node(id = "datalist", type = "datalist", slots = listOf(itemSlotId), props = listProps),
+                "item-text" to textNode("item-text", "{{item}}"),
+            ),
+            slots = mapOf(
+                rootSlotId to Slot(id = rootSlotId, nodeId = "root", name = "children", children = listOf("datalist")),
+                itemSlotId to Slot(id = itemSlotId, nodeId = "datalist", name = "item-template", children = listOf("item-text")),
+            ),
+        )
+        return doc to data
+    }
+
+    private fun renderToPdf(doc: TemplateDocument, data: Map<String, Any?>): ByteArray {
+        val output = ByteArrayOutputStream()
+        renderer.render(doc, data, output)
+        return output.toByteArray()
+    }
+
+    @Test
+    fun `renders bullet list from data`() {
+        val (doc, data) = documentWithDataList(
+            listProps = mapOf(
+                "expression" to mapOf("raw" to "items", "language" to "simple_path"),
+                "itemAlias" to "item",
+                "listType" to "bullet",
+            ),
+            data = mapOf("items" to listOf("Alpha", "Beta", "Gamma")),
+        )
+        val pdf = renderToPdf(doc, data)
+        assertTrue(pdf.isNotEmpty())
+        assertTrue(pdf.decodeToString(0, 5).startsWith("%PDF"))
+    }
+
+    @Test
+    fun `renders numbered list from data`() {
+        val (doc, data) = documentWithDataList(
+            listProps = mapOf(
+                "expression" to mapOf("raw" to "items", "language" to "simple_path"),
+                "itemAlias" to "item",
+                "listType" to "decimal",
+            ),
+            data = mapOf("items" to listOf("First", "Second", "Third")),
+        )
+        val pdf = renderToPdf(doc, data)
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders lower-alpha list`() {
+        val (doc, data) = documentWithDataList(
+            listProps = mapOf(
+                "expression" to mapOf("raw" to "items", "language" to "simple_path"),
+                "itemAlias" to "item",
+                "listType" to "lower-alpha",
+            ),
+            data = mapOf("items" to listOf("X", "Y", "Z")),
+        )
+        val pdf = renderToPdf(doc, data)
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders empty list when data is empty`() {
+        val (doc, data) = documentWithDataList(
+            listProps = mapOf(
+                "expression" to mapOf("raw" to "items", "language" to "simple_path"),
+                "itemAlias" to "item",
+                "listType" to "bullet",
+            ),
+            data = mapOf("items" to emptyList<String>()),
+        )
+        val pdf = renderToPdf(doc, data)
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders list with no marker`() {
+        val (doc, data) = documentWithDataList(
+            listProps = mapOf(
+                "expression" to mapOf("raw" to "items", "language" to "simple_path"),
+                "itemAlias" to "item",
+                "listType" to "none",
+            ),
+            data = mapOf("items" to listOf("One", "Two")),
+        )
+        val pdf = renderToPdf(doc, data)
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders list with index alias`() {
+        val (doc, data) = documentWithDataList(
+            listProps = mapOf(
+                "expression" to mapOf("raw" to "items", "language" to "simple_path"),
+                "itemAlias" to "item",
+                "indexAlias" to "idx",
+                "listType" to "decimal",
+            ),
+            data = mapOf("items" to listOf("A", "B")),
+        )
+        val pdf = renderToPdf(doc, data)
+        assertTrue(pdf.isNotEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

- **Data list component**: New `datalist` block type that loops over data and renders as a formatted list
- **List types**: bullet, decimal, lower/upper alpha, lower/upper roman, no marker
- **Fix iteration scope**: `item` alias is now always listed as an available variable (was missing for simple arrays — only `item.subField` paths and metadata like `item_index` were shown)
- **Expression dialog**: datalist recognized for array field highlighting
- 6 PDF rendering tests

## Test plan

- [ ] Add data list, set expression to an array field — renders as list
- [ ] Change list type — bullet/numbered/alpha/roman all work
- [ ] Child text block: `item` shows in available variables
- [ ] Existing loop component: `item` also now shows as a variable
- [ ] `pnpm --filter @epistola/editor test` — 1090 tests pass
- [ ] `./gradlew unitTest integrationTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)