### PR TITLE
fix(generation): bold, italic, strikethrough not rendering in PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- **Bold, italic, and strikethrough in PDF**: Text marks now render correctly in generated PDFs. The PDF converter expected TipTap mark names (`bold`, `italic`, `strike`) but ProseMirror uses `strong`, `em`, and `strikethrough`.
 - **Stencil creation**: Fixed crash when saving a newly created stencil. The initial draft version was stored with an empty JSON object (`{}`), which failed deserialization because `TemplateDocument` requires a `root` node. Now stores a valid minimal document with an empty root node.
 - **API docs**: Fixed 404 on `/api-docs/epistola-contract.yaml` — the resource handler used an exact path instead of a wildcard pattern, preventing Spring from resolving the OpenAPI spec from the classpath.
 - **Catalog export**: Cross-catalog theme dependencies from resource-level `themeId` are now included in the exported `catalog.json` dependencies list. Previously only `ThemeRefOverride` inside template models was scanned.

--- a/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/TipTapConverter.kt
@@ -341,10 +341,10 @@ class TipTapConverter(
 
         for (mark in marks) {
             when (mark["type"]) {
-                "bold" -> isBold = true
-                "italic" -> isItalic = true
+                "bold", "strong" -> isBold = true
+                "italic", "em" -> isItalic = true
                 "underline" -> text.setUnderline()
-                "strike" -> text.setLineThrough()
+                "strike", "strikethrough" -> text.setLineThrough()
                 "subscript" -> {
                     text.setTextRise(-3f)
                     text.setFontSize(renderingDefaults.baseFontSizePt * 0.75f)


### PR DESCRIPTION
Relates to #193

## Summary

- The PDF converter only recognized TipTap-style mark names (`bold`, `italic`, `strike`) but the editor uses ProseMirror which stores marks as `strong`, `em`, and `strikethrough`
- Added ProseMirror mark names as aliases so all three render correctly in generated PDFs

## Test plan

- [x] Make text bold in the editor and verify it renders bold in the PDF
- [x] Make text italic in the editor and verify it renders italic in the PDF
- [x] Make text bold+italic and verify both apply in the PDF
- [x] Apply strikethrough and verify it renders in the PDF
- [x] Run `./gradlew unitTest integrationTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)