### PR TITLE
fix: catalog, address block, stencil, and asset improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - **Catalog export**: Cross-catalog theme dependencies from resource-level `themeId` are now included in the exported `catalog.json` dependencies list. Previously only `ThemeRefOverride` inside template models was scanned.
 - **Catalog ZIP import**: Template `themeId` and `themeCatalogKey` are now preserved when importing from a ZIP archive. Previously these fields were silently dropped.
 - **Catalog import dialog**: Import errors now display inline in the dialog instead of replacing the dialog content with the full catalog list page.
-- **Address block right window**: Fixed aside margin calculation for DIN C5/6 right window positioning. The margin was computed using only the address width, ignoring the `left` prop and page geometry, causing the aside content to overlap the address area.
+- **Address block positioning**: Replaced `left` prop with `align` (`left`/`right`) and `sideDistance` (distance from the aligned page edge). The `standard` select now acts as a preset that populates these properties. Previously, right-window positioning required manually computing the left offset from the page edge.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Catalog export**: Cross-catalog theme dependencies from resource-level `themeId` are now included in the exported `catalog.json` dependencies list. Previously only `ThemeRefOverride` inside template models was scanned.
 - **Catalog ZIP import**: Template `themeId` and `themeCatalogKey` are now preserved when importing from a ZIP archive. Previously these fields were silently dropped.
 - **Catalog import dialog**: Import errors now display inline in the dialog instead of replacing the dialog content with the full catalog list page.
+- **Catalog delete dialog**: Delete errors (e.g. "catalog in use") now display in the confirm dialog instead of silently failing. Returns 422 with JSON error for HTMX requests.
 - **Address block positioning**: Replaced `left` prop with `align` (`left`/`right`) and `sideDistance` (distance from the aligned page edge). The `standard` select now acts as a preset that populates these properties. Previously, right-window positioning required manually computing the left offset from the page edge.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Added
 
+- **Catalog cross-references**: The catalog detail page now shows which templates in other catalogs reference this catalog's themes, stencils, or assets.
 - **`UpgradeCatalog` command**: Upgrades a subscribed catalog in place — re-fetches the manifest, updates metadata and version, upgrades previously installed resources, and removes installed resources no longer in the manifest. Replaces the old unregister/re-register approach which failed when other templates referenced the catalog's themes.
 - **Catalog theme references**: Templates imported from catalogs now carry a `themeId` that links them to a theme in the same catalog. Previously imported templates always had `theme_key = NULL`, requiring themeRef overrides in the templateModel. The theme reference is set on import, included in exports, and updated on reimport.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Catalog export**: Cross-catalog theme dependencies from resource-level `themeId` are now included in the exported `catalog.json` dependencies list. Previously only `ThemeRefOverride` inside template models was scanned.
 - **Catalog ZIP import**: Template `themeId` and `themeCatalogKey` are now preserved when importing from a ZIP archive. Previously these fields were silently dropped.
 - **Catalog export assets**: Assets referenced by templates but stored in other catalogs are now bundled in the exported ZIP. Previously only same-catalog assets were included, leaving cross-catalog asset references as unresolved dependencies.
+- **Asset catalog scoping**: Assets are now properly catalog-scoped. The `catalogKey` parameter is required on `UploadAsset` and `ImportAsset` (no more DEFAULT fallback). The template editor passes the current catalog when listing and uploading assets.
 - **Catalog import dialog**: Import errors now display inline in the dialog instead of replacing the dialog content with the full catalog list page.
 - **Catalog delete dialog**: Delete errors (e.g. "catalog in use") now display in the confirm dialog instead of silently failing. Returns 422 with JSON error for HTMX requests.
 - **Address block positioning**: Replaced `left` prop with `align` (`left`/`right`) and `sideDistance` (distance from the aligned page edge). The `standard` select now acts as a preset that populates these properties. Previously, right-window positioning required manually computing the left offset from the page edge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Added
 
+- **`UpgradeCatalog` command**: Upgrades a subscribed catalog in place — re-fetches the manifest, updates metadata and version, upgrades previously installed resources, and removes installed resources no longer in the manifest. Replaces the old unregister/re-register approach which failed when other templates referenced the catalog's themes.
 - **Catalog theme references**: Templates imported from catalogs now carry a `themeId` that links them to a theme in the same catalog. Previously imported templates always had `theme_key = NULL`, requiring themeRef overrides in the templateModel. The theme reference is set on import, included in exports, and updated on reimport.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Added
 
-- **Catalog cross-references**: The catalog detail page now shows which templates in other catalogs reference this catalog's themes, stencils, or assets.
+- **Catalog resource usage**: The catalog browse page shows per-resource usage counts from other catalogs. Clicking a count opens a dialog listing which templates reference that resource.
 - **`UpgradeCatalog` command**: Upgrades a subscribed catalog in place — re-fetches the manifest, updates metadata and version, upgrades previously installed resources, and removes installed resources no longer in the manifest. Replaces the old unregister/re-register approach which failed when other templates referenced the catalog's themes.
 - **Catalog theme references**: Templates imported from catalogs now carry a `themeId` that links them to a theme in the same catalog. Previously imported templates always had `theme_key = NULL`, requiring themeRef overrides in the templateModel. The theme reference is set on import, included in exports, and updated on reimport.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Catalog export**: Cross-catalog theme dependencies from resource-level `themeId` are now included in the exported `catalog.json` dependencies list. Previously only `ThemeRefOverride` inside template models was scanned.
 - **Catalog ZIP import**: Template `themeId` and `themeCatalogKey` are now preserved when importing from a ZIP archive. Previously these fields were silently dropped.
 - **Catalog import dialog**: Import errors now display inline in the dialog instead of replacing the dialog content with the full catalog list page.
+- **Address block right window**: Fixed aside margin calculation for DIN C5/6 right window positioning. The margin was computed using only the address width, ignoring the `left` prop and page geometry, causing the aside content to overlap the address area.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - **API docs**: Fixed 404 on `/api-docs/epistola-contract.yaml` — the resource handler used an exact path instead of a wildcard pattern, preventing Spring from resolving the OpenAPI spec from the classpath.
 - **Catalog export**: Cross-catalog theme dependencies from resource-level `themeId` are now included in the exported `catalog.json` dependencies list. Previously only `ThemeRefOverride` inside template models was scanned.
 - **Catalog ZIP import**: Template `themeId` and `themeCatalogKey` are now preserved when importing from a ZIP archive. Previously these fields were silently dropped.
-- **Catalog export assets**: Assets referenced by templates but stored in other catalogs are now bundled in the exported ZIP. Previously only same-catalog assets were included, leaving cross-catalog asset references as unresolved dependencies.
+- **Catalog export assets**: Cross-catalog asset references are now listed as dependencies in the exported `catalog.json`, consistent with how themes and stencils are handled.
 - **Asset catalog scoping**: Assets are now properly catalog-scoped. The `catalogKey` parameter is required on `UploadAsset` and `ImportAsset` (no more DEFAULT fallback). The template editor passes the current catalog when listing and uploading assets.
 - **Catalog import dialog**: Import errors now display inline in the dialog instead of replacing the dialog content with the full catalog list page.
 - **Catalog delete dialog**: Delete errors (e.g. "catalog in use") now display in the confirm dialog instead of silently failing. Returns 422 with JSON error for HTMX requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **API docs**: Fixed 404 on `/api-docs/epistola-contract.yaml` — the resource handler used an exact path instead of a wildcard pattern, preventing Spring from resolving the OpenAPI spec from the classpath.
 - **Catalog export**: Cross-catalog theme dependencies from resource-level `themeId` are now included in the exported `catalog.json` dependencies list. Previously only `ThemeRefOverride` inside template models was scanned.
 - **Catalog ZIP import**: Template `themeId` and `themeCatalogKey` are now preserved when importing from a ZIP archive. Previously these fields were silently dropped.
+- **Catalog export assets**: Assets referenced by templates but stored in other catalogs are now bundled in the exported ZIP. Previously only same-catalog assets were included, leaving cross-catalog asset references as unresolved dependencies.
 - **Catalog import dialog**: Import errors now display inline in the dialog instead of replacing the dialog content with the full catalog list page.
 - **Catalog delete dialog**: Delete errors (e.g. "catalog in use") now display in the confirm dialog instead of silently failing. Returns 422 with JSON error for HTMX requests.
 - **Address block positioning**: Replaced `left` prop with `align` (`left`/`right`) and `sideDistance` (distance from the aligned page edge). The `standard` select now acts as a preset that populates these properties. Previously, right-window positioning required manually computing the left offset from the page edge.

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoader.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/demo/DemoLoader.kt
@@ -8,7 +8,7 @@ import app.epistola.suite.catalog.CatalogKey
 import app.epistola.suite.catalog.commands.InstallFromCatalog
 import app.epistola.suite.catalog.commands.InstallStatus
 import app.epistola.suite.catalog.commands.RegisterCatalog
-import app.epistola.suite.catalog.commands.UnregisterCatalog
+import app.epistola.suite.catalog.commands.UpgradeCatalog
 import app.epistola.suite.catalog.queries.GetCatalog
 import app.epistola.suite.common.ids.ApiKeyKey
 import app.epistola.suite.common.ids.EnvironmentId
@@ -117,10 +117,25 @@ class DemoLoader(
             }
 
             log.info("Demo catalog version changed: {} -> {}", installedVersion, remoteVersion)
-            // Unregister and re-register to get fresh resources
-            mediator.send(UnregisterCatalog(tenantKey = tenantKey, catalogKey = existingCatalog.id))
+            transactionTemplate.executeWithoutResult {
+                val result = mediator.send(UpgradeCatalog(tenantKey = tenantKey, catalogKey = existingCatalog.id))
+                val installed = result.installResults.count { it.status == InstallStatus.INSTALLED }
+                val updated = result.installResults.count { it.status == InstallStatus.UPDATED }
+                val failed = result.installResults.count { it.status == InstallStatus.FAILED }
+                log.info(
+                    "Upgraded demo catalog: {} -> {}, {} installed, {} updated, {} failed, {} removed",
+                    result.previousVersion,
+                    result.newVersion,
+                    installed,
+                    updated,
+                    failed,
+                    result.removedResources.size,
+                )
+            }
+            return
         }
 
+        // First-time registration
         transactionTemplate.executeWithoutResult {
             val catalog = mediator.send(RegisterCatalog(tenantKey = tenantKey, sourceUrl = DEMO_CATALOG_URL))
             log.info("Registered demo catalog: {} (version {})", catalog.name, catalog.installedReleaseVersion)

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/AssetHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/AssetHandler.kt
@@ -140,7 +140,10 @@ class AssetHandler {
         val catalogKeyStr = multipartData["catalog"]?.firstOrNull()?.let {
             String(it.inputStream.readAllBytes()).trim()
         }?.ifBlank { null }
-        val catalogKey = if (catalogKeyStr != null) CatalogKey.of(catalogKeyStr) else null
+            ?: return ServerResponse.badRequest()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(mapOf("error" to "catalog is required"))
+        val catalogKey = CatalogKey.of(catalogKeyStr)
 
         val asset = try {
             UploadAsset(
@@ -150,7 +153,7 @@ class AssetHandler {
                 content = contentBytes,
                 width = dimensions?.first,
                 height = dimensions?.second,
-                catalogKey = catalogKey ?: CatalogKey.DEFAULT,
+                catalogKey = catalogKey,
             ).execute()
         } catch (e: AssetTooLargeException) {
             return ServerResponse.badRequest()

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
@@ -11,6 +11,7 @@ import app.epistola.suite.catalog.commands.InstallStatus
 import app.epistola.suite.catalog.commands.RegisterCatalog
 import app.epistola.suite.catalog.commands.UnregisterCatalog
 import app.epistola.suite.catalog.queries.BrowseCatalog
+import app.epistola.suite.catalog.queries.FindCatalogCrossReferences
 import app.epistola.suite.catalog.queries.ListCatalogs
 import app.epistola.suite.catalog.queries.PreviewInstall
 import app.epistola.suite.htmx.form
@@ -172,6 +173,7 @@ class CatalogHandler {
 
         return try {
             val result = BrowseCatalog(tenantKey = tenantId.key, catalogKey = catalogKey).query()
+            val crossReferences = FindCatalogCrossReferences(tenantKey = tenantId.key, catalogKey = catalogKey).query()
 
             ServerResponse.ok().page("catalogs/browse") {
                 "pageTitle" to "${result.catalog.name} - Catalog - Epistola"
@@ -179,6 +181,7 @@ class CatalogHandler {
                 "activeNavSection" to "catalogs"
                 "catalog" to result.catalog
                 "resources" to result.resources
+                "crossReferences" to crossReferences
             }
         } catch (e: Exception) {
             logger.warn("Failed to browse catalog: ${e.message}", e)

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
@@ -11,7 +11,7 @@ import app.epistola.suite.catalog.commands.InstallStatus
 import app.epistola.suite.catalog.commands.RegisterCatalog
 import app.epistola.suite.catalog.commands.UnregisterCatalog
 import app.epistola.suite.catalog.queries.BrowseCatalog
-import app.epistola.suite.catalog.queries.FindCatalogCrossReferences
+import app.epistola.suite.catalog.queries.FindResourceUsages
 import app.epistola.suite.catalog.queries.ListCatalogs
 import app.epistola.suite.catalog.queries.PreviewInstall
 import app.epistola.suite.htmx.form
@@ -173,7 +173,8 @@ class CatalogHandler {
 
         return try {
             val result = BrowseCatalog(tenantKey = tenantId.key, catalogKey = catalogKey).query()
-            val crossReferences = FindCatalogCrossReferences(tenantKey = tenantId.key, catalogKey = catalogKey).query()
+            val usages = FindResourceUsages(tenantKey = tenantId.key, catalogKey = catalogKey).query()
+            val usageCounts = usages.mapValues { it.value.size }
 
             ServerResponse.ok().page("catalogs/browse") {
                 "pageTitle" to "${result.catalog.name} - Catalog - Epistola"
@@ -181,12 +182,32 @@ class CatalogHandler {
                 "activeNavSection" to "catalogs"
                 "catalog" to result.catalog
                 "resources" to result.resources
-                "crossReferences" to crossReferences
+                "usageCounts" to usageCounts
             }
         } catch (e: Exception) {
             logger.warn("Failed to browse catalog: ${e.message}", e)
             listWithError(request, "Failed to fetch catalog. The remote server may be unavailable or the URL may be incorrect.")
         }
+    }
+
+    fun resourceUsages(request: ServerRequest): ServerResponse {
+        val tenantId = request.tenantId()
+        val catalogKey = CatalogKey.of(request.pathVariable("catalogId"))
+        val resourceType = request.param("type").orElse("")
+        val resourceSlug = request.param("slug").orElse("")
+        val key = "$resourceType:$resourceSlug"
+
+        val usages = FindResourceUsages(tenantKey = tenantId.key, catalogKey = catalogKey).query()
+        val resourceUsages = usages[key] ?: emptyList()
+
+        return ServerResponse.ok().render(
+            "catalogs/browse :: usage-detail",
+            mapOf(
+                "resourceType" to resourceType,
+                "resourceSlug" to resourceSlug,
+                "usages" to resourceUsages,
+            ),
+        )
     }
 
     fun installPreview(request: ServerRequest): ServerResponse {

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
@@ -147,10 +147,22 @@ class CatalogHandler {
                 }
             }
         } catch (e: app.epistola.suite.catalog.CatalogInUseException) {
-            listWithError(request, e.message ?: "Catalog is in use by other catalogs")
+            if (request.isHtmx) {
+                ServerResponse.status(422)
+                    .header("Content-Type", "application/json")
+                    .body(mapOf("error" to (e.message ?: "Catalog is in use by other catalogs")))
+            } else {
+                listWithError(request, e.message ?: "Catalog is in use by other catalogs")
+            }
         } catch (e: Exception) {
             logger.warn("Failed to unregister catalog: ${e.message}", e)
-            listWithError(request, e.message ?: "Failed to remove catalog.")
+            if (request.isHtmx) {
+                ServerResponse.status(422)
+                    .header("Content-Type", "application/json")
+                    .body(mapOf("error" to (e.message ?: "Failed to remove catalog.")))
+            } else {
+                listWithError(request, e.message ?: "Failed to remove catalog.")
+            }
         }
     }
 

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogRoutes.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogRoutes.kt
@@ -17,6 +17,7 @@ class CatalogRoutes(private val handler: CatalogHandler) {
             POST("/import", handler::importZip)
             POST("/{catalogId}/delete", handler::unregister)
             GET("/{catalogId}/browse", handler::browse)
+            GET("/{catalogId}/usages", handler::resourceUsages)
             GET("/{catalogId}/export", handler::export)
             GET("/{catalogId}/install-preview", handler::installPreview)
             POST("/{catalogId}/install", handler::install)

--- a/apps/epistola/src/main/resources/templates/catalogs/browse.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/browse.html
@@ -13,13 +13,6 @@
 
         <div id="catalog-alert"></div>
 
-        <div th:if="${!crossReferences.isEmpty()}" class="alert alert-info" style="margin-bottom: var(--ep-space-4);">
-            <strong>Referenced by other catalogs:</strong>
-            <ul style="margin: var(--ep-space-2) 0 0 var(--ep-space-4); padding: 0;">
-                <li th:each="ref : ${crossReferences}" th:text="${ref}"></li>
-            </ul>
-        </div>
-
         <div class="card" th:if="${!resources.isEmpty()}">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                 <h2>Resources</h2>
@@ -39,6 +32,7 @@
                             <th>Name</th>
                             <th>Slug</th>
                             <th>Description</th>
+                            <th>Used by</th>
                             <th th:if="${catalog.type.name() == 'SUBSCRIBED'}">Status</th>
                             <th th:if="${catalog.type.name() == 'SUBSCRIBED'}">Actions</th>
                         </tr>
@@ -79,6 +73,18 @@
                                 <span th:if="${resource.description}" th:text="${resource.description}"></span>
                                 <span th:unless="${resource.description}" class="text-muted">-</span>
                             </td>
+                            <td th:with="count=${usageCounts != null ? usageCounts.getOrDefault(resource.type + ':' + resource.slug, 0) : 0}">
+                                <button th:if="${count > 0}"
+                                        type="button" class="badge badge-default"
+                                        style="cursor: pointer; border: none; background: var(--ep-muted); padding: 2px 8px;"
+                                        th:text="${count}"
+                                        th:hx-get="@{/tenants/{tenantId}/catalogs/{catalogId}/usages(tenantId=${tenantId},catalogId=${catalog.id},type=${resource.type},slug=${resource.slug})}"
+                                        hx-target="#usage-detail-body"
+                                        hx-swap="innerHTML"
+                                        onclick="document.getElementById('usage-detail-dialog').showModal()">
+                                </button>
+                                <span th:if="${count == 0}" class="text-muted">-</span>
+                            </td>
                             <!-- Status + Actions only for subscribed catalogs -->
                             <td th:if="${catalog.type.name() == 'SUBSCRIBED'}">
                                 <span th:if="${resource.status.name() == 'INSTALLED'}" class="badge badge-success">Installed</span>
@@ -104,6 +110,15 @@
                 <p class="text-muted">This catalog has no resources.</p>
             </div>
         </div>
+
+        <!-- Usage detail dialog -->
+        <dialog id="usage-detail-dialog" class="ep-dialog">
+            <div id="usage-detail-body">
+                <div class="ep-dialog-body">
+                    <p class="text-muted">Loading...</p>
+                </div>
+            </div>
+        </dialog>
 
         <!-- Install preview dialog (subscribed catalogs only) -->
         <dialog th:if="${catalog.type.name() == 'SUBSCRIBED'}" id="install-preview-dialog" class="ep-dialog">
@@ -191,6 +206,37 @@
         <div class="ep-dialog-footer">
             <button type="button" class="btn btn-ghost"
                     onclick="document.getElementById('install-preview-dialog').close()">Close</button>
+        </div>
+    </th:block>
+
+    <!-- Fragment: usage detail (loaded into dialog via HTMX) -->
+    <th:block th:fragment="usage-detail">
+        <div class="ep-dialog-header">
+            <h3>
+                Used by
+                <span style="opacity: 0.6;" th:text="'(' + ${resourceType} + ': ' + ${resourceSlug} + ')'"></span>
+            </h3>
+        </div>
+        <div class="ep-dialog-body">
+            <table class="ep-table" th:if="${!usages.isEmpty()}">
+                <thead>
+                    <tr>
+                        <th>Template</th>
+                        <th>Catalog</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr th:each="usage : ${usages}">
+                        <td th:text="${usage.referencedByName}"></td>
+                        <td><code th:text="${usage.referencedByCatalog}"></code></td>
+                    </tr>
+                </tbody>
+            </table>
+            <p th:if="${usages.isEmpty()}" class="text-muted">No external usages found.</p>
+        </div>
+        <div class="ep-dialog-footer">
+            <button type="button" class="btn btn-ghost"
+                    onclick="document.getElementById('usage-detail-dialog').close()">Close</button>
         </div>
     </th:block>
 

--- a/apps/epistola/src/main/resources/templates/catalogs/browse.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/browse.html
@@ -13,6 +13,13 @@
 
         <div id="catalog-alert"></div>
 
+        <div th:if="${!crossReferences.isEmpty()}" class="alert alert-info" style="margin-bottom: var(--ep-space-4);">
+            <strong>Referenced by other catalogs:</strong>
+            <ul style="margin: var(--ep-space-2) 0 0 var(--ep-space-4); padding: 0;">
+                <li th:each="ref : ${crossReferences}" th:text="${ref}"></li>
+            </ul>
+        </div>
+
         <div class="card" th:if="${!resources.isEmpty()}">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                 <h2>Resources</h2>

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -122,9 +122,9 @@
             dataModel: window.DATA_MODEL,
             plugins: plugins,
             imageOptions: {
-                contentUrlPattern: '/tenants/' + tenantId + '/assets/default/{assetId}/content',
+                contentUrlPattern: '/tenants/' + tenantId + '/assets/' + catalogId + '/{assetId}/content',
                 listAssets: async () => {
-                    const resp = await fetch('/tenants/' + tenantId + '/assets/search', {
+                    const resp = await fetch('/tenants/' + tenantId + '/assets/search?catalog=' + catalogId, {
                         headers: { 'Accept': 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
                     });
                     if (!resp.ok) throw new Error('Failed to list assets');
@@ -133,6 +133,7 @@
                 uploadAsset: async (file) => {
                     const formData = new FormData();
                     formData.append('file', file);
+                    formData.append('catalog', catalogId);
                     const resp = await fetch('/tenants/' + tenantId + '/assets', {
                         method: 'POST',
                         headers: { 'Accept': 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -530,7 +530,7 @@ export function createDefaultRegistry(): ComponentRegistry {
     inspector: [
       {
         key: 'standard',
-        label: 'Envelope Standard',
+        label: 'Envelope Preset',
         type: 'select',
         options: [
           { label: 'DIN C5/6 Left Window', value: 'din-c56-left' },
@@ -538,17 +538,50 @@ export function createDefaultRegistry(): ComponentRegistry {
           { label: 'Custom', value: 'custom' },
         ],
       },
+      {
+        key: 'align',
+        label: 'Align',
+        type: 'select',
+        options: [
+          { label: 'Left', value: 'left' },
+          { label: 'Right', value: 'right' },
+        ],
+      },
       { key: 'top', label: 'Top (mm)', type: 'number' },
-      { key: 'left', label: 'Left (mm)', type: 'number' },
+      { key: 'sideDistance', label: 'Side Distance (mm)', type: 'number' },
       { key: 'addressWidth', label: 'Address Width (mm)', type: 'number' },
       { key: 'height', label: 'Height (mm)', type: 'number' },
     ],
     defaultProps: {
       standard: 'din-c56-left',
+      align: 'left',
       top: 45,
-      left: 20,
+      sideDistance: 20,
       addressWidth: 85,
       height: 45,
+    },
+    onPropChange: (key, value, props) => {
+      if (key === 'standard' && value !== 'custom') {
+        const presets: Record<string, Record<string, unknown>> = {
+          'din-c56-left': {
+            align: 'left',
+            top: 45,
+            sideDistance: 20,
+            addressWidth: 85,
+            height: 45,
+          },
+          'din-c56-right': {
+            align: 'right',
+            top: 45,
+            sideDistance: 20,
+            addressWidth: 85,
+            height: 45,
+          },
+        };
+        const preset = presets[value as string];
+        if (preset) Object.assign(props, preset);
+      }
+      return props;
     },
     maxInstancesPerDocument: 1,
   });

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/Asset.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/Asset.kt
@@ -30,7 +30,7 @@ enum class AssetMediaType(val mimeType: String) {
 data class Asset(
     val id: AssetKey,
     val tenantKey: TenantKey,
-    val catalogKey: CatalogKey = CatalogKey.DEFAULT,
+    val catalogKey: CatalogKey,
     val catalogType: CatalogType = CatalogType.AUTHORED,
     val name: String,
     val mediaType: AssetMediaType,
@@ -46,7 +46,7 @@ data class Asset(
 data class AssetContent(
     val id: AssetKey,
     val tenantKey: TenantKey,
-    val catalogKey: CatalogKey = CatalogKey.DEFAULT,
+    val catalogKey: CatalogKey,
     val mediaType: AssetMediaType,
     val content: ByteArray,
 ) {

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/commands/UploadAsset.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/commands/UploadAsset.kt
@@ -38,7 +38,7 @@ data class UploadAsset(
     val content: ByteArray,
     val width: Int?,
     val height: Int?,
-    val catalogKey: CatalogKey = CatalogKey.DEFAULT,
+    val catalogKey: CatalogKey,
     val id: AssetKey? = null,
 ) : Command<Asset>,
     RequiresPermission {
@@ -112,6 +112,7 @@ class UploadAssetHandler(
         return Asset(
             id = id,
             tenantKey = command.tenantId,
+            catalogKey = command.catalogKey,
             name = command.name,
             mediaType = command.mediaType,
             sizeBytes = sizeBytes,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/queries/GetAsset.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/queries/GetAsset.kt
@@ -3,6 +3,7 @@ package app.epistola.suite.assets.queries
 import app.epistola.suite.assets.Asset
 import app.epistola.suite.assets.AssetMediaType
 import app.epistola.suite.common.ids.AssetKey
+import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
@@ -36,7 +37,7 @@ class GetAssetHandler(
     override fun handle(query: GetAsset): Asset? = jdbi.withHandle<Asset?, Exception> { handle ->
         handle.createQuery(
             """
-            SELECT id, tenant_key, name, media_type, size_bytes, width, height, created_at
+            SELECT id, tenant_key, catalog_key, name, media_type, size_bytes, width, height, created_at
             FROM assets
             WHERE id = :assetId
               AND tenant_key = :tenantId
@@ -48,6 +49,7 @@ class GetAssetHandler(
                 Asset(
                     id = AssetKey(rs.getObject("id", UUID::class.java)),
                     tenantKey = TenantKey(rs.getString("tenant_key")),
+                    catalogKey = CatalogKey.of(rs.getString("catalog_key")),
                     name = rs.getString("name"),
                     mediaType = AssetMediaType.fromMimeType(rs.getString("media_type")),
                     sizeBytes = rs.getLong("size_bytes"),

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/queries/GetAssetContent.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/queries/GetAssetContent.kt
@@ -3,6 +3,7 @@ package app.epistola.suite.assets.queries
 import app.epistola.suite.assets.AssetContent
 import app.epistola.suite.assets.AssetMediaType
 import app.epistola.suite.common.ids.AssetKey
+import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
@@ -43,7 +44,7 @@ class GetAssetContentHandler(
         val metadata = jdbi.withHandle<AssetMeta?, Exception> { handle ->
             handle.createQuery(
                 """
-                SELECT id, tenant_key, media_type
+                SELECT id, tenant_key, catalog_key, media_type
                 FROM assets
                 WHERE id = :assetId
                   AND tenant_key = :tenantId
@@ -55,6 +56,7 @@ class GetAssetContentHandler(
                     AssetMeta(
                         id = AssetKey(rs.getObject("id", UUID::class.java)),
                         tenantId = TenantKey(rs.getString("tenant_key")),
+                        catalogKey = CatalogKey.of(rs.getString("catalog_key")),
                         mediaType = AssetMediaType.fromMimeType(rs.getString("media_type")),
                     )
                 }
@@ -69,6 +71,7 @@ class GetAssetContentHandler(
         return AssetContent(
             id = metadata.id,
             tenantKey = metadata.tenantId,
+            catalogKey = metadata.catalogKey,
             mediaType = metadata.mediaType,
             content = stored.content.readAllBytes(),
         )
@@ -77,6 +80,7 @@ class GetAssetContentHandler(
     private data class AssetMeta(
         val id: AssetKey,
         val tenantId: TenantKey,
+        val catalogKey: CatalogKey,
         val mediaType: AssetMediaType,
     )
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ExportCatalogZip.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ExportCatalogZip.kt
@@ -73,17 +73,7 @@ class ExportCatalogZipHandler(
         val stencils = ExportStencils(command.tenantKey, catalogKey = command.catalogKey).query()
         val attributes = ExportAttributes(command.tenantKey, catalogKey = command.catalogKey).query()
 
-        // Assets: include same-catalog assets + any assets referenced by templates (may be in other catalogs)
-        val catalogAssets = ExportAssets(command.tenantKey, catalogKey = command.catalogKey).query()
-        val referencedAssetIds = collectReferencedAssetIds(templates)
-        val catalogAssetIds = catalogAssets.map { it.slug }.toSet()
-        val missingAssetIds = referencedAssetIds - catalogAssetIds
-        val externalAssets = if (missingAssetIds.isNotEmpty()) {
-            ExportAssets(command.tenantKey, assetIds = missingAssetIds.toList()).query()
-        } else {
-            emptyList()
-        }
-        val assets = catalogAssets + externalAssets
+        val assets = ExportAssets(command.tenantKey, catalogKey = command.catalogKey).query()
 
         // Build resource entries and details
         val resourceEntries = mutableListOf<ResourceEntry>()
@@ -242,26 +232,6 @@ class ExportCatalogZipHandler(
     }
 
     /**
-     * Scan all template models for image node asset references.
-     */
-    private fun collectReferencedAssetIds(templates: List<TemplateResource>): Set<String> {
-        val assetIds = mutableSetOf<String>()
-        for (template in templates) {
-            val docs = mutableListOf(template.templateModel)
-            template.variants.mapNotNull { it.templateModel }.forEach { docs.add(it) }
-            for (doc in docs) {
-                for (node in doc.nodes.values) {
-                    if (node.type == "image") {
-                        val assetId = node.props?.get("assetId") as? String
-                        if (assetId != null) assetIds.add(assetId)
-                    }
-                }
-            }
-        }
-        return assetIds
-    }
-
-    /**
      * Scan template models for references to resources NOT in this catalog's manifest.
      * Collect them as cross-catalog dependencies. No DB queries — purely in-memory.
      */
@@ -305,7 +275,12 @@ class ExportCatalogZipHandler(
                                 dependencies.add(DependencyRef.Stencil(catalogKey = refCatalog, slug = stencilId))
                             }
                         }
-                        // Assets are bundled in the ZIP (including cross-catalog), so no dependency needed
+                        "image" -> {
+                            val assetId = node.props?.get("assetId") as? String
+                            if (assetId != null && "asset:$assetId" !in ownResources) {
+                                dependencies.add(DependencyRef.Asset(slug = assetId))
+                            }
+                        }
                     }
                 }
             }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ExportCatalogZip.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ExportCatalogZip.kt
@@ -72,7 +72,18 @@ class ExportCatalogZipHandler(
         val themes = ExportThemes(command.tenantKey, catalogKey = command.catalogKey).query()
         val stencils = ExportStencils(command.tenantKey, catalogKey = command.catalogKey).query()
         val attributes = ExportAttributes(command.tenantKey, catalogKey = command.catalogKey).query()
-        val assets = ExportAssets(command.tenantKey, catalogKey = command.catalogKey).query()
+
+        // Assets: include same-catalog assets + any assets referenced by templates (may be in other catalogs)
+        val catalogAssets = ExportAssets(command.tenantKey, catalogKey = command.catalogKey).query()
+        val referencedAssetIds = collectReferencedAssetIds(templates)
+        val catalogAssetIds = catalogAssets.map { it.slug }.toSet()
+        val missingAssetIds = referencedAssetIds - catalogAssetIds
+        val externalAssets = if (missingAssetIds.isNotEmpty()) {
+            ExportAssets(command.tenantKey, assetIds = missingAssetIds.toList()).query()
+        } else {
+            emptyList()
+        }
+        val assets = catalogAssets + externalAssets
 
         // Build resource entries and details
         val resourceEntries = mutableListOf<ResourceEntry>()
@@ -231,6 +242,26 @@ class ExportCatalogZipHandler(
     }
 
     /**
+     * Scan all template models for image node asset references.
+     */
+    private fun collectReferencedAssetIds(templates: List<TemplateResource>): Set<String> {
+        val assetIds = mutableSetOf<String>()
+        for (template in templates) {
+            val docs = mutableListOf(template.templateModel)
+            template.variants.mapNotNull { it.templateModel }.forEach { docs.add(it) }
+            for (doc in docs) {
+                for (node in doc.nodes.values) {
+                    if (node.type == "image") {
+                        val assetId = node.props?.get("assetId") as? String
+                        if (assetId != null) assetIds.add(assetId)
+                    }
+                }
+            }
+        }
+        return assetIds
+    }
+
+    /**
      * Scan template models for references to resources NOT in this catalog's manifest.
      * Collect them as cross-catalog dependencies. No DB queries — purely in-memory.
      */
@@ -274,15 +305,7 @@ class ExportCatalogZipHandler(
                                 dependencies.add(DependencyRef.Stencil(catalogKey = refCatalog, slug = stencilId))
                             }
                         }
-                        "image" -> {
-                            val assetId = node.props?.get("assetId") as? String
-                            if (assetId != null && "asset:$assetId" !in ownResources) {
-                                // Asset is external — we don't know which catalog it's in from the template model alone,
-                                // but we know it's not in this catalog. Use the current catalog as placeholder.
-                                // The importing system will resolve it by tenant-global asset lookup.
-                                dependencies.add(DependencyRef.Asset(slug = assetId))
-                            }
-                        }
+                        // Assets are bundled in the ZIP (including cross-catalog), so no dependency needed
                     }
                 }
             }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ExportCatalogZip.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ExportCatalogZip.kt
@@ -127,7 +127,7 @@ class ExportCatalogZipHandler(
             for ((_, detail) in resourceDetails) {
                 val resource = detail.resource
                 if (resource is AssetResource) {
-                    val filename = resource.contentUrl.removePrefix("./resources/assets/")
+                    val filename = resource.contentUrl.removePrefix("./resources/asset/")
                     val uuidStr = filename.substringBefore(".")
                     val assetId = try {
                         AssetKey.of(UUID.fromString(uuidStr))
@@ -139,7 +139,7 @@ class ExportCatalogZipHandler(
                         assetId = assetId,
                     ).query() ?: continue
 
-                    zip.putNextEntry(ZipEntry("resources/assets/$filename"))
+                    zip.putNextEntry(ZipEntry("resources/asset/$filename"))
                     zip.write(content.content)
                     zip.closeEntry()
                 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ImportAsset.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ImportAsset.kt
@@ -23,7 +23,7 @@ import java.io.ByteArrayInputStream
  */
 data class ImportAsset(
     val tenantId: TenantId,
-    val catalogKey: CatalogKey = CatalogKey.DEFAULT,
+    val catalogKey: CatalogKey,
     val id: AssetKey,
     val name: String,
     val mediaType: AssetMediaType,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
@@ -1,0 +1,175 @@
+package app.epistola.suite.catalog.commands
+
+import app.epistola.suite.catalog.CatalogClient
+import app.epistola.suite.catalog.CatalogImportContext
+import app.epistola.suite.catalog.CatalogKey
+import app.epistola.suite.catalog.queries.GetCatalog
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.Command
+import app.epistola.suite.mediator.CommandHandler
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.mediator.query
+import app.epistola.suite.security.Permission
+import app.epistola.suite.security.RequiresPermission
+import org.jdbi.v3.core.Jdbi
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Upgrades a subscribed catalog by re-fetching from its source URL.
+ * Updates catalog metadata and version, upgrades previously installed
+ * resources, and removes installed resources no longer in the manifest.
+ *
+ * Only resources that are already installed locally are upgraded — new
+ * resources in the manifest are not automatically installed.
+ */
+data class UpgradeCatalog(
+    override val tenantKey: TenantKey,
+    val catalogKey: CatalogKey,
+) : Command<UpgradeCatalogResult>,
+    RequiresPermission {
+    override val permission get() = Permission.TENANT_SETTINGS
+}
+
+data class UpgradeCatalogResult(
+    val previousVersion: String?,
+    val newVersion: String,
+    val installResults: List<InstallResult>,
+    val removedResources: List<RemovedResource>,
+)
+
+data class RemovedResource(
+    val type: String,
+    val slug: String,
+)
+
+@Component
+class UpgradeCatalogHandler(
+    private val jdbi: Jdbi,
+    private val catalogClient: CatalogClient,
+) : CommandHandler<UpgradeCatalog, UpgradeCatalogResult> {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun handle(command: UpgradeCatalog): UpgradeCatalogResult = CatalogImportContext.runAsImport {
+        val catalog = GetCatalog(command.tenantKey, command.catalogKey).query()
+            ?: throw IllegalArgumentException("Catalog not found: ${command.catalogKey}")
+
+        val sourceUrl = catalog.sourceUrl
+            ?: throw IllegalStateException("Catalog '${command.catalogKey}' has no source URL — only subscribed catalogs can be upgraded")
+
+        val previousVersion = catalog.installedReleaseVersion
+
+        // 1. Re-register: upserts metadata + version
+        val updated = RegisterCatalog(
+            tenantKey = command.tenantKey,
+            sourceUrl = sourceUrl,
+            authType = catalog.sourceAuthType,
+            authCredential = catalog.sourceAuthCredential,
+        ).execute()
+
+        // 2. Find which resources are currently installed locally
+        val installedSlugs = findInstalledResourceSlugs(command.tenantKey, command.catalogKey)
+
+        // 3. Upgrade only previously installed resources
+        val slugsToUpgrade = installedSlugs.values.flatten().map { it.slug }
+        val installResults = if (slugsToUpgrade.isNotEmpty()) {
+            InstallFromCatalog(
+                tenantKey = command.tenantKey,
+                catalogKey = command.catalogKey,
+                resourceSlugs = slugsToUpgrade,
+            ).execute()
+        } else {
+            emptyList()
+        }
+
+        // 4. Remove installed resources no longer in the manifest
+        val manifest = catalogClient.fetchManifest(sourceUrl, catalog.sourceAuthType, catalog.sourceAuthCredential)
+        val manifestSlugs = manifest.resources.groupBy({ it.type }, { it.slug })
+        val removed = removeStaleResources(command.tenantKey, command.catalogKey, installedSlugs, manifestSlugs)
+
+        val installed = installResults.count { it.status == InstallStatus.INSTALLED }
+        val updatedCount = installResults.count { it.status == InstallStatus.UPDATED }
+        val failed = installResults.count { it.status == InstallStatus.FAILED }
+        logger.info(
+            "Upgraded catalog '{}': {} -> {}, {} installed, {} updated, {} failed, {} removed",
+            command.catalogKey,
+            previousVersion,
+            updated.installedReleaseVersion,
+            installed,
+            updatedCount,
+            failed,
+            removed.size,
+        )
+
+        UpgradeCatalogResult(
+            previousVersion = previousVersion,
+            newVersion = updated.installedReleaseVersion ?: manifest.release.version,
+            installResults = installResults,
+            removedResources = removed,
+        )
+    }
+
+    private data class InstalledResource(val type: String, val slug: String)
+
+    private fun findInstalledResourceSlugs(tenantKey: TenantKey, catalogKey: CatalogKey): Map<String, List<InstalledResource>> = jdbi.withHandle<Map<String, List<InstalledResource>>, Exception> { handle ->
+        val resources = mutableListOf<InstalledResource>()
+
+        handle.createQuery("SELECT id FROM document_templates WHERE tenant_key = :t AND catalog_key = :c")
+            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
+            .forEach { resources.add(InstalledResource("template", it)) }
+
+        handle.createQuery("SELECT id FROM themes WHERE tenant_key = :t AND catalog_key = :c")
+            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
+            .forEach { resources.add(InstalledResource("theme", it)) }
+
+        handle.createQuery("SELECT id FROM stencils WHERE tenant_key = :t AND catalog_key = :c")
+            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
+            .forEach { resources.add(InstalledResource("stencil", it)) }
+
+        handle.createQuery("SELECT id FROM variant_attribute_definitions WHERE tenant_key = :t AND catalog_key = :c")
+            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
+            .forEach { resources.add(InstalledResource("attribute", it)) }
+
+        resources.groupBy { it.type }
+    }
+
+    /**
+     * Removes locally installed resources that are no longer in the remote manifest.
+     * Only deletes resources that were previously installed, not all resources in the catalog.
+     */
+    private fun removeStaleResources(
+        tenantKey: TenantKey,
+        catalogKey: CatalogKey,
+        installedSlugs: Map<String, List<InstalledResource>>,
+        manifestSlugs: Map<String, List<String>>,
+    ): List<RemovedResource> {
+        val removed = mutableListOf<RemovedResource>()
+
+        data class TableMapping(val type: String, val table: String)
+
+        val tables = listOf(
+            TableMapping("template", "document_templates"),
+            TableMapping("theme", "themes"),
+            TableMapping("stencil", "stencils"),
+            TableMapping("attribute", "variant_attribute_definitions"),
+        )
+
+        jdbi.useHandle<Exception> { handle ->
+            for ((type, table) in tables) {
+                val installed = installedSlugs[type]?.map { it.slug } ?: continue
+                val inManifest = manifestSlugs[type]?.toSet() ?: emptySet()
+                val toRemove = installed.filter { it !in inManifest }
+
+                for (slug in toRemove) {
+                    handle.createUpdate("DELETE FROM $table WHERE tenant_key = :t AND catalog_key = :c AND id = :id")
+                        .bind("t", tenantKey).bind("c", catalogKey).bind("id", slug).execute()
+                    removed.add(RemovedResource(type, slug))
+                    logger.info("Removed stale {} '{}' from catalog '{}'", type, slug, catalogKey)
+                }
+            }
+        }
+
+        return removed
+    }
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
@@ -137,6 +137,8 @@ class UpgradeCatalogHandler(
     /**
      * Removes locally installed resources that are no longer in the remote manifest.
      * Only deletes resources that were previously installed, not all resources in the catalog.
+     * Resources referenced by other catalogs (e.g. themes used by external templates)
+     * are skipped with a warning rather than silently nulling out the reference.
      */
     private fun removeStaleResources(
         tenantKey: TenantKey,
@@ -149,10 +151,11 @@ class UpgradeCatalogHandler(
         data class TableMapping(val type: String, val table: String)
 
         val tables = listOf(
+            // Delete templates before themes — templates may reference themes in the same catalog
             TableMapping("template", "document_templates"),
-            TableMapping("theme", "themes"),
             TableMapping("stencil", "stencils"),
             TableMapping("attribute", "variant_attribute_definitions"),
+            TableMapping("theme", "themes"),
         )
 
         jdbi.useHandle<Exception> { handle ->
@@ -162,6 +165,16 @@ class UpgradeCatalogHandler(
                 val toRemove = installed.filter { it !in inManifest }
 
                 for (slug in toRemove) {
+                    // Check for cross-catalog references before deleting
+                    if (type == "theme" && isThemeReferencedExternally(handle, tenantKey, catalogKey, slug)) {
+                        logger.warn(
+                            "Skipping removal of theme '{}' from catalog '{}': still referenced by templates in other catalogs",
+                            slug,
+                            catalogKey,
+                        )
+                        continue
+                    }
+
                     handle.createUpdate("DELETE FROM $table WHERE tenant_key = :t AND catalog_key = :c AND id = :id")
                         .bind("t", tenantKey).bind("c", catalogKey).bind("id", slug).execute()
                     removed.add(RemovedResource(type, slug))
@@ -172,4 +185,19 @@ class UpgradeCatalogHandler(
 
         return removed
     }
+
+    private fun isThemeReferencedExternally(
+        handle: org.jdbi.v3.core.Handle,
+        tenantKey: TenantKey,
+        catalogKey: CatalogKey,
+        themeSlug: String,
+    ): Boolean = handle.createQuery(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM document_templates
+            WHERE tenant_key = :t AND theme_catalog_key = :c AND theme_key = :slug AND catalog_key != :c
+        )
+        """,
+    ).bind("t", tenantKey).bind("c", catalogKey).bind("slug", themeSlug)
+        .mapTo(Boolean::class.java).one()
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
@@ -11,14 +11,18 @@ import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.Jdbi
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 /**
  * Upgrades a subscribed catalog by re-fetching from its source URL.
- * Updates catalog metadata and version, upgrades previously installed
- * resources, and removes installed resources no longer in the manifest.
+ *
+ * The upgrade is validated before execution: if removing stale resources
+ * would break cross-catalog references (themes used by other templates,
+ * stencils embedded in other template models, etc.), the entire upgrade
+ * is rejected with a [CatalogUpgradeConflictException].
  *
  * Only resources that are already installed locally are upgraded — new
  * resources in the manifest are not automatically installed.
@@ -43,6 +47,13 @@ data class RemovedResource(
     val slug: String,
 )
 
+class CatalogUpgradeConflictException(
+    val conflicts: List<String>,
+) : RuntimeException(
+    "Catalog upgrade blocked — the following resources would be removed but are still in use:\n" +
+        conflicts.joinToString("\n") { "  - $it" },
+)
+
 @Component
 class UpgradeCatalogHandler(
     private val jdbi: Jdbi,
@@ -60,7 +71,25 @@ class UpgradeCatalogHandler(
 
         val previousVersion = catalog.installedReleaseVersion
 
-        // 1. Re-register: upserts metadata + version
+        // 1. Fetch manifest (once — reused for install and stale check)
+        val manifest = catalogClient.fetchManifest(sourceUrl, catalog.sourceAuthType, catalog.sourceAuthCredential)
+        val manifestSlugs = manifest.resources.groupBy({ it.type }, { it.slug })
+
+        // 2. Find which resources are currently installed locally
+        val installedSlugs = findInstalledResourceSlugs(command.tenantKey, command.catalogKey)
+
+        // 3. Compute what would be removed
+        val staleResources = computeStaleResources(installedSlugs, manifestSlugs)
+
+        // 4. Validate: fail if any stale resource is still referenced
+        if (staleResources.isNotEmpty()) {
+            val conflicts = findConflicts(command.tenantKey, command.catalogKey, staleResources)
+            if (conflicts.isNotEmpty()) {
+                throw CatalogUpgradeConflictException(conflicts)
+            }
+        }
+
+        // 5. Re-register: upserts metadata + version
         val updated = RegisterCatalog(
             tenantKey = command.tenantKey,
             sourceUrl = sourceUrl,
@@ -68,10 +97,7 @@ class UpgradeCatalogHandler(
             authCredential = catalog.sourceAuthCredential,
         ).execute()
 
-        // 2. Find which resources are currently installed locally
-        val installedSlugs = findInstalledResourceSlugs(command.tenantKey, command.catalogKey)
-
-        // 3. Upgrade only previously installed resources
+        // 6. Upgrade only previously installed resources
         val slugsToUpgrade = installedSlugs.values.flatten().map { it.slug }
         val installResults = if (slugsToUpgrade.isNotEmpty()) {
             InstallFromCatalog(
@@ -83,10 +109,8 @@ class UpgradeCatalogHandler(
             emptyList()
         }
 
-        // 4. Remove installed resources no longer in the manifest
-        val manifest = catalogClient.fetchManifest(sourceUrl, catalog.sourceAuthType, catalog.sourceAuthCredential)
-        val manifestSlugs = manifest.resources.groupBy({ it.type }, { it.slug })
-        val removed = removeStaleResources(command.tenantKey, command.catalogKey, installedSlugs, manifestSlugs)
+        // 7. Remove stale resources (already validated)
+        val removed = removeStaleResources(command.tenantKey, command.catalogKey, staleResources)
 
         val installed = installResults.count { it.status == InstallStatus.INSTALLED }
         val updatedCount = installResults.count { it.status == InstallStatus.UPDATED }
@@ -110,94 +134,181 @@ class UpgradeCatalogHandler(
         )
     }
 
+    // ── Installed resource discovery ──────────────────────────────────────────
+
     private data class InstalledResource(val type: String, val slug: String)
 
     private fun findInstalledResourceSlugs(tenantKey: TenantKey, catalogKey: CatalogKey): Map<String, List<InstalledResource>> = jdbi.withHandle<Map<String, List<InstalledResource>>, Exception> { handle ->
         val resources = mutableListOf<InstalledResource>()
 
-        handle.createQuery("SELECT id FROM document_templates WHERE tenant_key = :t AND catalog_key = :c")
-            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
-            .forEach { resources.add(InstalledResource("template", it)) }
+        data class TableType(val type: String, val table: String)
 
-        handle.createQuery("SELECT id FROM themes WHERE tenant_key = :t AND catalog_key = :c")
-            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
-            .forEach { resources.add(InstalledResource("theme", it)) }
+        val tables = listOf(
+            TableType("template", "document_templates"),
+            TableType("theme", "themes"),
+            TableType("stencil", "stencils"),
+            TableType("attribute", "variant_attribute_definitions"),
+            TableType("asset", "assets"),
+        )
 
-        handle.createQuery("SELECT id FROM stencils WHERE tenant_key = :t AND catalog_key = :c")
-            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
-            .forEach { resources.add(InstalledResource("stencil", it)) }
-
-        handle.createQuery("SELECT id FROM variant_attribute_definitions WHERE tenant_key = :t AND catalog_key = :c")
-            .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
-            .forEach { resources.add(InstalledResource("attribute", it)) }
+        for ((type, table) in tables) {
+            handle.createQuery("SELECT id FROM $table WHERE tenant_key = :t AND catalog_key = :c")
+                .bind("t", tenantKey).bind("c", catalogKey).mapTo(String::class.java).list()
+                .forEach { resources.add(InstalledResource(type, it)) }
+        }
 
         resources.groupBy { it.type }
     }
 
+    // ── Stale resource computation ───────────────────────────────────────────
+
+    private fun computeStaleResources(
+        installedSlugs: Map<String, List<InstalledResource>>,
+        manifestSlugs: Map<String, List<String>>,
+    ): List<InstalledResource> {
+        val stale = mutableListOf<InstalledResource>()
+        for ((type, installed) in installedSlugs) {
+            val inManifest = manifestSlugs[type]?.toSet() ?: emptySet()
+            installed.filter { it.slug !in inManifest }.forEach { stale.add(it) }
+        }
+        return stale
+    }
+
+    // ── Conflict validation ──────────────────────────────────────────────────
+
     /**
-     * Removes locally installed resources that are no longer in the remote manifest.
-     * Only deletes resources that were previously installed, not all resources in the catalog.
-     * Resources referenced by other catalogs (e.g. themes used by external templates)
-     * are skipped with a warning rather than silently nulling out the reference.
+     * Checks all stale resources for cross-catalog references.
+     * Returns human-readable conflict descriptions. Empty list = safe to proceed.
      */
+    private fun findConflicts(
+        tenantKey: TenantKey,
+        catalogKey: CatalogKey,
+        staleResources: List<InstalledResource>,
+    ): List<String> = jdbi.withHandle<List<String>, Exception> { handle ->
+        val conflicts = mutableListOf<String>()
+
+        for (resource in staleResources) {
+            when (resource.type) {
+                "theme" -> findThemeConflicts(handle, tenantKey, catalogKey, resource.slug, conflicts)
+                "stencil" -> findStencilConflicts(handle, tenantKey, catalogKey, resource.slug, conflicts)
+                "template" -> findTemplateConflicts(handle, tenantKey, catalogKey, resource.slug, conflicts)
+                "attribute" -> findAttributeConflicts(handle, tenantKey, catalogKey, resource.slug, conflicts)
+            }
+        }
+
+        conflicts
+    }
+
+    private fun findThemeConflicts(handle: Handle, tenantKey: TenantKey, catalogKey: CatalogKey, slug: String, conflicts: MutableList<String>) {
+        // Templates in other catalogs referencing this theme
+        handle.createQuery(
+            """
+            SELECT name, catalog_key FROM document_templates
+            WHERE tenant_key = :t AND theme_catalog_key = :c AND theme_key = :slug AND catalog_key != :c
+            """,
+        ).bind("t", tenantKey).bind("c", catalogKey).bind("slug", slug)
+            .map { rs, _ -> "Theme '$slug' is used by template '${rs.getString("name")}' (catalog: ${rs.getString("catalog_key")})" }
+            .list().let { conflicts.addAll(it) }
+
+        // Tenant default theme
+        handle.createQuery(
+            "SELECT id FROM tenants WHERE id = :t AND default_theme_catalog_key = :c AND default_theme_key = :slug",
+        ).bind("t", tenantKey).bind("c", catalogKey).bind("slug", slug)
+            .mapTo(String::class.java).findOne().ifPresent {
+                conflicts.add("Theme '$slug' is the tenant default theme")
+            }
+    }
+
+    private fun findStencilConflicts(handle: Handle, tenantKey: TenantKey, catalogKey: CatalogKey, slug: String, conflicts: MutableList<String>) {
+        // Templates in other catalogs that embed this stencil in their template model
+        handle.createQuery(
+            """
+            SELECT DISTINCT dt.name, tv.catalog_key
+            FROM template_versions tv
+            JOIN document_templates dt ON dt.tenant_key = tv.tenant_key AND dt.catalog_key = tv.catalog_key AND dt.id = tv.template_key
+            CROSS JOIN LATERAL jsonb_each(tv.template_model -> 'nodes') AS n(key, value)
+            WHERE tv.tenant_key = :t AND tv.catalog_key != :c
+              AND tv.status IN ('draft', 'published')
+              AND n.value ->> 'type' = 'stencil'
+              AND n.value -> 'props' ->> 'catalogKey' = :cStr
+              AND n.value -> 'props' ->> 'stencilId' = :slug
+            """,
+        ).bind("t", tenantKey).bind("c", catalogKey).bind("cStr", catalogKey.value).bind("slug", slug)
+            .map { rs, _ -> "Stencil '$slug' is used by template '${rs.getString("name")}' (catalog: ${rs.getString("catalog_key")})" }
+            .list().let { conflicts.addAll(it) }
+    }
+
+    private fun findTemplateConflicts(handle: Handle, tenantKey: TenantKey, catalogKey: CatalogKey, slug: String, conflicts: MutableList<String>) {
+        // Template has active environment activations
+        val activationCount = handle.createQuery(
+            """
+            SELECT COUNT(*) FROM environment_activations
+            WHERE tenant_key = :t AND catalog_key = :c AND template_key = :slug
+            """,
+        ).bind("t", tenantKey).bind("c", catalogKey).bind("slug", slug)
+            .mapTo(Long::class.java).one()
+
+        if (activationCount > 0) {
+            conflicts.add("Template '$slug' has $activationCount environment activation(s) — removing it would break document generation")
+        }
+    }
+
+    private fun findAttributeConflicts(handle: Handle, tenantKey: TenantKey, catalogKey: CatalogKey, slug: String, conflicts: MutableList<String>) {
+        // Variants in other catalogs that use this attribute
+        handle.createQuery(
+            """
+            SELECT DISTINCT dt.name, v.catalog_key
+            FROM template_variants v
+            JOIN document_templates dt ON dt.tenant_key = v.tenant_key AND dt.catalog_key = v.catalog_key AND dt.id = v.template_key
+            WHERE v.tenant_key = :t AND v.catalog_key != :c
+              AND v.attributes::jsonb ? :slug
+            """,
+        ).bind("t", tenantKey).bind("c", catalogKey).bind("slug", slug)
+            .map { rs, _ -> "Attribute '$slug' is used by template '${rs.getString("name")}' (catalog: ${rs.getString("catalog_key")})" }
+            .list().let { conflicts.addAll(it) }
+    }
+
+    // ── Stale resource removal ───────────────────────────────────────────────
+
     private fun removeStaleResources(
         tenantKey: TenantKey,
         catalogKey: CatalogKey,
-        installedSlugs: Map<String, List<InstalledResource>>,
-        manifestSlugs: Map<String, List<String>>,
+        staleResources: List<InstalledResource>,
     ): List<RemovedResource> {
+        if (staleResources.isEmpty()) return emptyList()
+
         val removed = mutableListOf<RemovedResource>()
 
-        data class TableMapping(val type: String, val table: String)
-
-        val tables = listOf(
-            // Delete templates before themes — templates may reference themes in the same catalog
-            TableMapping("template", "document_templates"),
-            TableMapping("stencil", "stencils"),
-            TableMapping("attribute", "variant_attribute_definitions"),
-            TableMapping("theme", "themes"),
+        val tableByType = mapOf(
+            "template" to "document_templates",
+            "stencil" to "stencils",
+            "attribute" to "variant_attribute_definitions",
+            "theme" to "themes",
+            "asset" to "assets",
         )
 
+        // Delete in dependency order: templates first (may reference themes/stencils), then the rest
+        val ordered = staleResources.sortedBy {
+            when (it.type) {
+                "template" -> 0
+                "stencil" -> 1
+                "attribute" -> 2
+                "asset" -> 3
+                "theme" -> 4
+                else -> 5
+            }
+        }
+
         jdbi.useHandle<Exception> { handle ->
-            for ((type, table) in tables) {
-                val installed = installedSlugs[type]?.map { it.slug } ?: continue
-                val inManifest = manifestSlugs[type]?.toSet() ?: emptySet()
-                val toRemove = installed.filter { it !in inManifest }
-
-                for (slug in toRemove) {
-                    // Check for cross-catalog references before deleting
-                    if (type == "theme" && isThemeReferencedExternally(handle, tenantKey, catalogKey, slug)) {
-                        logger.warn(
-                            "Skipping removal of theme '{}' from catalog '{}': still referenced by templates in other catalogs",
-                            slug,
-                            catalogKey,
-                        )
-                        continue
-                    }
-
-                    handle.createUpdate("DELETE FROM $table WHERE tenant_key = :t AND catalog_key = :c AND id = :id")
-                        .bind("t", tenantKey).bind("c", catalogKey).bind("id", slug).execute()
-                    removed.add(RemovedResource(type, slug))
-                    logger.info("Removed stale {} '{}' from catalog '{}'", type, slug, catalogKey)
-                }
+            for (resource in ordered) {
+                val table = tableByType[resource.type] ?: continue
+                handle.createUpdate("DELETE FROM $table WHERE tenant_key = :t AND catalog_key = :c AND id = :id")
+                    .bind("t", tenantKey).bind("c", catalogKey).bind("id", resource.slug).execute()
+                removed.add(RemovedResource(resource.type, resource.slug))
+                logger.info("Removed stale {} '{}' from catalog '{}'", resource.type, resource.slug, catalogKey)
             }
         }
 
         return removed
     }
-
-    private fun isThemeReferencedExternally(
-        handle: org.jdbi.v3.core.Handle,
-        tenantKey: TenantKey,
-        catalogKey: CatalogKey,
-        themeSlug: String,
-    ): Boolean = handle.createQuery(
-        """
-        SELECT EXISTS(
-            SELECT 1 FROM document_templates
-            WHERE tenant_key = :t AND theme_catalog_key = :c AND theme_key = :slug AND catalog_key != :c
-        )
-        """,
-    ).bind("t", tenantKey).bind("c", catalogKey).bind("slug", themeSlug)
-        .mapTo(Boolean::class.java).one()
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
@@ -89,15 +89,7 @@ class UpgradeCatalogHandler(
             }
         }
 
-        // 5. Re-register: upserts metadata + version
-        val updated = RegisterCatalog(
-            tenantKey = command.tenantKey,
-            sourceUrl = sourceUrl,
-            authType = catalog.sourceAuthType,
-            authCredential = catalog.sourceAuthCredential,
-        ).execute()
-
-        // 6. Upgrade only previously installed resources
+        // 5. Install/update only previously installed resources
         val slugsToUpgrade = installedSlugs.values.flatten().map { it.slug }
         val installResults = if (slugsToUpgrade.isNotEmpty()) {
             InstallFromCatalog(
@@ -109,9 +101,14 @@ class UpgradeCatalogHandler(
             emptyList()
         }
 
-        // 7. Remove stale resources (already validated)
+        // 6. Remove stale resources (already validated)
         val removed = removeStaleResources(command.tenantKey, command.catalogKey, staleResources)
 
+        // 7. Bump version last — if any step above fails, version stays at the old value
+        //    and the next run will retry the upgrade.
+        updateCatalogVersion(command.tenantKey, command.catalogKey, manifest.release.version, manifest.catalog.name, manifest.catalog.description)
+
+        val newVersion = manifest.release.version
         val installed = installResults.count { it.status == InstallStatus.INSTALLED }
         val updatedCount = installResults.count { it.status == InstallStatus.UPDATED }
         val failed = installResults.count { it.status == InstallStatus.FAILED }
@@ -119,7 +116,7 @@ class UpgradeCatalogHandler(
             "Upgraded catalog '{}': {} -> {}, {} installed, {} updated, {} failed, {} removed",
             command.catalogKey,
             previousVersion,
-            updated.installedReleaseVersion,
+            newVersion,
             installed,
             updatedCount,
             failed,
@@ -128,7 +125,7 @@ class UpgradeCatalogHandler(
 
         UpgradeCatalogResult(
             previousVersion = previousVersion,
-            newVersion = updated.installedReleaseVersion ?: manifest.release.version,
+            newVersion = newVersion,
             installResults = installResults,
             removedResources = removed,
         )
@@ -310,5 +307,23 @@ class UpgradeCatalogHandler(
         }
 
         return removed
+    }
+
+    private fun updateCatalogVersion(tenantKey: TenantKey, catalogKey: CatalogKey, version: String, name: String, description: String?) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate(
+                """
+                UPDATE catalogs
+                SET installed_release_version = :version, name = :name, description = :description, last_modified = NOW()
+                WHERE tenant_key = :t AND id = :c
+                """,
+            )
+                .bind("t", tenantKey)
+                .bind("c", catalogKey)
+                .bind("version", version)
+                .bind("name", name)
+                .bind("description", description)
+                .execute()
+        }
     }
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/queries/ExportAssets.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/queries/ExportAssets.kt
@@ -69,7 +69,7 @@ class ExportAssetsHandler(
                 mediaType = row.mediaType,
                 width = row.width,
                 height = row.height,
-                contentUrl = "./resources/assets/${row.id}$ext",
+                contentUrl = "./resources/asset/${row.id}$ext",
             )
         }
     }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/queries/FindResourceUsages.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/queries/FindResourceUsages.kt
@@ -1,0 +1,122 @@
+package app.epistola.suite.catalog.queries
+
+import app.epistola.suite.catalog.CatalogKey
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.Query
+import app.epistola.suite.mediator.QueryHandler
+import app.epistola.suite.security.Permission
+import app.epistola.suite.security.RequiresPermission
+import org.jdbi.v3.core.Jdbi
+import org.springframework.stereotype.Component
+
+/**
+ * Finds cross-catalog usage counts for each resource in a catalog.
+ * Returns a map of "type:slug" → list of usage descriptions.
+ */
+data class FindResourceUsages(
+    override val tenantKey: TenantKey,
+    val catalogKey: CatalogKey,
+) : Query<Map<String, List<ResourceUsage>>>,
+    RequiresPermission {
+    override val permission get() = Permission.TEMPLATE_VIEW
+}
+
+data class ResourceUsage(
+    val referencedByName: String,
+    val referencedByCatalog: String,
+    val referenceType: String,
+)
+
+@Component
+class FindResourceUsagesHandler(
+    private val jdbi: Jdbi,
+) : QueryHandler<FindResourceUsages, Map<String, List<ResourceUsage>>> {
+
+    override fun handle(query: FindResourceUsages): Map<String, List<ResourceUsage>> = jdbi.withHandle<Map<String, List<ResourceUsage>>, Exception> { handle ->
+        val usages = mutableListOf<Pair<String, ResourceUsage>>()
+
+        // Themes referenced by templates in other catalogs
+        handle.createQuery(
+            """
+                SELECT dt.theme_key AS resource_slug, dt.name AS ref_name, dt.catalog_key AS ref_catalog
+                FROM document_templates dt
+                WHERE dt.tenant_key = :tenantKey
+                  AND dt.theme_catalog_key = :catalogKey
+                  AND dt.catalog_key != :catalogKey
+                  AND dt.theme_key IS NOT NULL
+                """,
+        )
+            .bind("tenantKey", query.tenantKey)
+            .bind("catalogKey", query.catalogKey)
+            .map { rs, _ ->
+                "theme:${rs.getString("resource_slug")}" to ResourceUsage(
+                    referencedByName = rs.getString("ref_name"),
+                    referencedByCatalog = rs.getString("ref_catalog"),
+                    referenceType = "template",
+                )
+            }
+            .list()
+            .let { usages.addAll(it) }
+
+        // Stencils used by templates in other catalogs
+        handle.createQuery(
+            """
+                SELECT DISTINCT
+                    n.value -> 'props' ->> 'stencilId' AS resource_slug,
+                    dt.name AS ref_name,
+                    tv.catalog_key AS ref_catalog
+                FROM template_versions tv
+                JOIN document_templates dt ON dt.tenant_key = tv.tenant_key AND dt.catalog_key = tv.catalog_key AND dt.id = tv.template_key
+                CROSS JOIN LATERAL jsonb_each(tv.template_model -> 'nodes') AS n(key, value)
+                WHERE tv.tenant_key = :tenantKey
+                  AND tv.catalog_key != :catalogKey
+                  AND tv.status IN ('draft', 'published')
+                  AND n.value ->> 'type' = 'stencil'
+                  AND n.value -> 'props' ->> 'catalogKey' = :catalogKeyStr
+                """,
+        )
+            .bind("tenantKey", query.tenantKey)
+            .bind("catalogKey", query.catalogKey)
+            .bind("catalogKeyStr", query.catalogKey.value)
+            .map { rs, _ ->
+                "stencil:${rs.getString("resource_slug")}" to ResourceUsage(
+                    referencedByName = rs.getString("ref_name"),
+                    referencedByCatalog = rs.getString("ref_catalog"),
+                    referenceType = "template",
+                )
+            }
+            .list()
+            .let { usages.addAll(it) }
+
+        // Assets used by templates in other catalogs
+        handle.createQuery(
+            """
+                SELECT DISTINCT
+                    a.id::text AS resource_slug,
+                    dt.name AS ref_name,
+                    tv.catalog_key AS ref_catalog
+                FROM template_versions tv
+                JOIN document_templates dt ON dt.tenant_key = tv.tenant_key AND dt.catalog_key = tv.catalog_key AND dt.id = tv.template_key
+                CROSS JOIN LATERAL jsonb_each(tv.template_model -> 'nodes') AS n(key, value)
+                JOIN assets a ON a.tenant_key = tv.tenant_key AND a.catalog_key = :catalogKey AND a.id::text = n.value -> 'props' ->> 'assetId'
+                WHERE tv.tenant_key = :tenantKey
+                  AND tv.catalog_key != :catalogKey
+                  AND tv.status IN ('draft', 'published')
+                  AND n.value ->> 'type' = 'image'
+                """,
+        )
+            .bind("tenantKey", query.tenantKey)
+            .bind("catalogKey", query.catalogKey)
+            .map { rs, _ ->
+                "asset:${rs.getString("resource_slug")}" to ResourceUsage(
+                    referencedByName = rs.getString("ref_name"),
+                    referencedByCatalog = rs.getString("ref_catalog"),
+                    referenceType = "template",
+                )
+            }
+            .list()
+            .let { usages.addAll(it) }
+
+        usages.groupBy({ it.first }, { it.second })
+    }
+}

--- a/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/epistola-app"
   },
   "release": {
-    "version": "5.0",
+    "version": "5.1",
     "releasedAt": "2026-04-21T00:00:00Z"
   },
   "resources": [

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/simple-letter.json
@@ -76,9 +76,9 @@
           "type": "addressblock",
           "slots": ["s-address", "s-aside"],
           "props": {
-            "standard": "din-c56-left",
+            "align": "left",
             "top": 45,
-            "left": 20,
+            "sideDistance": 20,
             "addressWidth": 85,
             "height": 45
           }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/assets/AssetIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/assets/AssetIntegrationTest.kt
@@ -8,6 +8,7 @@ import app.epistola.suite.assets.queries.GetAssetContent
 import app.epistola.suite.assets.queries.ListAssets
 import app.epistola.suite.common.ids.AssetKey
 import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TemplateId
 import app.epistola.suite.common.ids.TenantId
 import app.epistola.suite.common.ids.VariantId
@@ -41,6 +42,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
             content = testPngBytes,
             width = 1,
             height = 1,
+            catalogKey = CatalogKey.DEFAULT,
         ).execute()
 
         assertThat(asset.id).isNotNull()
@@ -55,8 +57,8 @@ class AssetIntegrationTest : IntegrationTestBase() {
     fun `list assets returns uploaded assets in reverse chronological order`() = withMediator {
         val tenant = createTenant("Test Tenant")
 
-        UploadAsset(tenant.id, "first.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
-        UploadAsset(tenant.id, "second.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        UploadAsset(tenant.id, "first.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
+        UploadAsset(tenant.id, "second.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val assets = ListAssets(tenantId = tenant.id).query()
 
@@ -69,8 +71,8 @@ class AssetIntegrationTest : IntegrationTestBase() {
     fun `list assets with search filter`() = withMediator {
         val tenant = createTenant("Test Tenant")
 
-        UploadAsset(tenant.id, "logo.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
-        UploadAsset(tenant.id, "banner.jpeg", AssetMediaType.JPEG, testPngBytes, 1, 1).execute()
+        UploadAsset(tenant.id, "logo.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
+        UploadAsset(tenant.id, "banner.jpeg", AssetMediaType.JPEG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val results = ListAssets(tenantId = tenant.id, searchTerm = "logo").query()
 
@@ -81,7 +83,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
     @Test
     fun `get asset metadata`() = withMediator {
         val tenant = createTenant("Test Tenant")
-        val uploaded = UploadAsset(tenant.id, "test.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        val uploaded = UploadAsset(tenant.id, "test.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val asset = GetAsset(tenantId = tenant.id, assetId = uploaded.id).query()
 
@@ -93,7 +95,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
     @Test
     fun `get asset content`() = withMediator {
         val tenant = createTenant("Test Tenant")
-        val uploaded = UploadAsset(tenant.id, "test.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        val uploaded = UploadAsset(tenant.id, "test.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val content = GetAssetContent(tenantId = tenant.id, assetId = uploaded.id).query()
 
@@ -114,7 +116,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
     @Test
     fun `delete asset`() = withMediator {
         val tenant = createTenant("Test Tenant")
-        val uploaded = UploadAsset(tenant.id, "test.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        val uploaded = UploadAsset(tenant.id, "test.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val deleted = DeleteAsset(tenantId = tenant.id, assetId = uploaded.id).execute()
         assertThat(deleted).isTrue()
@@ -137,8 +139,8 @@ class AssetIntegrationTest : IntegrationTestBase() {
         val tenant1 = createTenant("Tenant 1")
         val tenant2 = createTenant("Tenant 2")
 
-        UploadAsset(tenant1.id, "tenant1-logo.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
-        UploadAsset(tenant2.id, "tenant2-logo.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        UploadAsset(tenant1.id, "tenant1-logo.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
+        UploadAsset(tenant2.id, "tenant2-logo.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val tenant1Assets = ListAssets(tenantId = tenant1.id).query()
         val tenant2Assets = ListAssets(tenantId = tenant2.id).query()
@@ -154,7 +156,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
         val tenant1 = createTenant("Tenant 1")
         val tenant2 = createTenant("Tenant 2")
 
-        val uploaded = UploadAsset(tenant1.id, "secret.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        val uploaded = UploadAsset(tenant1.id, "secret.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val content = GetAssetContent(tenantId = tenant2.id, assetId = uploaded.id).query()
 
@@ -168,7 +170,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
             val oversizedContent = ByteArray(5 * 1024 * 1024 + 1) // 5MB + 1 byte
 
             assertThatThrownBy {
-                UploadAsset(tenant.id, "huge.png", AssetMediaType.PNG, oversizedContent, 100, 100).execute()
+                UploadAsset(tenant.id, "huge.png", AssetMediaType.PNG, oversizedContent, 100, 100, CatalogKey.DEFAULT).execute()
             }.isInstanceOf(AssetTooLargeException::class.java)
         }
     }
@@ -179,7 +181,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
             val tenant = createTenant("Test Tenant")
 
             assertThatThrownBy {
-                UploadAsset(tenant.id, "  ", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+                UploadAsset(tenant.id, "  ", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
             }.isInstanceOf(IllegalArgumentException::class.java)
         }
     }
@@ -196,6 +198,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
             content = svgBytes,
             width = null,
             height = null,
+            catalogKey = CatalogKey.DEFAULT,
         ).execute()
 
         assertThat(asset.width).isNull()
@@ -208,7 +211,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
         withMediator {
             val tenant = createTenant("Test Tenant")
             val tenantId = TenantId(tenant.id)
-            val asset = UploadAsset(tenant.id, "header.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+            val asset = UploadAsset(tenant.id, "header.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
             val templateKey = TestIdHelpers.nextTemplateId()
             val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
@@ -231,7 +234,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
     fun `find asset usages returns template info for referenced asset`() = withMediator {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
-        val asset = UploadAsset(tenant.id, "logo.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        val asset = UploadAsset(tenant.id, "logo.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
@@ -252,7 +255,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
     @Test
     fun `find asset usages returns empty for unused asset`() = withMediator {
         val tenant = createTenant("Test Tenant")
-        val asset = UploadAsset(tenant.id, "unused.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        val asset = UploadAsset(tenant.id, "unused.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val usages = FindAssetUsages(tenantId = tenant.id, assetId = asset.id).query()
 
@@ -263,7 +266,7 @@ class AssetIntegrationTest : IntegrationTestBase() {
     fun `delete asset succeeds when asset removed from template`() = withMediator {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
-        val asset = UploadAsset(tenant.id, "temp.png", AssetMediaType.PNG, testPngBytes, 1, 1).execute()
+        val asset = UploadAsset(tenant.id, "temp.png", AssetMediaType.PNG, testPngBytes, 1, 1, CatalogKey.DEFAULT).execute()
 
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogDeletionTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogDeletionTest.kt
@@ -237,6 +237,7 @@ class CatalogDeletionTest : IntegrationTestBase() {
                     content = createMinimalPng(),
                     width = 1,
                     height = 1,
+                    catalogKey = CatalogKey.DEFAULT,
                 ).execute()
 
                 // Create a template that uses the asset
@@ -271,6 +272,7 @@ class CatalogDeletionTest : IntegrationTestBase() {
                     content = createMinimalPng(),
                     width = 1,
                     height = 1,
+                    catalogKey = CatalogKey.DEFAULT,
                 ).execute()
 
                 // Create a template that uses the asset

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -34,7 +34,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("5.0")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("5.1")
         }
     }
 

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalogTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalogTest.kt
@@ -8,9 +8,13 @@ import app.epistola.suite.common.ids.TemplateKey
 import app.epistola.suite.common.ids.TenantId
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
+import app.epistola.suite.templates.commands.CreateDocumentTemplate
+import app.epistola.suite.templates.commands.UpdateDocumentTemplate
 import app.epistola.suite.templates.queries.GetDocumentTemplate
 import app.epistola.suite.testing.IntegrationTestBase
+import app.epistola.suite.testing.TestIdHelpers
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -120,6 +124,55 @@ class UpgradeCatalogTest : IntegrationTestBase() {
             val upgradedSlugs = result.installResults.map { it.slug }.toSet()
             assertThat(upgradedSlugs).contains("corporate")
             assertThat(upgradedSlugs).doesNotContain("hello-world", "simple-letter", "demo-invoice")
+        }
+    }
+
+    @Test
+    fun `upgrade is rejected when removing a theme referenced by another catalog`() {
+        val tenant = createTenant("Upgrade Conflict Test")
+        val tenantId = TenantId(tenant.id)
+        val catalogKey = CatalogKey.of("epistola-demo")
+        val defaultCatalogId = CatalogId(CatalogKey.DEFAULT, tenantId)
+
+        withMediator {
+            // Install demo catalog with all resources (includes "corporate" theme)
+            RegisterCatalog(tenantKey = tenant.id, sourceUrl = DEMO_CATALOG_URL, authType = AuthType.NONE).execute()
+            InstallFromCatalog(tenantKey = tenant.id, catalogKey = catalogKey).execute()
+
+            // Create a template in the default catalog that references the demo catalog's theme
+            val templateKey = TestIdHelpers.nextTemplateId()
+            val templateId = TemplateId(templateKey, defaultCatalogId)
+            CreateDocumentTemplate(id = templateId, name = "Cross-Ref Template").execute()
+            UpdateDocumentTemplate(
+                id = templateId,
+                themeId = app.epistola.suite.common.ids.ThemeKey.of("corporate"),
+                themeCatalogKey = catalogKey,
+            ).execute()
+
+            // Manually insert a stale theme that is NOT in the manifest but IS referenced
+            jdbi.useHandle<Exception> { handle ->
+                handle.createUpdate(
+                    """
+                    INSERT INTO themes (id, tenant_key, catalog_key, name, created_at, last_modified)
+                    VALUES ('stale-theme', :t, :c, 'Stale Theme', NOW(), NOW())
+                    """,
+                ).bind("t", tenant.id).bind("c", catalogKey).execute()
+            }
+
+            // Point the cross-ref template at the stale theme
+            UpdateDocumentTemplate(
+                id = templateId,
+                themeId = app.epistola.suite.common.ids.ThemeKey.of("stale-theme"),
+                themeCatalogKey = catalogKey,
+            ).execute()
+
+            // Upgrade should be rejected because stale-theme is referenced
+            assertThatThrownBy {
+                UpgradeCatalog(tenantKey = tenant.id, catalogKey = catalogKey).execute()
+            }
+                .isInstanceOf(CatalogUpgradeConflictException::class.java)
+                .hasMessageContaining("stale-theme")
+                .hasMessageContaining("Cross-Ref Template")
         }
     }
 }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalogTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalogTest.kt
@@ -1,0 +1,125 @@
+package app.epistola.suite.catalog.commands
+
+import app.epistola.suite.catalog.AuthType
+import app.epistola.suite.catalog.CatalogKey
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TemplateKey
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.mediator.query
+import app.epistola.suite.templates.queries.GetDocumentTemplate
+import app.epistola.suite.testing.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.jdbi.v3.core.Jdbi
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+private const val DEMO_CATALOG_URL = "classpath:demo/catalog/catalog.json"
+
+class UpgradeCatalogTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var jdbi: Jdbi
+
+    @Test
+    fun `upgrade updates installed resources and version`() {
+        val tenant = createTenant("Upgrade All Test")
+
+        withMediator {
+            RegisterCatalog(
+                tenantKey = tenant.id,
+                sourceUrl = DEMO_CATALOG_URL,
+                authType = AuthType.NONE,
+            ).execute()
+
+            InstallFromCatalog(
+                tenantKey = tenant.id,
+                catalogKey = CatalogKey.of("epistola-demo"),
+            ).execute()
+
+            val result = UpgradeCatalog(
+                tenantKey = tenant.id,
+                catalogKey = CatalogKey.of("epistola-demo"),
+            ).execute()
+
+            assertThat(result.newVersion).isNotBlank()
+            assertThat(result.installResults).isNotEmpty()
+            assertThat(result.installResults.filter { it.status == InstallStatus.FAILED }).isEmpty()
+        }
+    }
+
+    @Test
+    fun `upgrade removes stale resources`() {
+        val tenant = createTenant("Upgrade Stale Test")
+        val catalogKey = CatalogKey.of("epistola-demo")
+
+        withMediator {
+            RegisterCatalog(
+                tenantKey = tenant.id,
+                sourceUrl = DEMO_CATALOG_URL,
+                authType = AuthType.NONE,
+            ).execute()
+
+            InstallFromCatalog(
+                tenantKey = tenant.id,
+                catalogKey = catalogKey,
+            ).execute()
+
+            // Manually insert a fake template that is not in the manifest
+            jdbi.useHandle<Exception> { handle ->
+                handle.createUpdate(
+                    "INSERT INTO document_templates (id, tenant_key, catalog_key, name, created_at, last_modified) VALUES ('stale-template', :tenantKey, :catalogKey, 'Stale', NOW(), NOW())",
+                )
+                    .bind("tenantKey", tenant.id)
+                    .bind("catalogKey", catalogKey)
+                    .execute()
+            }
+
+            val result = UpgradeCatalog(
+                tenantKey = tenant.id,
+                catalogKey = catalogKey,
+            ).execute()
+
+            assertThat(result.removedResources).anyMatch { it.slug == "stale-template" }
+
+            val templateId = TemplateId(
+                TemplateKey.of("stale-template"),
+                CatalogId(catalogKey, TenantId(tenant.id)),
+            )
+            val staleTemplate = GetDocumentTemplate(templateId).query()
+            assertThat(staleTemplate).isNull()
+        }
+    }
+
+    @Test
+    fun `upgrade only upgrades previously installed resources`() {
+        val tenant = createTenant("Upgrade Selective Test")
+        val catalogKey = CatalogKey.of("epistola-demo")
+
+        withMediator {
+            RegisterCatalog(
+                tenantKey = tenant.id,
+                sourceUrl = DEMO_CATALOG_URL,
+                authType = AuthType.NONE,
+            ).execute()
+
+            // Install only a specific resource (corporate theme)
+            InstallFromCatalog(
+                tenantKey = tenant.id,
+                catalogKey = catalogKey,
+                resourceSlugs = listOf("corporate"),
+            ).execute()
+
+            val result = UpgradeCatalog(
+                tenantKey = tenant.id,
+                catalogKey = catalogKey,
+            ).execute()
+
+            // Only previously installed resources should be upgraded
+            val upgradedSlugs = result.installResults.map { it.slug }.toSet()
+            assertThat(upgradedSlugs).contains("corporate")
+            assertThat(upgradedSlugs).doesNotContain("hello-world", "simple-letter", "demo-invoice")
+        }
+    }
+}

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/commands/CreateStencilTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/commands/CreateStencilTest.kt
@@ -1,0 +1,41 @@
+package app.epistola.suite.stencils.commands
+
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.StencilId
+import app.epistola.suite.common.ids.StencilVersionId
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.VersionKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.mediator.query
+import app.epistola.suite.stencils.queries.GetStencilVersion
+import app.epistola.suite.testing.IntegrationTestBase
+import app.epistola.suite.testing.TestIdHelpers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CreateStencilTest : IntegrationTestBase() {
+
+    @Test
+    fun `create stencil without content produces a loadable draft version`() {
+        val tenant = createTenant("Test Tenant")
+        val tenantId = TenantId(tenant.id)
+        val id = StencilId(TestIdHelpers.nextStencilId(), CatalogId.default(tenantId))
+
+        withMediator {
+            CreateStencil(
+                id = id,
+                name = "Empty Stencil",
+            ).execute()
+
+            val versionId = StencilVersionId(VersionKey.of(1), id)
+            val version = GetStencilVersion(versionId = versionId).query()
+
+            assertThat(version).isNotNull
+            assertThat(version!!.content).isNotNull
+            assertThat(version.content.root).isNotNull
+            assertThat(version.content.root).isEqualTo("root")
+            assertThat(version.content.nodes).containsKey("root")
+            assertThat(version.content.slots).containsKey("slot-root")
+        }
+    }
+}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockEventHandler.kt
@@ -37,11 +37,17 @@ class AddressBlockEventHandler(
         val addressNode = document.nodes[addressNodeId] ?: return
         val props = addressNode.props ?: return
 
+        val align = props["align"] as? String ?: "left"
         val topPt = ((props["top"] as? Number)?.toFloat() ?: 45f) * MM_TO_PT
-        val leftPt = ((props["left"] as? Number)?.toFloat() ?: 20f) * MM_TO_PT
+        val sideDistancePt = ((props["sideDistance"] as? Number)?.toFloat() ?: 20f) * MM_TO_PT
         val widthPt = ((props["addressWidth"] as? Number)?.toFloat() ?: 85f) * MM_TO_PT
         val heightPt = ((props["height"] as? Number)?.toFloat() ?: 45f) * MM_TO_PT
 
+        val leftPt = if (align == "right") {
+            pageSize.width - sideDistancePt - widthPt
+        } else {
+            sideDistancePt
+        }
         val rect = Rectangle(leftPt, pageSize.top - topPt - heightPt, widthPt, heightPt)
 
         val pdfCanvas = PdfCanvas(page.newContentStreamAfter(), page.resources, pdfDoc)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
@@ -15,7 +15,7 @@ import com.itextpdf.layout.element.Image
  * by [AddressBlockEventHandler].
  *
  * The aside div has:
- * - Left margin matching the address width (for left window) so text wraps beside the address
+ * - Left/right margin matching the address area so text wraps beside the address
  * - Min-height ensuring body content after starts below the address bottom
  *
  * [DirectPdfRenderer.hoistAddressBlock] moves this to the first child of root.
@@ -33,16 +33,16 @@ class AddressBlockNodeRenderer : NodeRenderer {
         registry: NodeRendererRegistry,
     ): List<IElement> {
         val props = node.props ?: return emptyList()
-        val standard = props["standard"] as? String ?: "din-c56-left"
+        val align = props["align"] as? String ?: "left"
         val topMm = (props["top"] as? Number)?.toFloat() ?: 45f
-        val leftMm = (props["left"] as? Number)?.toFloat() ?: 20f
+        val sideDistanceMm = (props["sideDistance"] as? Number)?.toFloat() ?: 20f
         val addressWidthMm = (props["addressWidth"] as? Number)?.toFloat() ?: 85f
         val heightMm = (props["height"] as? Number)?.toFloat() ?: 45f
 
         val addressBottomPt = (topMm + heightMm) * MM_TO_PT
 
-        val pageMargins = document.pageSettingsOverride?.margins
-            ?: context.renderingDefaults.defaultPageSettings.margins
+        val pageSettings = document.pageSettingsOverride ?: context.renderingDefaults.defaultPageSettings
+        val pageMargins = pageSettings.margins
         val pageTopMarginPt = pageMargins.top.toFloat() * MM_TO_PT
         val pageLeftMarginPt = pageMargins.left.toFloat() * MM_TO_PT
 
@@ -55,7 +55,7 @@ class AddressBlockNodeRenderer : NodeRenderer {
         }
 
         val contentAreaTopPt = pageTopMarginPt + headerHeightPt
-        val isRightWindow = standard == "din-c56-right"
+        val isRight = align == "right"
 
         // Render aside slot
         val slotsByName = node.slots.mapNotNull { slotId ->
@@ -65,23 +65,17 @@ class AddressBlockNodeRenderer : NodeRenderer {
 
         val asideDiv = Div()
         // Margin on the address side to leave room for the absolute-positioned address.
-        // The address right edge (from page edge) minus the content area left edge (page left margin)
-        // gives the margin needed in the content area.
         val gapPt = 4f * MM_TO_PT // small gap between address and aside
-        if (isRightWindow) {
-            val pageSettings = document.pageSettingsOverride ?: context.renderingDefaults.defaultPageSettings
-            val pageWidthMm = when (pageSettings.format) {
-                PageFormat.A4 -> if (pageSettings.orientation == Orientation.landscape) 297f else 210f
-                PageFormat.Letter -> if (pageSettings.orientation == Orientation.landscape) 279.4f else 215.9f
-                PageFormat.Custom -> if (pageSettings.orientation == Orientation.landscape) 297f else 210f
-            }
+        if (isRight) {
+            // sideDistance is from the right page edge; compute margin from content area right edge
+            val pageWidthMm = pageWidthMm(pageSettings.format, pageSettings.orientation)
+            val addressLeftEdgePt = (pageWidthMm - sideDistanceMm - addressWidthMm) * MM_TO_PT
             val contentRightEdgePt = (pageWidthMm - pageMargins.right.toFloat()) * MM_TO_PT
-            val addressLeftEdgePt = leftMm * MM_TO_PT
             asideDiv.setMarginRight(maxOf(0f, contentRightEdgePt - addressLeftEdgePt + gapPt))
         } else {
-            val addressRightEdgeFromPageEdge = (leftMm + addressWidthMm) * MM_TO_PT
-            val addressRightEdgeFromContentLeft = addressRightEdgeFromPageEdge - pageLeftMarginPt
-            asideDiv.setMarginLeft(maxOf(0f, addressRightEdgeFromContentLeft + gapPt))
+            // sideDistance is from the left page edge
+            val addressRightEdgePt = (sideDistanceMm + addressWidthMm) * MM_TO_PT
+            asideDiv.setMarginLeft(maxOf(0f, addressRightEdgePt - pageLeftMarginPt + gapPt))
         }
         asideDiv.setMarginTop(0f)
         asideDiv.setMarginBottom(0f)
@@ -97,5 +91,11 @@ class AddressBlockNodeRenderer : NodeRenderer {
         }
 
         return listOf(asideDiv)
+    }
+
+    private fun pageWidthMm(format: PageFormat, orientation: Orientation): Float = when (format) {
+        PageFormat.A4 -> if (orientation == Orientation.landscape) 297f else 210f
+        PageFormat.Letter -> if (orientation == Orientation.landscape) 279.4f else 215.9f
+        PageFormat.Custom -> if (orientation == Orientation.landscape) 297f else 210f
     }
 }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/AddressBlockNodeRenderer.kt
@@ -1,6 +1,8 @@
 package app.epistola.generation.pdf
 
 import app.epistola.template.model.Node
+import app.epistola.template.model.Orientation
+import app.epistola.template.model.PageFormat
 import app.epistola.template.model.TemplateDocument
 import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IBlockElement
@@ -37,7 +39,6 @@ class AddressBlockNodeRenderer : NodeRenderer {
         val addressWidthMm = (props["addressWidth"] as? Number)?.toFloat() ?: 85f
         val heightMm = (props["height"] as? Number)?.toFloat() ?: 45f
 
-        val addressWidthPt = addressWidthMm * MM_TO_PT
         val addressBottomPt = (topMm + heightMm) * MM_TO_PT
 
         val pageMargins = document.pageSettingsOverride?.margins
@@ -68,8 +69,15 @@ class AddressBlockNodeRenderer : NodeRenderer {
         // gives the margin needed in the content area.
         val gapPt = 4f * MM_TO_PT // small gap between address and aside
         if (isRightWindow) {
-            val addressLeftFromContentRight = addressWidthPt + gapPt
-            asideDiv.setMarginRight(addressLeftFromContentRight)
+            val pageSettings = document.pageSettingsOverride ?: context.renderingDefaults.defaultPageSettings
+            val pageWidthMm = when (pageSettings.format) {
+                PageFormat.A4 -> if (pageSettings.orientation == Orientation.landscape) 297f else 210f
+                PageFormat.Letter -> if (pageSettings.orientation == Orientation.landscape) 279.4f else 215.9f
+                PageFormat.Custom -> if (pageSettings.orientation == Orientation.landscape) 297f else 210f
+            }
+            val contentRightEdgePt = (pageWidthMm - pageMargins.right.toFloat()) * MM_TO_PT
+            val addressLeftEdgePt = leftMm * MM_TO_PT
+            asideDiv.setMarginRight(maxOf(0f, contentRightEdgePt - addressLeftEdgePt + gapPt))
         } else {
             val addressRightEdgeFromPageEdge = (leftMm + addressWidthMm) * MM_TO_PT
             val addressRightEdgeFromContentLeft = addressRightEdgeFromPageEdge - pageLeftMarginPt

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/AddressBlockTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/AddressBlockTest.kt
@@ -45,7 +45,7 @@ class AddressBlockTest {
                     props = mapOf(
                         "standard" to "din-c56-left",
                         "top" to 45,
-                        "left" to 20,
+                        "sideDistance" to 20,
                         "addressWidth" to 85,
                         "height" to 45,
                     ) + addressProps,
@@ -103,7 +103,7 @@ class AddressBlockTest {
     fun `renders with DIN C5-6 right window`() {
         val pdf = renderToBytes(
             documentWithAddressBlock(
-                addressProps = mapOf("standard" to "din-c56-right", "left" to 105),
+                addressProps = mapOf("align" to "right", "sideDistance" to 20),
             ),
         )
         assertTrue(pdf.isNotEmpty())
@@ -113,7 +113,7 @@ class AddressBlockTest {
     fun `renders with custom position`() {
         val pdf = renderToBytes(
             documentWithAddressBlock(
-                addressProps = mapOf("standard" to "custom", "top" to 30, "left" to 50, "addressWidth" to 70, "height" to 30),
+                addressProps = mapOf("top" to 30, "sideDistance" to 50, "addressWidth" to 70, "height" to 30),
             ),
         )
         assertTrue(pdf.isNotEmpty())
@@ -135,7 +135,7 @@ class AddressBlockTest {
                     id = "addressblock",
                     type = "addressblock",
                     slots = listOf(addressSlotId, asideSlotId),
-                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                    props = mapOf("top" to 45, "sideDistance" to 20, "addressWidth" to 85, "height" to 45),
                 ),
                 "address-text" to textNode("address-text", "Nested Address"),
                 "aside-text" to textNode("aside-text", "Nested Aside"),
@@ -163,7 +163,7 @@ class AddressBlockTest {
                     id = "addressblock",
                     type = "addressblock",
                     slots = listOf("slot-address", "slot-aside"),
-                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                    props = mapOf("top" to 45, "sideDistance" to 20, "addressWidth" to 85, "height" to 45),
                 ),
                 "address-text" to Node(
                     id = "address-text",
@@ -215,7 +215,7 @@ class AddressBlockTest {
                     id = "addressblock",
                     type = "addressblock",
                     slots = listOf(addressSlotId, asideSlotId),
-                    props = mapOf("top" to 45, "left" to 20, "addressWidth" to 85, "height" to 45),
+                    props = mapOf("top" to 45, "sideDistance" to 20, "addressWidth" to 85, "height" to 45),
                 ),
                 "address-text" to textNode("address-text", "PAGE ONE ADDRESS"),
                 "aside-text" to textNode("aside-text", "Reference"),

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/AddressBlockTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/AddressBlockTest.kt
@@ -101,12 +101,15 @@ class AddressBlockTest {
 
     @Test
     fun `renders with DIN C5-6 right window`() {
-        val pdf = renderToBytes(
+        val text = renderAndExtract(
             documentWithAddressBlock(
                 addressProps = mapOf("align" to "right", "sideDistance" to 20),
+                addressText = "Right Window Recipient",
+                asideText = "Right Window Reference",
             ),
         )
-        assertTrue(pdf.isNotEmpty())
+        assertContains(text, "Right Window Recipient", message = "Address content should appear in right-window PDF")
+        assertContains(text, "Right Window Reference", message = "Aside content should appear in right-window PDF")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Stencil creation**: Fixed crash when saving a new stencil — empty `{}` content replaced with valid minimal TemplateDocument
- **API docs**: Fixed 404 on OpenAPI spec — resource handler used exact path instead of wildcard
- **Catalog export/import**: `themeCatalogKey` now preserved in exports and ZIP imports; cross-catalog asset references bundled in ZIP
- **Catalog import dialog**: Errors display inline instead of replacing dialog with full page
- **Catalog delete dialog**: Errors now shown in confirm dialog (422 JSON response for HTMX)
- **Address block**: Replaced `left` prop with `align` + `sideDistance` for intuitive left/right positioning; envelope standard is now a preset
- **UpgradeCatalog command**: In-place catalog upgrades with compatibility validation — checks for cross-catalog conflicts before mutating, bumps version last
- **Catalog resource usage**: Per-resource usage counts on browse page with clickable detail dialog
- **Asset catalog scoping**: `catalogKey` is now required on upload (no more DEFAULT fallback); editor passes catalog context
- **Asset export path**: Consistent `resources/asset/` folder in exported ZIPs

## Test plan

- [x] `./gradlew unitTest integrationTest` — all pass
- [x] New tests: `UpgradeCatalogTest` (4 tests), `CreateStencilTest`, enhanced `AddressBlockTest` and `CatalogExportImportTest`
- [ ] Manual: verify address block right-window positioning in editor + PDF preview
- [ ] Manual: export/import catalog round-trip with themes and assets
- [ ] Manual: upload asset in non-default catalog, verify correct catalog_key in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)