### PR TITLE
fix(generation): parent-to-child style inheritance in PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Style inheritance in PDF**: Inheritable styles (font family, size, weight, color, line height, letter spacing, text align) now cascade from parent nodes to children in generated PDFs, matching the browser behavior in the editor. Previously each node resolved styles only from the document level, ignoring parent overrides.
+- **Editor unit input clearing**: Setting a unit-type style value (font size, letter spacing, border radius) to 0 now removes the property instead of storing an explicit "0pt", allowing inheritance from the parent or document level.
+
 ## [0.15.0] - 2026-04-20
 
 ### Added

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -47,7 +47,7 @@ export function renderUnitInput(
 
   const handleNumberChange = (e: Event) => {
     const num = parseFloat((e.target as HTMLInputElement).value) || 0;
-    onChange(formatValueWithUnit(num, parsed.unit));
+    onChange(num === 0 ? '' : formatValueWithUnit(num, parsed.unit));
   };
 
   const handleUnitChange = (e: Event) => {
@@ -60,7 +60,7 @@ export function renderUnitInput(
     } else if (oldUnit === 'sp' && newUnit === 'pt') {
       newValue = parsed.value * baseUnit;
     }
-    onChange(formatValueWithUnit(newValue, newUnit));
+    onChange(newValue === 0 ? '' : formatValueWithUnit(newValue, newUnit));
   };
 
   return html`

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockEventHandler.kt
@@ -52,7 +52,8 @@ class AddressBlockEventHandler(
         }.toMap()
 
         slotsByName["address"]?.let { slotId ->
-            for (element in registry.renderSlot(slotId, document, context)) {
+            val childContext = context.withInheritedStylesFrom(addressNode)
+            for (element in registry.renderSlot(slotId, document, childContext)) {
                 when (element) {
                     is IBlockElement -> canvas.add(element)
                     is Image -> canvas.add(element)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
@@ -60,7 +60,8 @@ class AddressBlockNodeRenderer : NodeRenderer {
         val slotsByName = node.slots.mapNotNull { slotId ->
             document.slots[slotId]?.let { slot -> slot.name to slot.id }
         }.toMap()
-        val asideElements = slotsByName["aside"]?.let { registry.renderSlot(it, document, context) } ?: emptyList()
+        val childContext = context.withInheritedStylesFrom(node)
+        val asideElements = slotsByName["aside"]?.let { registry.renderSlot(it, document, childContext) } ?: emptyList()
 
         val asideDiv = Div()
         // Margin on the address side to leave room for the absolute-positioned address.

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ColumnsNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ColumnsNodeRenderer.kt
@@ -72,6 +72,9 @@ class ColumnsNodeRenderer : NodeRenderer {
         val gap = (node.props?.get("gap") as? Number)?.toFloat() ?: context.renderingDefaults.columnGap
         val cellPadding = gap / 2f
 
+        // Compute inherited styles once for all column slots
+        val childContext = context.withInheritedStylesFrom(node)
+
         // Render each column slot
         for ((index, slot) in columnSlots.withIndex()) {
             val cell = Cell()
@@ -85,8 +88,6 @@ class ColumnsNodeRenderer : NodeRenderer {
                 cell.setPaddingRight(cellPadding)
             }
 
-            // Render slot children with this node's resolved styles as inherited styles
-            val childContext = context.withInheritedStylesFrom(node)
             val childElements = registry.renderSlot(slot.id, document, childContext)
             for (element in childElements) {
                 when (element) {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ColumnsNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ColumnsNodeRenderer.kt
@@ -61,7 +61,7 @@ class ColumnsNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("columns"),
             context.renderingDefaults.baseFontSizePt,
@@ -85,8 +85,9 @@ class ColumnsNodeRenderer : NodeRenderer {
                 cell.setPaddingRight(cellPadding)
             }
 
-            // Render slot children
-            val childElements = registry.renderSlot(slot.id, document, context)
+            // Render slot children with this node's resolved styles as inherited styles
+            val childContext = context.withInheritedStylesFrom(node)
+            val childElements = registry.renderSlot(slot.id, document, childContext)
             for (element in childElements) {
                 when (element) {
                     is com.itextpdf.layout.element.IBlockElement -> cell.add(element)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ContainerNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ContainerNodeRenderer.kt
@@ -26,15 +26,16 @@ class ContainerNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults(node.type),
             context.renderingDefaults.baseFontSizePt,
             context.spacingUnit,
         )
 
-        // Render all slots
-        val childElements = registry.renderSlots(node, document, context)
+        // Render all slots with this node's resolved styles as inherited styles for children
+        val childContext = context.withInheritedStylesFrom(node)
+        val childElements = registry.renderSlots(node, document, childContext)
         for (element in childElements) {
             when (element) {
                 is com.itextpdf.layout.element.IBlockElement -> div.add(element)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DataListNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DataListNodeRenderer.kt
@@ -60,6 +60,9 @@ class DataListNodeRenderer : NodeRenderer {
             context.spacingUnit,
         )
 
+        // Compute inherited styles once for all iterations
+        val inheritedContext = context.withInheritedStylesFrom(node)
+
         for ((index, item) in iterable.withIndex()) {
             val itemContext = context.loopContext.toMutableMap()
             itemContext[itemAlias] = item
@@ -70,7 +73,7 @@ class DataListNodeRenderer : NodeRenderer {
                 itemContext[indexAlias] = index
             }
 
-            val childContext = context.withInheritedStylesFrom(node).copy(loopContext = itemContext)
+            val childContext = inheritedContext.copy(loopContext = itemContext)
             val childElements = registry.renderSlots(node, document, childContext)
 
             val listItem = ListItem()

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DataListNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DataListNodeRenderer.kt
@@ -53,7 +53,7 @@ class DataListNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("datalist"),
             context.renderingDefaults.baseFontSizePt,
@@ -70,7 +70,7 @@ class DataListNodeRenderer : NodeRenderer {
                 itemContext[indexAlias] = index
             }
 
-            val childContext = context.copy(loopContext = itemContext)
+            val childContext = context.withInheritedStylesFrom(node).copy(loopContext = itemContext)
             val childElements = registry.renderSlots(node, document, childContext)
 
             val listItem = ListItem()

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DatatableNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DatatableNodeRenderer.kt
@@ -105,6 +105,9 @@ class DatatableNodeRenderer : NodeRenderer {
         val itemAlias = node.props?.get("itemAlias") as? String ?: "item"
         val indexAlias = node.props?.get("indexAlias") as? String
 
+        // Compute inherited styles once for all row iterations
+        val inheritedContext = context.withInheritedStylesFrom(node)
+
         for ((index, item) in iterable.withIndex()) {
             // Create loop context with current item
             val itemContext = context.loopContext.toMutableMap()
@@ -117,7 +120,7 @@ class DatatableNodeRenderer : NodeRenderer {
                 itemContext[indexAlias] = index
             }
 
-            val childContext = context.withInheritedStylesFrom(node).copy(loopContext = itemContext)
+            val childContext = inheritedContext.copy(loopContext = itemContext)
 
             // Render each column's body slot with the loop context
             for (columnNode in columnNodes) {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DatatableNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DatatableNodeRenderer.kt
@@ -72,7 +72,7 @@ class DatatableNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("datatable"),
             context.renderingDefaults.baseFontSizePt,
@@ -117,7 +117,7 @@ class DatatableNodeRenderer : NodeRenderer {
                 itemContext[indexAlias] = index
             }
 
-            val childContext = context.copy(loopContext = itemContext)
+            val childContext = context.withInheritedStylesFrom(node).copy(loopContext = itemContext)
 
             // Render each column's body slot with the loop context
             for (columnNode in columnNodes) {
@@ -156,7 +156,7 @@ class DatatableNodeRenderer : NodeRenderer {
             styles,
             columnNode.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             baseFontSizePt = context.renderingDefaults.baseFontSizePt,
             spacingUnit = context.spacingUnit,

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
@@ -81,7 +81,7 @@ class ImageNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("image"),
             context.renderingDefaults.baseFontSizePt,

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
@@ -54,7 +54,7 @@ class PageFooterEventHandler(
             val hideOnFirstPage = footerNode.props?.get("hideOnFirstPage") == true
             if (hideOnFirstPage && pageNumber == 1) return
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
-            val pageContext = context.withPageParams(pageNumber, totalPages)
+            val pageContext = context.withInheritedStylesFrom(footerNode).withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(footerNode, document, pageContext)
             for (element in elements) {
                 when (element) {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
@@ -57,7 +57,7 @@ class PageHeaderEventHandler(
             val hideOnFirstPage = headerNode.props?.get("hideOnFirstPage") == true
             if (hideOnFirstPage && pageNumber == 1) return
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
-            val pageContext = context.withPageParams(pageNumber, totalPages)
+            val pageContext = context.withInheritedStylesFrom(headerNode).withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(headerNode, document, pageContext)
             for (element in elements) {
                 when (element) {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/QrCodeNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/QrCodeNodeRenderer.kt
@@ -57,7 +57,7 @@ class QrCodeNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("qrcode"),
             context.renderingDefaults.baseFontSizePt,

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderContext.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderContext.kt
@@ -34,7 +34,30 @@ data class RenderContext(
     val systemParams: Map<String, Any?> = emptyMap(),
     /** Pre-calculated total page count from two-pass rendering. Null during first pass or single-pass rendering. */
     val totalPages: Int? = null,
+    /**
+     * Inherited styles from the parent node, used for CSS-like style inheritance.
+     * Initialized from document styles (inheritable keys only) and updated as we
+     * traverse the node tree — each node's resolved inheritable styles become the
+     * inherited styles for its children.
+     */
+    val inheritedStyles: Map<String, Any> = documentStyles
+        ?.filterKeys { it in StyleApplicator.INHERITABLE_KEYS }
+        ?: emptyMap(),
 ) {
+    /**
+     * Returns a copy of this context with updated inherited styles based on a node's
+     * resolved styles. Only inheritable style properties are propagated to children.
+     */
+    fun withInheritedStylesFrom(node: app.epistola.template.model.Node): RenderContext {
+        val resolved = StyleApplicator.resolveInheritedStyles(
+            inheritedStyles,
+            node.stylePreset,
+            blockStylePresets,
+            node.styles?.filterNonNullValues(),
+        )
+        return if (resolved === inheritedStyles) this else copy(inheritedStyles = resolved)
+    }
+
     /**
      * Data map with system parameters merged under the `sys` key.
      * Returns the original [data] map when no system parameters are set.

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/SeparatorNodeRenderer.kt
@@ -64,7 +64,7 @@ class SeparatorNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("separator"),
             context.renderingDefaults.baseFontSizePt,

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -79,9 +79,11 @@ object StyleApplicator {
         // Apply component default styles first (lowest priority)
         defaultStyles?.let { applyBlockStyles(element, it, fontCache, baseFontSizePt, spacingUnit) }
 
-        // Apply inherited styles (from parent node, or document styles at root level)
-        if (inheritedStyles.isNotEmpty()) {
-            applyBlockStyles(element, inheritedStyles, fontCache, baseFontSizePt, spacingUnit)
+        // Apply inherited styles (from parent node, or document styles at root level),
+        // but only for keys that are allowed to cascade.
+        val effectiveInheritedStyles = inheritedStyles.filterKeys { it in INHERITABLE_KEYS }
+        if (effectiveInheritedStyles.isNotEmpty()) {
+            applyBlockStyles(element, effectiveInheritedStyles, fontCache, baseFontSizePt, spacingUnit)
         }
 
         // Resolve preset styles (if preset exists)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -61,7 +61,7 @@ object StyleApplicator {
      * @param blockInlineStyles The block's inline styles (may be null)
      * @param blockStylePreset The name of the theme preset referenced by the block (may be null)
      * @param blockStylePresets All available presets from the theme
-     * @param documentStyles Document-level default styles
+     * @param inheritedStyles Inherited styles from parent node (inheritable keys only)
      * @param fontCache The font cache for font lookups
      * @param defaultStyles Component-type default styles (may be null)
      */
@@ -70,7 +70,7 @@ object StyleApplicator {
         blockInlineStyles: Map<String, Any>?,
         blockStylePreset: String?,
         blockStylePresets: Map<String, Map<String, Any>>,
-        documentStyles: DocumentStyles?,
+        inheritedStyles: Map<String, Any>,
         fontCache: FontCache,
         defaultStyles: Map<String, Any>? = null,
         baseFontSizePt: Float = 12f,
@@ -79,22 +79,41 @@ object StyleApplicator {
         // Apply component default styles first (lowest priority)
         defaultStyles?.let { applyBlockStyles(element, it, fontCache, baseFontSizePt, spacingUnit) }
 
-        // Apply only inheritable document-level styles
-        documentStyles?.let { docStyles ->
-            val inheritable = docStyles.filterKeys { it in INHERITABLE_KEYS }
-            if (inheritable.isNotEmpty()) {
-                applyBlockStyles(element, inheritable, fontCache, baseFontSizePt, spacingUnit)
-            }
+        // Apply inherited styles (from parent node, or document styles at root level)
+        if (inheritedStyles.isNotEmpty()) {
+            applyBlockStyles(element, inheritedStyles, fontCache, baseFontSizePt, spacingUnit)
         }
 
         // Resolve preset styles (if preset exists)
         val presetStyles = blockStylePreset?.let { blockStylePresets[it] }
 
-        // Apply preset styles (override document styles)
+        // Apply preset styles (override inherited styles)
         presetStyles?.let { applyBlockStyles(element, it, fontCache, baseFontSizePt, spacingUnit) }
 
         // Apply block inline styles (override preset styles)
         blockInlineStyles?.let { applyBlockStyles(element, it, fontCache, baseFontSizePt, spacingUnit) }
+    }
+
+    /**
+     * Resolves the effective inherited styles for child nodes.
+     * Merges parent inherited styles with the current node's preset and inline styles
+     * (filtered to inheritable keys only).
+     */
+    fun resolveInheritedStyles(
+        parentInherited: Map<String, Any>,
+        presetName: String?,
+        blockStylePresets: Map<String, Map<String, Any>>,
+        inlineStyles: Map<String, Any>?,
+    ): Map<String, Any> {
+        val presetStyles = presetName?.let { blockStylePresets[it] }
+        val hasOverrides = presetStyles != null || inlineStyles != null
+        if (!hasOverrides) return parentInherited
+
+        return buildMap {
+            putAll(parentInherited)
+            presetStyles?.filterKeys { it in INHERITABLE_KEYS }?.let { putAll(it) }
+            inlineStyles?.filterKeys { it in INHERITABLE_KEYS }?.let { putAll(it) }
+        }
     }
 
     /**

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TableNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TableNodeRenderer.kt
@@ -83,6 +83,9 @@ class TableNodeRenderer : NodeRenderer {
             document.slots[slotId]?.let { slot -> slot.name to slot.id }
         }.toMap()
 
+        // Compute inherited styles once for all cell slots
+        val childContext = context.withInheritedStylesFrom(node)
+
         // Render cells in row-major order
         for (row in 0 until rowCount) {
             val isHeaderRow = row < headerRows
@@ -130,7 +133,6 @@ class TableNodeRenderer : NodeRenderer {
                 val slotName = "cell-$row-$col"
                 val slotId = slotsByName[slotName]
                 if (slotId != null) {
-                    val childContext = context.withInheritedStylesFrom(node)
                     val childElements = registry.renderSlot(slotId, document, childContext)
                     for (element in childElements) {
                         when (element) {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TableNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TableNodeRenderer.kt
@@ -53,7 +53,7 @@ class TableNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("table"),
             context.renderingDefaults.baseFontSizePt,
@@ -130,7 +130,8 @@ class TableNodeRenderer : NodeRenderer {
                 val slotName = "cell-$row-$col"
                 val slotId = slotsByName[slotName]
                 if (slotId != null) {
-                    val childElements = registry.renderSlot(slotId, document, context)
+                    val childContext = context.withInheritedStylesFrom(node)
+                    val childElements = registry.renderSlot(slotId, document, childContext)
                     for (element in childElements) {
                         when (element) {
                             is com.itextpdf.layout.element.IBlockElement -> cell.add(element)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TextNodeRenderer.kt
@@ -26,7 +26,7 @@ class TextNodeRenderer : NodeRenderer {
             node.styles?.filterNonNullValues(),
             node.stylePreset,
             context.blockStylePresets,
-            context.documentStyles,
+            context.inheritedStyles,
             context.fontCache,
             context.renderingDefaults.componentDefaults("text"),
             context.renderingDefaults.baseFontSizePt,
@@ -36,7 +36,7 @@ class TextNodeRenderer : NodeRenderer {
         // Resolve the full style cascade, then parse size values to points.
         // TipTapConverter receives pre-resolved values — it doesn't parse units.
         val rawStyles = buildMap<String, Any> {
-            context.documentStyles?.filterKeys { it in StyleApplicator.INHERITABLE_KEYS }?.let { putAll(it) }
+            putAll(context.inheritedStyles)
             StyleApplicator.resolveBlockStyles(context.blockStylePresets, node.stylePreset, node.styles?.filterNonNullValues())
                 ?.let { putAll(it) }
         }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -118,17 +118,33 @@ class StyleApplicatorTest {
         )
     }
 
+    // -----------------------------------------------------------------------
+    // resolveInheritedStyles
+    // -----------------------------------------------------------------------
+
     @Test
-    fun `applyStylesWithPreset filters non-inheritable document styles`() {
-        val div = Div()
-        StyleApplicator.applyStylesWithPreset(
-            div,
-            blockInlineStyles = null,
-            blockStylePreset = null,
-            blockStylePresets = emptyMap(),
-            inheritedStyles = mapOf("backgroundColor" to "#ff0000", "fontSize" to "14pt"),
-            fontCache = fontCache,
-        )
+    fun `resolveInheritedStyles returns parent styles when no overrides`() {
+        val parent = mapOf("fontSize" to "12pt" as Any, "color" to "#000" as Any)
+        val result = StyleApplicator.resolveInheritedStyles(parent, null, emptyMap(), null)
+        assertEquals(parent, result)
+    }
+
+    @Test
+    fun `resolveInheritedStyles merges inline overrides filtered to inheritable keys`() {
+        val parent = mapOf("fontSize" to "12pt" as Any)
+        val inline = mapOf("fontSize" to "18pt" as Any, "marginBottom" to "8pt" as Any)
+        val result = StyleApplicator.resolveInheritedStyles(parent, null, emptyMap(), inline)
+        assertEquals("18pt", result["fontSize"]) // overridden
+        assert("marginBottom" !in result) // non-inheritable filtered out
+    }
+
+    @Test
+    fun `resolveInheritedStyles merges preset overrides filtered to inheritable keys`() {
+        val parent = mapOf("fontSize" to "12pt" as Any)
+        val presets = mapOf("heading" to mapOf("fontSize" to "24pt" as Any, "paddingTop" to "4pt" as Any))
+        val result = StyleApplicator.resolveInheritedStyles(parent, "heading", presets, null)
+        assertEquals("24pt", result["fontSize"]) // preset overrides parent
+        assert("paddingTop" !in result) // non-inheritable filtered out
     }
 
     // -----------------------------------------------------------------------

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -84,7 +84,7 @@ class StyleApplicatorTest {
             blockInlineStyles = null,
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
             defaultStyles = mapOf("marginBottom" to "1.5sp"),
         )
@@ -99,7 +99,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("color" to "#333"),
             blockStylePreset = "heading",
             blockStylePresets = presets,
-            documentStyles = mapOf("fontFamily" to "Arial"),
+            inheritedStyles = mapOf("fontFamily" to "Arial"),
             fontCache = fontCache,
             defaultStyles = mapOf("marginBottom" to "1.5sp"),
         )
@@ -113,7 +113,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("fontSize" to "14pt"),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
         )
     }
@@ -126,7 +126,7 @@ class StyleApplicatorTest {
             blockInlineStyles = null,
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = mapOf("backgroundColor" to "#ff0000", "fontSize" to "14pt"),
+            inheritedStyles = mapOf("backgroundColor" to "#ff0000", "fontSize" to "14pt"),
             fontCache = fontCache,
         )
     }
@@ -143,7 +143,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("marginBottom" to "2sp"),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
         )
     }
@@ -156,7 +156,7 @@ class StyleApplicatorTest {
             blockInlineStyles = null,
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
             defaultStyles = mapOf("marginBottom" to "1.5sp"),
         )
@@ -170,7 +170,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("marginBottom" to "2sp"),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
             spacingUnit = 6f, // 2sp = 12pt
         )
@@ -184,7 +184,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("marginBottom" to "16pt", "paddingTop" to "8pt"),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
         )
     }
@@ -201,7 +201,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("keepTogether" to true),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
         )
         assertTrue(div.getProperty<Boolean>(Property.KEEP_TOGETHER) == true)
@@ -215,7 +215,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("keepTogether" to "true"),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
         )
         assertTrue(div.getProperty<Boolean>(Property.KEEP_TOGETHER) == true)
@@ -229,7 +229,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("keepWithNext" to true),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
         )
         assertTrue(div.getProperty<Boolean>(Property.KEEP_WITH_NEXT) == true)
@@ -243,7 +243,7 @@ class StyleApplicatorTest {
             blockInlineStyles = mapOf("marginBottom" to "4pt"),
             blockStylePreset = null,
             blockStylePresets = emptyMap(),
-            documentStyles = null,
+            inheritedStyles = emptyMap(),
             fontCache = fontCache,
         )
         assertEquals(null, div.getProperty<Boolean>(Property.KEEP_TOGETHER))


### PR DESCRIPTION
Closes #193

## Summary

- Inheritable styles (font, color, text-align, etc.) now cascade from parent nodes to children in PDF rendering, matching browser behavior in the editor
- Adds `inheritedStyles` to `RenderContext` that propagates through the node tree instead of each node resolving independently from document-level styles
- Fixes editor unit input so clearing a value (setting to 0) removes the style key instead of storing "0pt"

## Test plan

- [x] Set fontSize on a container and verify children without explicit fontSize inherit it in PDF output
- [x] Verify document-level styles still apply as defaults when no parent overrides
- [x] Verify inline styles and presets still override inherited styles
- [x] Test nested containers (grandparent → parent → child inheritance)
- [x] Verify editor: clearing a unit value shows empty field and PDF uses inherited value
- [x] Run `./gradlew unitTest integrationTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)