### PR TITLE
feat(editor): add address block and fix page margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 - **First-page header/footer variation**: Page headers and footers now have a "Hide on first page" checkbox. When enabled, the header/footer is not rendered on the first page of the PDF.
 - **Data list component**: New block that loops over a data expression and renders items as a formatted list (bullet, numbered, alpha, roman, or no marker). Combines the iteration of loop blocks with proper list formatting.
 - **Table cell styling**: Per-cell background color, text alignment, and padding via the inspector when a cell is selected. Table border color and width are now overridable from props instead of hardcoded.
+- **Address block**: Two-part envelope window component. Address content renders at absolute page coordinates (exact mm from page edge, regardless of margins). Aside content renders in normal flow beside the address. DIN C5/6 left/right presets. Nestable in stencils/containers.
+
+### Fixed
+
+- **Page margins**: Margins are now correctly converted from mm to points before passing to iText. Previously mm values were treated as points, making margins ~2.8x smaller than intended.
 
 ### Fixed
 

--- a/docs/editor-features.md
+++ b/docs/editor-features.md
@@ -74,20 +74,122 @@ These are style properties available on all block components (text, container, c
 
 ### Line Height
 
-Line height is configured as a fixed value in pt or sp (not a multiplier). It's an inheritable property — setting it at the document or theme level applies to all text blocks.
+Line height is a unitless multiplier (e.g., `1.5` = 150% of font size). It's an inheritable property — setting it at the document or theme level applies to all text blocks. The default tenant theme sets `lineHeight: 1.5`.
 
-**PDF rendering:** `TextNodeRenderer` resolves the style cascade and parses the value to points. The resolved value is passed to `TipTapConverter` via a pre-resolved styles map. `TipTapConverter.applyTextStyles()` calls `paragraph.setFixedLeading(pts)`.
+**PDF rendering:** `TextNodeRenderer` resolves the style cascade and passes the value to `TipTapConverter` via a pre-resolved styles map. `TipTapConverter.applyTextStyles()` calls `paragraph.setMultipliedLeading(value)`.
 
-## PDF Rendering Defaults
+### Table Cell Styling
 
-### Widow/Orphan Control
+Individual table cells can have per-cell styles: background color, text alignment, and per-side borders.
 
-All paragraphs and headings have widow/orphan control enabled by default:
+**Storage:** Cell styles are stored in `node.props.cellStyles` keyed by `"row-col"`:
 
-- **Orphans:** minimum 2 lines at the bottom of a page
-- **Widows:** minimum 2 lines at the top of a page
+```json
+{ "cellStyles": { "0-0": { "backgroundColor": "#f0f0f0", "textAlign": "center" } } }
+```
 
-This prevents single isolated lines from appearing alone at page boundaries. No editor UI — applied as sensible defaults in `TipTapConverter`.
+**Inspector:** When a cell is selected, the "Cell Style" section appears with background, text align, and border controls. Multi-cell selection applies the style to all selected cells.
+
+**PDF rendering:** `TableNodeRenderer` applies per-cell styles via `StyleApplicator`. Table-level borders are skipped when a cell has its own borders. Default padding (8pt) is only applied when no per-cell padding is set. Table border color and width are overridable from node props.
+
+### List Numbering and Bullet Styles
+
+Ordered lists support multiple numbering formats, and bullet lists support multiple bullet styles. The **#** button in the bubble menu cycles through styles within the current list type.
+
+**Ordered list formats:** decimal (1,2,3), lower-alpha (a,b,c), upper-alpha (A,B,C), lower-roman (i,ii,iii), upper-roman (I,II,III)
+
+**Bullet list styles:** disc (•), circle (○), square (■), dash (–)
+
+**PDF rendering:** `TipTapConverter` maps `listType` attribute to iText `ListNumberingType` for ordered lists, and `listStyle` attribute to custom `setListSymbol()` for bullet lists.
+
+## Page Components
+
+### Page Header / Footer
+
+Headers and footers render on every page via iText page event handlers.
+
+| Property        | Type    | Default | Description                      |
+| --------------- | ------- | ------- | -------------------------------- |
+| height          | unit    | 60pt    | Height of the header/footer band |
+| hideOnFirstPage | boolean | false   | When true, hidden on page 1      |
+
+**System parameters available:** `sys.pages.current` (page number), `sys.pages.total` (total pages, requires two-pass rendering).
+
+### Address Block
+
+A two-part layout for envelope window positioning. Consists of an **address** slot (rendered at absolute page coordinates) and an **aside** slot (rendered in the document flow).
+
+**Architecture:**
+
+```
+┌─────────────────────────────────────────┐ ← page edge
+│         (page margin)                   │
+│   ┌─────────────────────────────────┐   │ ← content area top
+│   │            [aside content       │   │ ← aside starts here (flow)
+│   │             starts from top]    │   │
+│   │                                 │   │
+│ ┌─┤─────────┐                       │   │ ← address anchor (absolute)
+│ │ │ Address  │                       │   │
+│ │ │ content  │                       │   │
+│ └─┤─────────┘                       │   │ ← address bottom
+│   │                                 │   │
+│   ├─────────────────────────────────┤   │ ← aside min-height end
+│   │ [body content continues]        │   │
+│   └─────────────────────────────────┘   │
+└─────────────────────────────────────────┘
+```
+
+**Properties:**
+
+| Property     | Type   | Default      | Description                        |
+| ------------ | ------ | ------------ | ---------------------------------- |
+| standard     | select | din-c56-left | Envelope standard preset           |
+| top          | number | 45           | Top position in mm from page edge  |
+| left         | number | 20           | Left position in mm from page edge |
+| addressWidth | number | 85           | Address window width in mm         |
+| height       | number | 45           | Address window height in mm        |
+
+**Presets:**
+
+| Standard       | Top  | Left  | Width | Height |
+| -------------- | ---- | ----- | ----- | ------ |
+| DIN C5/6 Left  | 45mm | 20mm  | 85mm  | 45mm   |
+| DIN C5/6 Right | 45mm | 105mm | 85mm  | 45mm   |
+
+**Rendering:**
+
+- **Address content** is rendered by `AddressBlockEventHandler` at absolute page coordinates using `PdfCanvas`. This guarantees exact positioning regardless of page margins. Renders on page 1 only.
+- **Aside content** is rendered by `AddressBlockNodeRenderer` in the document flow as a `Div` with left margin matching the address width. Min-height ensures body content starts below the address bottom.
+- `DirectPdfRenderer.hoistAddressBlock()` moves the address block to be the first child of root, ensuring aside content renders on page 1.
+
+**Constraints:**
+
+- One per document (`maxInstancesPerDocument: 1`)
+- Can be nested in containers/stencils (found by type scan)
+- The address block should be the first content element (after header). Content before it may overlap the address area.
+
+### Data List
+
+A block that loops over a data expression and renders items as a formatted list.
+
+**Properties:**
+
+| Property   | Type       | Default | Description                     |
+| ---------- | ---------- | ------- | ------------------------------- |
+| expression | expression | —       | Array data source               |
+| itemAlias  | text       | item    | Variable name for current item  |
+| indexAlias | text       | —       | Variable name for current index |
+| listType   | select     | bullet  | List format                     |
+
+**List types:** bullet, decimal, lower-alpha, upper-alpha, lower-roman, upper-roman, none
+
+**PDF rendering:** `DataListNodeRenderer` evaluates the expression, iterates results, and renders each item's template as an iText `ListItem` inside a `List`.
+
+## PDF Rendering
+
+### Page Margins
+
+Page margins are stored in millimeters in `PageSettings.margins` and converted to points (`1mm = 2.834645pt`) before passing to iText's `Document.setMargins()`.
 
 ### Component Default Spacing
 
@@ -103,3 +205,7 @@ All block components have a default bottom margin defined in `RenderingDefaults.
 | image     | 1.5sp (6pt)  |
 | qrcode    | 1.5sp (6pt)  |
 | separator | 1.5sp (6pt)  |
+
+### Hard Breaks
+
+Hard breaks (Shift+Enter) split the content into separate `Paragraph` objects at each break point. Intermediate paragraphs have zero margin/padding and `spacingRatio(0)` for tight line spacing. Only the last paragraph gets the standard `paragraphMarginBottom`.

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -520,6 +520,40 @@ export function createDefaultRegistry(): ComponentRegistry {
   });
 
   registry.register({
+    type: 'addressblock',
+    label: 'Address Block',
+    icon: 'mail',
+    category: 'page',
+    slots: [{ name: 'address' }, { name: 'aside' }],
+    allowedChildren: { mode: 'all' },
+    applicableStyles: [],
+    inspector: [
+      {
+        key: 'standard',
+        label: 'Envelope Standard',
+        type: 'select',
+        options: [
+          { label: 'DIN C5/6 Left Window', value: 'din-c56-left' },
+          { label: 'DIN C5/6 Right Window', value: 'din-c56-right' },
+          { label: 'Custom', value: 'custom' },
+        ],
+      },
+      { key: 'top', label: 'Top (mm)', type: 'number' },
+      { key: 'left', label: 'Left (mm)', type: 'number' },
+      { key: 'addressWidth', label: 'Address Width (mm)', type: 'number' },
+      { key: 'height', label: 'Height (mm)', type: 'number' },
+    ],
+    defaultProps: {
+      standard: 'din-c56-left',
+      top: 45,
+      left: 20,
+      addressWidth: 85,
+      height: 45,
+    },
+    maxInstancesPerDocument: 1,
+  });
+
+  registry.register({
     type: 'pagebreak',
     label: 'Page Break',
     icon: 'file-break',

--- a/modules/editor/src/main/typescript/ui/icons.ts
+++ b/modules/editor/src/main/typescript/ui/icons.ts
@@ -31,6 +31,7 @@ const ICONS = {
   repeat:
     '<path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/>',
   list: '<line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/>',
+  mail: '<rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>',
   minus: '<path d="M5 12h14"/>',
   'file-break':
     '<path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M4 7V4a2 2 0 0 1 2-2h8l6 6v4"/><path d="M4 12H2"/><path d="M22 12h-2"/><path d="M4 12a1 1 0 0 0-1 1v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6a1 1 0 0 0-1-1"/><path d="M8 12h8"/>',

--- a/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/epistola-app"
   },
   "release": {
-    "version": "4.8",
-    "releasedAt": "2026-04-18T00:00:00Z"
+    "version": "4.9",
+    "releasedAt": "2026-04-20T00:00:00Z"
   },
   "resources": [
     {

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
@@ -71,6 +71,69 @@
           "type": "root",
           "slots": ["s-root-children"]
         },
+        "n-addressblock": {
+          "id": "n-addressblock",
+          "type": "addressblock",
+          "slots": ["s-address", "s-aside"],
+          "props": {
+            "standard": "din-c56-left",
+            "top": 45,
+            "left": 20,
+            "addressWidth": 85,
+            "height": 45
+          }
+        },
+        "n-address-text": {
+          "id": "n-address-text",
+          "type": "text",
+          "slots": [],
+          "props": {
+            "content": {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "expression", "attrs": { "expression": "recipient.name" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "recipient.address" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "recipient.city" } }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "n-aside-text": {
+          "id": "n-aside-text",
+          "type": "text",
+          "slots": [],
+          "props": {
+            "content": {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "expression", "attrs": { "expression": "sender.name" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "sender.address" } },
+                    { "type": "hard_break" },
+                    { "type": "expression", "attrs": { "expression": "sender.city" } }
+                  ]
+                },
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "text", "text": "Date: " },
+                    { "type": "expression", "attrs": { "expression": "date" } }
+                  ]
+                }
+              ]
+            }
+          }
+        },
         "n-sender": {
           "id": "n-sender",
           "type": "text",
@@ -258,7 +321,19 @@
           "id": "s-root-children",
           "nodeId": "n-root",
           "name": "children",
-          "children": ["n-footer", "n-sender", "n-recipient", "n-date", "n-separator", "n-subject", "n-body", "n-attachments"]
+          "children": ["n-footer", "n-addressblock", "n-separator", "n-subject", "n-body", "n-attachments"]
+        },
+        "s-address": {
+          "id": "s-address",
+          "nodeId": "n-addressblock",
+          "name": "address",
+          "children": ["n-address-text"]
+        },
+        "s-aside": {
+          "id": "s-aside",
+          "nodeId": "n-addressblock",
+          "name": "aside",
+          "children": ["n-aside-text"]
         },
         "s-footer-children": {
           "id": "s-footer-children",

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -34,7 +34,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("4.8")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("4.9")
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockEventHandler.kt
@@ -1,0 +1,67 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.TemplateDocument
+import com.itextpdf.kernel.geom.Rectangle
+import com.itextpdf.kernel.pdf.canvas.PdfCanvas
+import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEvent
+import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEventHandler
+import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
+import com.itextpdf.layout.Canvas
+import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.IBlockElement
+import com.itextpdf.layout.element.Image
+
+/**
+ * Renders address content at absolute page coordinates on page 1.
+ * Guarantees exact positioning regardless of page margins.
+ */
+class AddressBlockEventHandler(
+    private val addressNodeId: String,
+    private val document: TemplateDocument,
+    private val context: RenderContext,
+    private val registry: NodeRendererRegistry,
+) : AbstractPdfDocumentEventHandler() {
+
+    companion object {
+        private const val MM_TO_PT = 2.834645f
+    }
+
+    override fun onAcceptedEvent(event: AbstractPdfDocumentEvent) {
+        val docEvent = event as? PdfDocumentEvent ?: return
+        val page = docEvent.page ?: return
+        val pdfDoc = docEvent.document
+        val pageSize = page.pageSize
+
+        if (pdfDoc.getPageNumber(page) != 1) return
+
+        val addressNode = document.nodes[addressNodeId] ?: return
+        val props = addressNode.props ?: return
+
+        val topPt = ((props["top"] as? Number)?.toFloat() ?: 45f) * MM_TO_PT
+        val leftPt = ((props["left"] as? Number)?.toFloat() ?: 20f) * MM_TO_PT
+        val widthPt = ((props["addressWidth"] as? Number)?.toFloat() ?: 85f) * MM_TO_PT
+        val heightPt = ((props["height"] as? Number)?.toFloat() ?: 45f) * MM_TO_PT
+
+        val rect = Rectangle(leftPt, pageSize.top - topPt - heightPt, widthPt, heightPt)
+
+        val pdfCanvas = PdfCanvas(page.newContentStreamAfter(), page.resources, pdfDoc)
+        val canvas = Canvas(pdfCanvas, rect)
+
+        val slotsByName = addressNode.slots.mapNotNull { slotId ->
+            document.slots[slotId]?.let { slot -> slot.name to slot.id }
+        }.toMap()
+
+        slotsByName["address"]?.let { slotId ->
+            for (element in registry.renderSlot(slotId, document, context)) {
+                when (element) {
+                    is IBlockElement -> canvas.add(element)
+                    is Image -> canvas.add(element)
+                    is AreaBreak -> Unit
+                }
+            }
+        }
+
+        canvas.close()
+        pdfCanvas.release()
+    }
+}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
@@ -1,0 +1,93 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.TemplateDocument
+import com.itextpdf.layout.element.Div
+import com.itextpdf.layout.element.IBlockElement
+import com.itextpdf.layout.element.IElement
+import com.itextpdf.layout.element.Image
+
+/**
+ * Renders the aside content in the document flow with a margin to avoid
+ * the address area. The address content is rendered at absolute coordinates
+ * by [AddressBlockEventHandler].
+ *
+ * The aside div has:
+ * - Left margin matching the address width (for left window) so text wraps beside the address
+ * - Min-height ensuring body content after starts below the address bottom
+ *
+ * [DirectPdfRenderer.hoistAddressBlock] moves this to the first child of root.
+ */
+class AddressBlockNodeRenderer : NodeRenderer {
+
+    companion object {
+        private const val MM_TO_PT = 2.834645f
+    }
+
+    override fun render(
+        node: Node,
+        document: TemplateDocument,
+        context: RenderContext,
+        registry: NodeRendererRegistry,
+    ): List<IElement> {
+        val props = node.props ?: return emptyList()
+        val standard = props["standard"] as? String ?: "din-c56-left"
+        val topMm = (props["top"] as? Number)?.toFloat() ?: 45f
+        val leftMm = (props["left"] as? Number)?.toFloat() ?: 20f
+        val addressWidthMm = (props["addressWidth"] as? Number)?.toFloat() ?: 85f
+        val heightMm = (props["height"] as? Number)?.toFloat() ?: 45f
+
+        val addressWidthPt = addressWidthMm * MM_TO_PT
+        val addressBottomPt = (topMm + heightMm) * MM_TO_PT
+
+        val pageMargins = document.pageSettingsOverride?.margins
+            ?: context.renderingDefaults.defaultPageSettings.margins
+        val pageTopMarginPt = pageMargins.top.toFloat() * MM_TO_PT
+        val pageLeftMarginPt = pageMargins.left.toFloat() * MM_TO_PT
+
+        val headerNode = document.nodes.values.firstOrNull { it.type == "pageheader" }
+        val headerHeightPt = if (headerNode != null) {
+            val h = parseNodeHeight(headerNode, context) ?: context.renderingDefaults.pageHeaderHeight
+            h + context.renderingDefaults.pageHeaderPadding
+        } else {
+            0f
+        }
+
+        val contentAreaTopPt = pageTopMarginPt + headerHeightPt
+        val isRightWindow = standard == "din-c56-right"
+
+        // Render aside slot
+        val slotsByName = node.slots.mapNotNull { slotId ->
+            document.slots[slotId]?.let { slot -> slot.name to slot.id }
+        }.toMap()
+        val asideElements = slotsByName["aside"]?.let { registry.renderSlot(it, document, context) } ?: emptyList()
+
+        val asideDiv = Div()
+        // Margin on the address side to leave room for the absolute-positioned address.
+        // The address right edge (from page edge) minus the content area left edge (page left margin)
+        // gives the margin needed in the content area.
+        val gapPt = 4f * MM_TO_PT // small gap between address and aside
+        if (isRightWindow) {
+            val addressLeftFromContentRight = addressWidthPt + gapPt
+            asideDiv.setMarginRight(addressLeftFromContentRight)
+        } else {
+            val addressRightEdgeFromPageEdge = (leftMm + addressWidthMm) * MM_TO_PT
+            val addressRightEdgeFromContentLeft = addressRightEdgeFromPageEdge - pageLeftMarginPt
+            asideDiv.setMarginLeft(maxOf(0f, addressRightEdgeFromContentLeft + gapPt))
+        }
+        asideDiv.setMarginTop(0f)
+        asideDiv.setMarginBottom(0f)
+        asideDiv.setPadding(0f)
+        // Ensure body content starts below the address bottom
+        asideDiv.setMinHeight(maxOf(0f, addressBottomPt - contentAreaTopPt))
+
+        for (element in asideElements) {
+            when (element) {
+                is IBlockElement -> asideDiv.add(element)
+                is Image -> asideDiv.add(element)
+            }
+        }
+
+        return listOf(asideDiv)
+    }
+}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
@@ -165,9 +165,10 @@ class DirectPdfRenderer(
             parseNodeHeight(it, context) ?: renderingDefaults.pageFooterHeight
         } ?: 0f
 
-        val topMargin = margins.top.toFloat() +
+        val mmToPt = 2.834645f
+        val topMargin = margins.top.toFloat() * mmToPt +
             if (headerNode != null) renderingDefaults.pageHeaderPadding + headerHeight else 0f
-        val bottomMargin = margins.bottom.toFloat() +
+        val bottomMargin = margins.bottom.toFloat() * mmToPt +
             if (footerNode != null) renderingDefaults.pageFooterPadding + footerHeight else 0f
 
         performRenderWithContext(
@@ -181,8 +182,8 @@ class DirectPdfRenderer(
             pageSettings = pageSettings,
             topMargin = topMargin,
             bottomMargin = bottomMargin,
-            rightMargin = margins.right.toFloat(),
-            leftMargin = margins.left.toFloat(),
+            rightMargin = margins.right.toFloat() * mmToPt,
+            leftMargin = margins.left.toFloat() * mmToPt,
         )
     }
 
@@ -224,9 +225,10 @@ class DirectPdfRenderer(
             parseNodeHeight(it, heightContext) ?: renderingDefaults.pageFooterHeight
         } ?: 0f
 
-        val topMargin = margins.top.toFloat() +
+        val mmToPt = 2.834645f
+        val topMargin = margins.top.toFloat() * mmToPt +
             if (headerNode != null) renderingDefaults.pageHeaderPadding + headerHeight else 0f
-        val bottomMargin = margins.bottom.toFloat() +
+        val bottomMargin = margins.bottom.toFloat() * mmToPt +
             if (footerNode != null) renderingDefaults.pageFooterPadding + footerHeight else 0f
 
         // First pass: render to count total pages (bytes are discarded).
@@ -254,8 +256,8 @@ class DirectPdfRenderer(
             pageSettings = pageSettings,
             topMargin = topMargin,
             bottomMargin = bottomMargin,
-            rightMargin = margins.right.toFloat(),
-            leftMargin = margins.left.toFloat(),
+            rightMargin = margins.right.toFloat() * mmToPt,
+            leftMargin = margins.left.toFloat() * mmToPt,
             enablePdfA = false,
             enableMetadata = false,
             enableHeaderFooter = false,
@@ -284,8 +286,8 @@ class DirectPdfRenderer(
             pageSettings = pageSettings,
             topMargin = topMargin,
             bottomMargin = bottomMargin,
-            rightMargin = margins.right.toFloat(),
-            leftMargin = margins.left.toFloat(),
+            rightMargin = margins.right.toFloat() * mmToPt,
+            leftMargin = margins.left.toFloat() * mmToPt,
         )
     }
 
@@ -337,7 +339,18 @@ class DirectPdfRenderer(
             footerHandler?.let { pdfDocument.addEventHandler(PdfDocumentEvent.END_PAGE, it) }
         }
 
-        val elements = nodeRendererRegistry.renderNode(document.root, document, context)
+        // Address block: aside rendered in flow (hoisted to first child of root),
+        // address content rendered at absolute coordinates via event handler.
+        val renderDocument = hoistAddressBlock(document)
+        val addressNode = renderDocument.nodes.values.firstOrNull { it.type == "addressblock" }
+        addressNode?.let {
+            pdfDocument.addEventHandler(
+                PdfDocumentEvent.END_PAGE,
+                AddressBlockEventHandler(it.id, renderDocument, context, nodeRendererRegistry),
+            )
+        }
+
+        val elements = nodeRendererRegistry.renderNode(renderDocument.root, renderDocument, context)
         for (element in elements) {
             when (element) {
                 is com.itextpdf.layout.element.IBlockElement -> iTextDocument.add(element)
@@ -425,7 +438,45 @@ class DirectPdfRenderer(
                 "pagebreak" to PageBreakNodeRenderer(),
                 "pageheader" to PageHeaderNodeRenderer(),
                 "pagefooter" to PageFooterNodeRenderer(),
+                "addressblock" to AddressBlockNodeRenderer(),
             ),
         )
+    }
+
+    /**
+     * If the document contains an address block nested somewhere in the tree,
+     * move it to be the first child of the root slot. This ensures it renders
+     * on page 1 before any other content.
+     *
+     * Returns the original document if no address block exists or if it's
+     * already the first child of root.
+     */
+    private fun hoistAddressBlock(document: TemplateDocument): TemplateDocument {
+        val addressNode = document.nodes.values.firstOrNull { it.type == "addressblock" }
+            ?: return document
+
+        val rootNode = document.nodes[document.root] ?: return document
+        val rootSlotId = rootNode.slots.firstOrNull() ?: return document
+        val rootSlot = document.slots[rootSlotId] ?: return document
+
+        // Already first child of root?
+        if (rootSlot.children.firstOrNull() == addressNode.id) return document
+
+        // Find the slot that currently contains the address block and remove it
+        val mutableSlots = document.slots.toMutableMap()
+        for ((slotId, slot) in document.slots) {
+            if (addressNode.id in slot.children) {
+                mutableSlots[slotId] = slot.copy(children = slot.children.filter { it != addressNode.id })
+                break
+            }
+        }
+
+        // Insert as first child of root slot
+        val updatedRootSlot = mutableSlots[rootSlotId]!!
+        mutableSlots[rootSlotId] = updatedRootSlot.copy(
+            children = listOf(addressNode.id) + updatedRootSlot.children,
+        )
+
+        return document.copy(slots = mutableSlots)
     }
 }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/AddressBlockTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/AddressBlockTest.kt
@@ -1,0 +1,241 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.Slot
+import app.epistola.template.model.TemplateDocument
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+
+class AddressBlockTest {
+
+    private val renderer = DirectPdfRenderer()
+
+    private fun textNode(id: String, text: String) = Node(
+        id = id,
+        type = "text",
+        props = mapOf(
+            "content" to mapOf(
+                "type" to "doc",
+                "content" to listOf(
+                    mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to text))),
+                ),
+            ),
+        ),
+    )
+
+    private fun documentWithAddressBlock(
+        addressProps: Map<String, Any?> = emptyMap(),
+        addressText: String = "John Doe\n123 Main Street\nAmsterdam",
+        asideText: String = "Reference: 2026-001\nDate: 2026-04-20",
+    ): TemplateDocument {
+        val rootSlotId = "slot-root"
+        val addressSlotId = "slot-address"
+        val asideSlotId = "slot-aside"
+
+        return TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
+                "addressblock" to Node(
+                    id = "addressblock",
+                    type = "addressblock",
+                    slots = listOf(addressSlotId, asideSlotId),
+                    props = mapOf(
+                        "standard" to "din-c56-left",
+                        "top" to 45,
+                        "left" to 20,
+                        "addressWidth" to 85,
+                        "height" to 45,
+                    ) + addressProps,
+                ),
+                "address-text" to textNode("address-text", addressText),
+                "aside-text" to textNode("aside-text", asideText),
+                "body-text" to textNode("body-text", "Body content starts here."),
+            ),
+            slots = mapOf(
+                rootSlotId to Slot(id = rootSlotId, nodeId = "root", name = "children", children = listOf("addressblock", "body-text")),
+                addressSlotId to Slot(id = addressSlotId, nodeId = "addressblock", name = "address", children = listOf("address-text")),
+                asideSlotId to Slot(id = asideSlotId, nodeId = "addressblock", name = "aside", children = listOf("aside-text")),
+            ),
+        )
+    }
+
+    private fun renderAndExtract(doc: TemplateDocument, data: Map<String, Any?> = emptyMap()): String {
+        val output = ByteArrayOutputStream()
+        renderer.render(doc, data, output)
+        return PdfContentExtractor.extract(output.toByteArray())
+    }
+
+    private fun renderToBytes(doc: TemplateDocument): ByteArray {
+        val output = ByteArrayOutputStream()
+        renderer.render(doc, emptyMap(), output)
+        return output.toByteArray()
+    }
+
+    @Test
+    fun `renders address block with DIN C5-6 left position`() {
+        val pdf = renderToBytes(documentWithAddressBlock())
+        assertTrue(pdf.isNotEmpty())
+        assertTrue(pdf.decodeToString(0, 5).startsWith("%PDF"))
+    }
+
+    @Test
+    fun `address and aside content both appear in PDF`() {
+        val text = renderAndExtract(
+            documentWithAddressBlock(
+                addressText = "Recipient Name",
+                asideText = "Reference Info",
+            ),
+        )
+        assertContains(text, "Recipient Name")
+        assertContains(text, "Reference Info")
+    }
+
+    @Test
+    fun `body text renders below address block`() {
+        val text = renderAndExtract(documentWithAddressBlock())
+        assertContains(text, "Body content starts here.")
+    }
+
+    @Test
+    fun `renders with DIN C5-6 right window`() {
+        val pdf = renderToBytes(
+            documentWithAddressBlock(
+                addressProps = mapOf("standard" to "din-c56-right", "left" to 105),
+            ),
+        )
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders with custom position`() {
+        val pdf = renderToBytes(
+            documentWithAddressBlock(
+                addressProps = mapOf("standard" to "custom", "top" to 30, "left" to 50, "addressWidth" to 70, "height" to 30),
+            ),
+        )
+        assertTrue(pdf.isNotEmpty())
+    }
+
+    @Test
+    fun `renders address block nested in container`() {
+        val rootSlotId = "slot-root"
+        val containerSlotId = "slot-container"
+        val addressSlotId = "slot-address"
+        val asideSlotId = "slot-aside"
+
+        val doc = TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
+                "container" to Node(id = "container", type = "container", slots = listOf(containerSlotId)),
+                "addressblock" to Node(
+                    id = "addressblock",
+                    type = "addressblock",
+                    slots = listOf(addressSlotId, asideSlotId),
+                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                ),
+                "address-text" to textNode("address-text", "Nested Address"),
+                "aside-text" to textNode("aside-text", "Nested Aside"),
+            ),
+            slots = mapOf(
+                rootSlotId to Slot(id = rootSlotId, nodeId = "root", name = "children", children = listOf("container")),
+                containerSlotId to Slot(id = containerSlotId, nodeId = "container", name = "children", children = listOf("addressblock")),
+                addressSlotId to Slot(id = addressSlotId, nodeId = "addressblock", name = "address", children = listOf("address-text")),
+                asideSlotId to Slot(id = asideSlotId, nodeId = "addressblock", name = "aside", children = listOf("aside-text")),
+            ),
+        )
+
+        val text = renderAndExtract(doc)
+        assertContains(text, "Nested Address")
+        assertContains(text, "Nested Aside")
+    }
+
+    @Test
+    fun `address block with expressions renders data`() {
+        val doc = TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf("slot-root")),
+                "addressblock" to Node(
+                    id = "addressblock",
+                    type = "addressblock",
+                    slots = listOf("slot-address", "slot-aside"),
+                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                ),
+                "address-text" to Node(
+                    id = "address-text",
+                    type = "text",
+                    props = mapOf(
+                        "content" to mapOf(
+                            "type" to "doc",
+                            "content" to listOf(
+                                mapOf(
+                                    "type" to "paragraph",
+                                    "content" to listOf(
+                                        mapOf("type" to "expression", "attrs" to mapOf("expression" to "recipient.name")),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                "aside-text" to textNode("aside-text", "Ref"),
+            ),
+            slots = mapOf(
+                "slot-root" to Slot(id = "slot-root", nodeId = "root", name = "children", children = listOf("addressblock")),
+                "slot-address" to Slot(id = "slot-address", nodeId = "addressblock", name = "address", children = listOf("address-text")),
+                "slot-aside" to Slot(id = "slot-aside", nodeId = "addressblock", name = "aside", children = listOf("aside-text")),
+            ),
+        )
+
+        val text = renderAndExtract(doc, mapOf("recipient" to mapOf("name" to "Jane Smith")))
+        assertContains(text, "Jane Smith")
+    }
+
+    @Test
+    fun `address block renders on page 1 in multi-page document`() {
+        val longText = "This is a long paragraph that fills space. ".repeat(50)
+        val rootSlotId = "slot-root"
+        val addressSlotId = "slot-address"
+        val asideSlotId = "slot-aside"
+
+        // Create many body text nodes to push onto multiple pages
+        val bodyNodes = (1..15).associate { i ->
+            "body-$i" to textNode("body-$i", "$longText (Paragraph $i)")
+        }
+
+        val doc = TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
+                "addressblock" to Node(
+                    id = "addressblock",
+                    type = "addressblock",
+                    slots = listOf(addressSlotId, asideSlotId),
+                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                ),
+                "address-text" to textNode("address-text", "PAGE ONE ADDRESS"),
+                "aside-text" to textNode("aside-text", "Reference"),
+            ) + bodyNodes,
+            slots = mapOf(
+                rootSlotId to Slot(
+                    id = rootSlotId,
+                    nodeId = "root",
+                    name = "children",
+                    children = listOf("addressblock") + bodyNodes.keys.toList(),
+                ),
+                addressSlotId to Slot(id = addressSlotId, nodeId = "addressblock", name = "address", children = listOf("address-text")),
+                asideSlotId to Slot(id = asideSlotId, nodeId = "addressblock", name = "aside", children = listOf("aside-text")),
+            ),
+        )
+
+        val text = renderAndExtract(doc)
+        // Should have multiple pages and address content should be present
+        val pages = text.split("--- PAGE ")
+        assertTrue(pages.size > 2, "Should have multiple pages")
+        assertContains(text, "PAGE ONE ADDRESS", message = "Address content should be in the PDF")
+    }
+}

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DirectPdfRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DirectPdfRendererTest.kt
@@ -1090,4 +1090,133 @@ class DirectPdfRendererTest {
         assertTrue(extracted.contains("2/3"), "Page 2 should show '2/3' but got:\n$extracted")
         assertTrue(extracted.contains("3/3"), "Page 3 should show '3/3' but got:\n$extracted")
     }
+
+    // -----------------------------------------------------------------------
+    // Address block hoisting
+    // -----------------------------------------------------------------------
+
+    private fun textNode(id: String, text: String) = Node(
+        id = id,
+        type = "text",
+        props = mapOf(
+            "content" to mapOf(
+                "type" to "doc",
+                "content" to listOf(
+                    mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to text))),
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `address block nested in container is hoisted to root and renders`() {
+        val rootSlotId = "slot-root"
+        val containerSlotId = "slot-container"
+        val addressSlotId = "slot-address"
+        val asideSlotId = "slot-aside"
+
+        val document = TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
+                "body" to textNode("body", "Body after address"),
+                "container" to Node(id = "container", type = "container", slots = listOf(containerSlotId)),
+                "addressblock" to Node(
+                    id = "addressblock",
+                    type = "addressblock",
+                    slots = listOf(addressSlotId, asideSlotId),
+                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                ),
+                "address-text" to textNode("address-text", "HOISTED ADDRESS"),
+                "aside-text" to textNode("aside-text", "HOISTED ASIDE"),
+            ),
+            slots = mapOf(
+                rootSlotId to Slot(id = rootSlotId, nodeId = "root", name = "children", children = listOf("container", "body")),
+                containerSlotId to Slot(id = containerSlotId, nodeId = "container", name = "children", children = listOf("addressblock")),
+                addressSlotId to Slot(id = addressSlotId, nodeId = "addressblock", name = "address", children = listOf("address-text")),
+                asideSlotId to Slot(id = asideSlotId, nodeId = "addressblock", name = "aside", children = listOf("aside-text")),
+            ),
+        )
+
+        val output = ByteArrayOutputStream()
+        renderer.render(document, emptyMap(), output)
+
+        val text = PdfContentExtractor.extract(output.toByteArray())
+        assertTrue(text.contains("HOISTED ADDRESS"), "Address content should render")
+        assertTrue(text.contains("HOISTED ASIDE"), "Aside content should render")
+        assertTrue(text.contains("Body after address"), "Body content should render")
+    }
+
+    @Test
+    fun `address block already at root is not duplicated`() {
+        val rootSlotId = "slot-root"
+        val addressSlotId = "slot-address"
+        val asideSlotId = "slot-aside"
+
+        val document = TemplateDocument(
+            root = "root",
+            nodes = mapOf(
+                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
+                "addressblock" to Node(
+                    id = "addressblock",
+                    type = "addressblock",
+                    slots = listOf(addressSlotId, asideSlotId),
+                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                ),
+                "address-text" to textNode("address-text", "Address"),
+                "aside-text" to textNode("aside-text", "Aside"),
+                "body" to textNode("body", "Body"),
+            ),
+            slots = mapOf(
+                rootSlotId to Slot(id = rootSlotId, nodeId = "root", name = "children", children = listOf("addressblock", "body")),
+                addressSlotId to Slot(id = addressSlotId, nodeId = "addressblock", name = "address", children = listOf("address-text")),
+                asideSlotId to Slot(id = asideSlotId, nodeId = "addressblock", name = "aside", children = listOf("aside-text")),
+            ),
+        )
+
+        val output = ByteArrayOutputStream()
+        renderer.render(document, emptyMap(), output)
+
+        val pdfBytes = output.toByteArray()
+        assertTrue(pdfBytes.isNotEmpty())
+        assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+    }
+
+    @Test
+    fun `renders with custom page margins in mm`() {
+        val document = documentWithChildren(
+            childNodes = mapOf("text1" to textNode("text1", "Content with large margins")),
+            childNodeIds = listOf("text1"),
+            pageSettingsOverride = PageSettings(
+                format = PageFormat.A4,
+                orientation = Orientation.portrait,
+                margins = Margins(top = 50, right = 40, bottom = 50, left = 40),
+            ),
+        )
+
+        val output = ByteArrayOutputStream()
+        renderer.render(document, emptyMap(), output)
+
+        val pdfBytes = output.toByteArray()
+        assertTrue(pdfBytes.isNotEmpty())
+        assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+
+        // Verify content renders (margins don't push content off page)
+        val text = PdfContentExtractor.extract(pdfBytes)
+        assertTrue(text.contains("Content with large margins"))
+    }
+
+    @Test
+    fun `document without address block renders normally`() {
+        val document = documentWithChildren(
+            childNodes = mapOf("text1" to textNode("text1", "No address block")),
+            childNodeIds = listOf("text1"),
+        )
+
+        val output = ByteArrayOutputStream()
+        renderer.render(document, emptyMap(), output)
+
+        val text = PdfContentExtractor.extract(output.toByteArray())
+        assertTrue(text.contains("No address block"))
+    }
 }


### PR DESCRIPTION
## Summary

### Address block
- **Address slot**: rendered at absolute page coordinates via `AddressBlockEventHandler` (page 1 only)
- **Aside slot**: rendered in document flow with left margin to avoid address area
- **Presets**: DIN C5/6 left window (20mm, 45mm) and right window (105mm, 45mm)
- **Nestable**: found by type scan, works in containers/stencils
- `hoistAddressBlock()` moves it to first child of root for page 1 rendering

### Page margin fix
- Margins now correctly converted from mm to points (`* 2.834645`)
- Previously mm values were passed directly as points, making margins ~2.8x smaller

### Documentation
- Comprehensive docs in `docs/editor-features.md` covering all new features

## Test plan
- [ ] Address at exact mm coordinates regardless of page margins
- [ ] Aside content starts from content area top, beside the address
- [ ] DIN C5/6 left/right presets work
- [ ] Nested in container — still works
- [ ] Page margins now render at correct mm size
- [ ] `./gradlew unitTest integrationTest` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)