### PR TITLE
Border input UX, table borders via CSS, and cell-scoped inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Border input UX**: The per-side border input now shows the style dropdown (None/Solid/Dashed/Dotted) on top and the width/unit/color controls below. Width/unit/color are hidden when style is `None`. New borders default to `None` instead of `Solid`, and the width is clamped to at least 0.5 in the active unit whenever a visible style is chosen.
+- **Table borders via CSS only**: Removed the `borderStyle`/`borderColor`/`borderWidth` props on the `table` component and the "Border Style" inspector dropdown. Borders are now set exclusively via the CSS `border` property — on the node for the outer table border, or on selected cells for per-cell borders. Default cell borders are suppressed; new tables render borderless until the user opts in.
+- **Table inspector scoping**: Selecting a cell shows only cell-specific controls (merge actions and cell style). Selecting the table without a cell shows only table-level controls (rows, columns, widths, header rows, and node styles). Previously both sets were shown at once, which caused confusion about which properties applied where.
+
 ## [0.16.0] - 2026-04-23
 
 ### Added
@@ -37,19 +43,6 @@
 - **Catalog import dialog**: Import errors now display inline in the dialog instead of replacing the dialog content with the full catalog list page.
 - **Catalog delete dialog**: Delete errors (e.g. "catalog in use") now display in the confirm dialog instead of silently failing. Returns 422 with JSON error for HTMX requests.
 - **Address block positioning**: Replaced `left` prop with `align` (`left`/`right`) and `sideDistance` (distance from the aligned page edge). The `standard` select now acts as a preset that populates these properties. Previously, right-window positioning required manually computing the left offset from the page edge.
-
-### Added
-
-- **Catalog resource usage**: The catalog browse page shows per-resource usage counts from other catalogs. Clicking a count opens a dialog listing which templates reference that resource.
-- **`UpgradeCatalog` command**: Upgrades a subscribed catalog in place — re-fetches the manifest, updates metadata and version, upgrades previously installed resources, and removes installed resources no longer in the manifest. Replaces the old unregister/re-register approach which failed when other templates referenced the catalog's themes.
-- **Catalog theme references**: Templates imported from catalogs now carry a `themeId` that links them to a theme in the same catalog. Previously imported templates always had `theme_key = NULL`, requiring themeRef overrides in the templateModel. The theme reference is set on import, included in exports, and updated on reimport.
-
-### Changed
-
-- **Demo templates**: Replaced `themeRef` overrides (which lock the theme at the variant level) with `themeId` at the resource level, allowing the theme to be changed from the template settings page.
-- **Border input UX**: The per-side border input now shows the style dropdown (None/Solid/Dashed/Dotted) on top and the width/unit/color controls below. Width/unit/color are hidden when style is `None`. New borders default to `None` instead of `Solid`, and the width is clamped to at least 0.5 in the active unit whenever a visible style is chosen.
-- **Table borders via CSS only**: Removed the `borderStyle`/`borderColor`/`borderWidth` props on the `table` component and the "Border Style" inspector dropdown. Borders are now set exclusively via the CSS `border` property — on the node for the outer table border, or on selected cells for per-cell borders. Default cell borders are suppressed; new tables render borderless until the user opts in.
-- **Table inspector scoping**: Selecting a cell shows only cell-specific controls (merge actions and cell style). Selecting the table without a cell shows only table-level controls (rows, columns, widths, header rows, and node styles). Previously both sets were shown at once, which caused confusion about which properties applied where.
 
 ## [0.15.0] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 ### Changed
 
 - **Demo templates**: Replaced `themeRef` overrides (which lock the theme at the variant level) with `themeId` at the resource level, allowing the theme to be changed from the template settings page.
+- **Border input UX**: The per-side border input now shows the style dropdown (None/Solid/Dashed/Dotted) on top and the width/unit/color controls below. Width/unit/color are hidden when style is `None`. New borders default to `None` instead of `Solid`, and the width is clamped to at least 0.5 in the active unit whenever a visible style is chosen.
+- **Table borders via CSS only**: Removed the `borderStyle`/`borderColor`/`borderWidth` props on the `table` component and the "Border Style" inspector dropdown. Borders are now set exclusively via the CSS `border` property — on the node for the outer table border, or on selected cells for per-cell borders. Default cell borders are suppressed; new tables render borderless until the user opts in.
+- **Table inspector scoping**: Selecting a cell shows only cell-specific controls (merge actions and cell style). Selecting the table without a cell shows only table-level controls (rows, columns, widths, header rows, and node styles). Previously both sets were shown at once, which caused confusion about which properties applied where.
 
 ## [0.15.0] - 2026-04-20
 

--- a/modules/editor/src/main/typescript/components/table/TableInspector.ts
+++ b/modules/editor/src/main/typescript/components/table/TableInspector.ts
@@ -74,13 +74,17 @@ export class TableInspector extends LitElement {
   }
 
   override render() {
+    // When a cell is selected, show cell-only controls. When only the table
+    // is selected (no cell selection), show table-only controls.
+    if (this._cellSelection) {
+      return html` ${this._renderMergeControls()} ${this._renderCellStyles()} `;
+    }
     return html`
       <div class="inspector-section">
         <div class="inspector-section-label">Table Layout</div>
         ${this._renderRowCount()} ${this._renderColumnCount()} ${this._renderColumnWidths()}
-        ${this._renderHeaderRows()} ${this._renderMergeControls()}
+        ${this._renderHeaderRows()}
       </div>
-      ${this._renderCellStyles()}
     `;
   }
 

--- a/modules/editor/src/main/typescript/components/table/table-commands.ts
+++ b/modules/editor/src/main/typescript/components/table/table-commands.ts
@@ -116,7 +116,6 @@ function getTableProps(node: Node) {
     columnWidths: (props.columnWidths as number[]) ?? [],
     merges: (props.merges as CellMerge[]) ?? [],
     headerRows: (props.headerRows as number) ?? 0,
-    borderStyle: (props.borderStyle as string) ?? 'all',
   };
 }
 

--- a/modules/editor/src/main/typescript/components/table/table-registration.ts
+++ b/modules/editor/src/main/typescript/components/table/table-registration.ts
@@ -223,6 +223,23 @@ export function createTableDefinition(): ComponentDefinition {
       return html`<table-inspector .node=${node} .engine=${engine}></table-inspector>`;
     },
 
+    // When a cell is selected, replace the generic inspector header label
+    // and hide all node-level sections so only the table-inspector's
+    // cell-specific controls remain visible.
+    getInspectorPresentation: (_node, eng) => {
+      const engine = eng as EditorEngine;
+      if (engine.getComponentState<CellSelection>('table:cellSelection') == null) {
+        return undefined;
+      }
+      return {
+        label: 'Table Cell',
+        suppressPropsSection: true,
+        suppressStylePresetSection: true,
+        suppressStylesSection: true,
+        suppressDeleteSection: true,
+      };
+    },
+
     // ----- Palette pre-insert hook -----
     onBeforeInsert: async () => {
       const result = await openTableDialog();

--- a/modules/editor/src/main/typescript/components/table/table-registration.ts
+++ b/modules/editor/src/main/typescript/components/table/table-registration.ts
@@ -32,7 +32,6 @@ export const TABLE_DEFAULT_PROPS = {
   rows: 2,
   columns: 2,
   columnWidths: [50, 50],
-  borderStyle: 'all',
   headerRows: 0,
   merges: [],
 };
@@ -58,20 +57,7 @@ export function createTableDefinition(): ComponentDefinition {
     allowedChildren: { mode: 'all' },
     applicableStyles: LAYOUT_STYLES,
     defaultStyles: { marginBottom: '1.5sp' },
-    inspector: [
-      {
-        key: 'borderStyle',
-        label: 'Border Style',
-        type: 'select',
-        options: [
-          { label: 'None', value: 'none' },
-          { label: 'All', value: 'all' },
-          { label: 'Horizontal', value: 'horizontal' },
-          { label: 'Vertical', value: 'vertical' },
-        ],
-        defaultValue: 'all',
-      },
-    ],
+    inspector: [],
     defaultProps: { ...TABLE_DEFAULT_PROPS },
     createInitialSlots: (nodeId: NodeId, props?: Record<string, unknown>) => {
       const rows = (props?.rows as number | undefined) ?? TABLE_DEFAULT_PROPS.rows;
@@ -105,7 +91,6 @@ export function createTableDefinition(): ComponentDefinition {
       const columnWidths = (props.columnWidths as number[]) ?? [];
       const merges = (props.merges as CellMerge[]) ?? [];
       const headerRows = (props.headerRows as number) ?? 0;
-      const borderStyle = (props.borderStyle as string) ?? 'all';
 
       if (rows <= 0 || columns <= 0) return html`<div class="table-canvas-empty">Empty table</div>`;
 
@@ -212,7 +197,7 @@ export function createTableDefinition(): ComponentDefinition {
 
       return html`
         <div
-          class="table-canvas-grid border-${borderStyle}"
+          class="table-canvas-grid"
           style=${styleMap({ 'grid-template-columns': gridTemplateColumns })}
         >
           ${cells}

--- a/modules/editor/src/main/typescript/components/table/table-registration.ts
+++ b/modules/editor/src/main/typescript/components/table/table-registration.ts
@@ -141,6 +141,17 @@ export function createTableDefinition(): ComponentDefinition {
         engine.setComponentState('table:cellSelection', newSel);
       };
 
+      // Click on the grid wrapper outside any cell: clear the cell selection
+      // so the inspector returns to table-level controls. `selectNode` is a
+      // no-op when the table is already selected, so clearing the component
+      // state is the only reliable exit path that keeps the table selected.
+      const handleGridClick = (e: MouseEvent) => {
+        if (e.target !== e.currentTarget) return;
+        if (engine.getComponentState<CellSelection>('table:cellSelection') == null) return;
+        engine.setComponentState('table:cellSelection', null);
+        e.stopPropagation();
+      };
+
       // Build cells
       const cells: unknown[] = [];
       for (let r = 0; r < rows; r++) {
@@ -199,6 +210,7 @@ export function createTableDefinition(): ComponentDefinition {
         <div
           class="table-canvas-grid"
           style=${styleMap({ 'grid-template-columns': gridTemplateColumns })}
+          @click=${handleGridClick}
         >
           ${cells}
         </div>

--- a/modules/editor/src/main/typescript/components/table/table.css
+++ b/modules/editor/src/main/typescript/components/table/table.css
@@ -23,26 +23,9 @@
     cursor: default;
   }
 
-  /* Border variants */
-  .table-canvas-grid.border-all .table-canvas-cell {
-    border: 1px solid var(--ep-gray-300);
-  }
-
-  .table-canvas-grid.border-horizontal .table-canvas-cell {
-    border-top: 1px solid var(--ep-gray-300);
-    border-bottom: 1px solid var(--ep-gray-300);
-    border-left: none;
-    border-right: none;
-  }
-
-  .table-canvas-grid.border-vertical .table-canvas-cell {
-    border-top: none;
-    border-bottom: none;
-    border-left: 1px solid var(--ep-gray-300);
-    border-right: 1px solid var(--ep-gray-300);
-  }
-
-  .table-canvas-grid.border-none .table-canvas-cell {
+  /* Canvas-only placeholder grid. Real borders come from inline styles
+     (cellStyle['border-top'] etc.) which override this rule. */
+  .table-canvas-grid .table-canvas-cell {
     border: 1px dashed var(--ep-gray-200);
   }
 

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -71,6 +71,24 @@ export interface ScopeDeclaration {
   evaluationData?: Record<string, unknown>;
 }
 
+/**
+ * Lets a component customise how the generic inspector renders for the current
+ * node — without the inspector needing any knowledge of the component's type
+ * or internal state. All fields are optional; `undefined` means "use defaults".
+ */
+export interface InspectorPresentation {
+  /** Override the node label rendered in the inspector header. */
+  label?: string;
+  /** Hide the generic Props section. */
+  suppressPropsSection?: boolean;
+  /** Hide the generic Style Preset section. */
+  suppressStylePresetSection?: boolean;
+  /** Hide the generic Styles section. */
+  suppressStylesSection?: boolean;
+  /** Hide the generic Delete section. */
+  suppressDeleteSection?: boolean;
+}
+
 export interface ComponentDefinition {
   type: string;
   label: string;
@@ -136,6 +154,13 @@ export interface ComponentDefinition {
 
   /** Custom inspector section rendered above generic props. */
   renderInspector?: (ctx: { node: Node; engine: unknown }) => unknown;
+
+  /**
+   * Lets a component customise the generic inspector's presentation (label
+   * override, hide standard sections) based on the current node and engine
+   * state. Return `undefined` to use the defaults.
+   */
+  getInspectorPresentation?: (node: Node, engine: unknown) => InspectorPresentation | undefined;
 
   /** Called before dispatching prop changes. Can transform props (e.g. lock aspect ratio). */
   onPropChange?: (

--- a/modules/editor/src/main/typescript/styles/inspector.css
+++ b/modules/editor/src/main/typescript/styles/inspector.css
@@ -187,7 +187,7 @@
   .style-border-side-group {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: var(--ep-space-2);
   }
 
   .style-border-row {
@@ -231,8 +231,8 @@
   }
 
   .style-border-color-text {
-    width: 68px;
-    flex-shrink: 0;
+    flex: 1;
+    min-width: 68px;
   }
 
   .style-border-color-picker {

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.test.ts
@@ -638,3 +638,101 @@ describe('EpistolaEditor block clipboard', () => {
     expect(editorAny._pasteDialogOpen).toBe(false);
   });
 });
+
+describe('EpistolaEditor table cell-mode exit', () => {
+  type CellSelection = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+  type EditorHandle = {
+    _handleKeydown: (event: KeyboardEvent) => void;
+    _engine: {
+      selectedNodeId: string | null;
+      selectNode: (id: string | null) => void;
+      getComponentState: <T>(key: string) => T | undefined;
+      setComponentState: (key: string, value: unknown) => void;
+    };
+  };
+
+  function escapeEvent(overrides: Partial<KeyboardEvent> = {}): {
+    event: KeyboardEvent;
+    wasPrevented: () => boolean;
+    wasStopped: () => boolean;
+  } {
+    let prevented = false;
+    let stopped = false;
+    const event = {
+      key: 'Escape',
+      code: 'Escape',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      shiftKey: false,
+      preventDefault: () => {
+        prevented = true;
+      },
+      stopPropagation: () => {
+        stopped = true;
+      },
+      ...overrides,
+    } as unknown as KeyboardEvent;
+    return {
+      event,
+      wasPrevented: () => prevented,
+      wasStopped: () => stopped,
+    };
+  }
+
+  it('Escape clears an active cell selection without deselecting the table', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as EditorHandle;
+    editorAny._engine.selectNode(textNodeId);
+    const selection: CellSelection = { startRow: 0, startCol: 0, endRow: 0, endCol: 0 };
+    editorAny._engine.setComponentState('table:cellSelection', selection);
+
+    const { event, wasPrevented, wasStopped } = escapeEvent();
+    editorAny._handleKeydown(event);
+
+    expect(editorAny._engine.getComponentState('table:cellSelection')).toBeNull();
+    expect(editorAny._engine.selectedNodeId).toBe(textNodeId);
+    expect(wasPrevented()).toBe(true);
+    expect(wasStopped()).toBe(true);
+  });
+
+  it('Escape with no cell selection falls through to the existing deselect shortcut', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as EditorHandle;
+    editorAny._engine.selectNode(textNodeId);
+    expect(editorAny._engine.getComponentState('table:cellSelection')).toBeNull();
+
+    const { event } = escapeEvent();
+    editorAny._handleKeydown(event);
+
+    // My interceptor must skip (no cell selection), letting the existing
+    // 'deselectSelectedBlock' shortcut deselect to document level.
+    expect(editorAny._engine.selectedNodeId).toBeNull();
+  });
+
+  it('modified Escape (e.g. Shift+Escape) bypasses the cell-mode exit branch', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as EditorHandle;
+    editorAny._engine.selectNode(textNodeId);
+    const selection: CellSelection = { startRow: 1, startCol: 2, endRow: 1, endCol: 2 };
+    editorAny._engine.setComponentState('table:cellSelection', selection);
+
+    const { event } = escapeEvent({ shiftKey: true });
+    editorAny._handleKeydown(event);
+
+    // If the interceptor fired for Shift+Escape, the table would stay
+    // selected (it calls stopPropagation before the shortcut resolver runs).
+    // Skipping it lets the existing deselect shortcut clear the selection.
+    expect(editorAny._engine.selectedNodeId).toBeNull();
+  });
+});

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.test.ts
@@ -652,6 +652,35 @@ describe('EpistolaEditor table cell-mode exit', () => {
     };
   };
 
+  function createDocWithTable(): { doc: TemplateDocument; tableNodeId: NodeId } {
+    const rootId = nodeId('root');
+    const rootSlotId = slotId('root-slot');
+    const tableNodeId = nodeId('table1');
+    const doc: TemplateDocument = {
+      modelVersion: 1,
+      root: rootId,
+      nodes: {
+        [rootId]: { id: rootId, type: 'root', slots: [rootSlotId] },
+        [tableNodeId]: {
+          id: tableNodeId,
+          type: 'table',
+          slots: [],
+          props: { rows: 2, columns: 2 },
+        },
+      },
+      slots: {
+        [rootSlotId]: {
+          id: rootSlotId,
+          nodeId: rootId,
+          name: 'children',
+          children: [tableNodeId],
+        },
+      },
+      themeRef: { type: 'inherit' },
+    };
+    return { doc, tableNodeId };
+  }
+
   function escapeEvent(overrides: Partial<KeyboardEvent> = {}): {
     event: KeyboardEvent;
     wasPrevented: () => boolean;
@@ -682,12 +711,12 @@ describe('EpistolaEditor table cell-mode exit', () => {
   }
 
   it('Escape clears an active cell selection without deselecting the table', () => {
-    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const { doc, tableNodeId } = createDocWithTable();
     const editor = new EpistolaEditor();
     editor.initEngine(doc, testRegistry());
 
     const editorAny = editor as unknown as EditorHandle;
-    editorAny._engine.selectNode(textNodeId);
+    editorAny._engine.selectNode(tableNodeId);
     const selection: CellSelection = { startRow: 0, startCol: 0, endRow: 0, endCol: 0 };
     editorAny._engine.setComponentState('table:cellSelection', selection);
 
@@ -695,18 +724,18 @@ describe('EpistolaEditor table cell-mode exit', () => {
     editorAny._handleKeydown(event);
 
     expect(editorAny._engine.getComponentState('table:cellSelection')).toBeNull();
-    expect(editorAny._engine.selectedNodeId).toBe(textNodeId);
+    expect(editorAny._engine.selectedNodeId).toBe(tableNodeId);
     expect(wasPrevented()).toBe(true);
     expect(wasStopped()).toBe(true);
   });
 
   it('Escape with no cell selection falls through to the existing deselect shortcut', () => {
-    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const { doc, tableNodeId } = createDocWithTable();
     const editor = new EpistolaEditor();
     editor.initEngine(doc, testRegistry());
 
     const editorAny = editor as unknown as EditorHandle;
-    editorAny._engine.selectNode(textNodeId);
+    editorAny._engine.selectNode(tableNodeId);
     expect(editorAny._engine.getComponentState('table:cellSelection')).toBeNull();
 
     const { event } = escapeEvent();
@@ -718,12 +747,12 @@ describe('EpistolaEditor table cell-mode exit', () => {
   });
 
   it('modified Escape (e.g. Shift+Escape) bypasses the cell-mode exit branch', () => {
-    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const { doc, tableNodeId } = createDocWithTable();
     const editor = new EpistolaEditor();
     editor.initEngine(doc, testRegistry());
 
     const editorAny = editor as unknown as EditorHandle;
-    editorAny._engine.selectNode(textNodeId);
+    editorAny._engine.selectNode(tableNodeId);
     const selection: CellSelection = { startRow: 1, startCol: 2, endRow: 1, endCol: 2 };
     editorAny._engine.setComponentState('table:cellSelection', selection);
 
@@ -733,6 +762,28 @@ describe('EpistolaEditor table cell-mode exit', () => {
     // If the interceptor fired for Shift+Escape, the table would stay
     // selected (it calls stopPropagation before the shortcut resolver runs).
     // Skipping it lets the existing deselect shortcut clear the selection.
+    expect(editorAny._engine.selectedNodeId).toBeNull();
+  });
+
+  it('Escape on a non-table node with stale cell-selection state does not clear the selection', () => {
+    const { doc, textNodeId } = createTestDocumentWithChildren();
+    const editor = new EpistolaEditor();
+    editor.initEngine(doc, testRegistry());
+
+    const editorAny = editor as unknown as EditorHandle;
+    editorAny._engine.selectNode(textNodeId);
+    // Spurious cell-selection state on a non-table node — the interceptor
+    // must not act on this and must let the deselect shortcut run as usual.
+    editorAny._engine.setComponentState('table:cellSelection', {
+      startRow: 0,
+      startCol: 0,
+      endRow: 0,
+      endCol: 0,
+    } satisfies CellSelection);
+
+    const { event } = escapeEvent();
+    editorAny._handleKeydown(event);
+
     expect(editorAny._engine.selectedNodeId).toBeNull();
   });
 });

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
@@ -429,13 +429,17 @@ export class EpistolaEditor extends LitElement {
     // returns to table-level controls, without deselecting the table itself.
     // `EditorEngine.selectNode` is a no-op when re-selecting the already
     // selected table, so the normal `selection:change` path can't clear this.
+    // Guard: only intercept when the selected node is actually a table to avoid
+    // swallowing Escape for unrelated selections if state is ever set spuriously.
     if (
       e.key === 'Escape' &&
       !e.ctrlKey &&
       !e.metaKey &&
       !e.altKey &&
       !e.shiftKey &&
-      this._engine.getComponentState('table:cellSelection') != null
+      this._engine.getComponentState('table:cellSelection') != null &&
+      this._selectedNodeId != null &&
+      this._engine.getNode(this._selectedNodeId)?.type === 'table'
     ) {
       this._engine.setComponentState('table:cellSelection', null);
       e.preventDefault();

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
@@ -425,6 +425,24 @@ export class EpistolaEditor extends LitElement {
       return;
     }
 
+    // Escape in table cell-mode: clear the cell selection so the inspector
+    // returns to table-level controls, without deselecting the table itself.
+    // `EditorEngine.selectNode` is a no-op when re-selecting the already
+    // selected table, so the normal `selection:change` path can't clear this.
+    if (
+      e.key === 'Escape' &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey &&
+      !e.shiftKey &&
+      this._engine.getComponentState('table:cellSelection') != null
+    ) {
+      this._engine.setComponentState('table:cellSelection', null);
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
     const inInsertDialog = this._insertDialogOpen;
     const activeContexts = inInsertDialog
       ? (['insertDialog'] as const)

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { EpistolaInspector } from './EpistolaInspector.js';
+import { EditorEngine } from '../engine/EditorEngine.js';
+import { nodeId, resetCounter, slotId, testRegistry } from '../engine/test-helpers.js';
+import type { ComponentDefinition, ComponentRegistry } from '../engine/registry.js';
+import type { NodeId, TemplateDocument } from '../types/index.js';
+
+beforeEach(() => {
+  resetCounter();
+});
+
+/**
+ * Recursively serialise a Lit `TemplateResult` (or any render value) to a flat
+ * string so tests can assert on rendered content without a real DOM. Handles
+ * nested templates, the `nothing` sentinel (a Symbol), and `.map` arrays.
+ */
+function templateToHtml(value: unknown): string {
+  if (value == null || value === false) return '';
+  if (typeof value === 'symbol') return ''; // Lit's `nothing`
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  if (Array.isArray(value)) return value.map(templateToHtml).join('');
+  if (typeof value === 'object' && 'strings' in value && 'values' in value) {
+    const tr = value as { strings: ArrayLike<string>; values: unknown[] };
+    return Array.from(tr.strings)
+      .map((s, i) => s + (i < tr.values.length ? templateToHtml(tr.values[i]) : ''))
+      .join('');
+  }
+  return '';
+}
+
+interface SetupResult {
+  engine: EditorEngine;
+  inspector: EpistolaInspector;
+  textNodeId: NodeId;
+  registry: ComponentRegistry;
+}
+
+function setupInspector(): SetupResult {
+  const rootId = nodeId('root');
+  const rootSlotId = slotId('root-slot');
+  const textNodeId = nodeId('text1');
+
+  const doc: TemplateDocument = {
+    modelVersion: 1,
+    root: rootId,
+    nodes: {
+      [rootId]: { id: rootId, type: 'root', slots: [rootSlotId] },
+      [textNodeId]: {
+        id: textNodeId,
+        type: 'text',
+        slots: [],
+        props: { content: null },
+      },
+    },
+    slots: {
+      [rootSlotId]: {
+        id: rootSlotId,
+        nodeId: rootId,
+        name: 'children',
+        children: [textNodeId],
+      },
+    },
+    themeRef: { type: 'inherit' },
+  };
+
+  const registry = testRegistry();
+  const engine = new EditorEngine(doc, registry);
+  const inspector = new EpistolaInspector();
+  inspector.engine = engine;
+  inspector.doc = engine.doc;
+  inspector.selectedNodeId = textNodeId;
+
+  return { engine, inspector, textNodeId, registry };
+}
+
+describe('EpistolaInspector generic presentation hook', () => {
+  it('renders the default component label and full generic sections when no presentation hook is provided', () => {
+    const { inspector } = setupInspector();
+
+    const html = templateToHtml(inspector.render());
+
+    // Default `text` component label.
+    expect(html).toContain('Text');
+    // Style preset and styles sections render because `applicableStyles: 'all'`.
+    expect(html).toContain('Style Preset');
+    expect(html).toContain('Styles');
+    // Delete section renders by default.
+    expect(html).toContain('Delete Block');
+  });
+
+  it('uses presentation.label and hides suppressed sections', () => {
+    const { inspector, registry } = setupInspector();
+
+    const original = registry.getOrThrow('text');
+    const overridden: ComponentDefinition = {
+      ...original,
+      getInspectorPresentation: () => ({
+        label: 'Custom Label',
+        suppressPropsSection: true,
+        suppressStylePresetSection: true,
+        suppressStylesSection: true,
+        suppressDeleteSection: true,
+      }),
+    };
+    registry.register(overridden);
+
+    const html = templateToHtml(inspector.render());
+
+    expect(html).toContain('Custom Label');
+    expect(html).not.toContain('Style Preset');
+    expect(html).not.toContain('Delete Block');
+    // The component-specific renderInspector still runs (text has none, so
+    // nothing extra here), and the inspector header (label + id) still shows.
+  });
+
+  it('falls back to def.getLabel when presentation does not provide a label', () => {
+    const { inspector, registry } = setupInspector();
+
+    const original = registry.getOrThrow('text');
+    const overridden: ComponentDefinition = {
+      ...original,
+      getLabel: () => 'Dynamic Label',
+      // Suppression without label override.
+      getInspectorPresentation: () => ({ suppressDeleteSection: true }),
+    };
+    registry.register(overridden);
+
+    const html = templateToHtml(inspector.render());
+
+    expect(html).toContain('Dynamic Label');
+    expect(html).not.toContain('Delete Block');
+    // Other sections still render because they were not suppressed.
+    expect(html).toContain('Style Preset');
+  });
+
+  it('re-renders on any component-state change via the generic subscription', () => {
+    const { engine, inspector } = setupInspector();
+
+    // The subscription is wired in Lit's `updated` lifecycle, which only fires
+    // when properties change through Lit's reactivity. In tests we set
+    // properties directly, so call the private hook explicitly.
+    (
+      inspector as unknown as { _resubscribeComponentState: () => void }
+    )._resubscribeComponentState();
+
+    let updateCount = 0;
+    (inspector as unknown as { requestUpdate: () => void }).requestUpdate = () => {
+      updateCount++;
+    };
+
+    engine.setComponentState('arbitrary:key', { foo: 'bar' });
+    engine.setComponentState('another:key', null);
+
+    expect(updateCount).toBe(2);
+  });
+});

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import type { TemplateDocument, NodeId, Node, PageSettings } from '../types/index.js';
 import type { EditorEngine } from '../engine/EditorEngine.js';
 import type { ComponentDefinition, InspectorField, ScopeDeclaration } from '../engine/registry.js';
@@ -32,6 +32,40 @@ export class EpistolaInspector extends LitElement {
   @property({ attribute: false }) doc?: TemplateDocument;
   @property({ attribute: false }) selectedNodeId: NodeId | null = null;
 
+  @state() private _tableCellSelectionActive = false;
+  private _unsubState?: () => void;
+  private _lastSubscribedEngine?: EditorEngine;
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has('engine')) {
+      this._resubscribeCellSelection();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this._unsubState?.();
+    this._unsubState = undefined;
+    this._lastSubscribedEngine = undefined;
+    super.disconnectedCallback();
+  }
+
+  private _resubscribeCellSelection(): void {
+    if (this._lastSubscribedEngine === this.engine) return;
+    this._unsubState?.();
+    this._unsubState = undefined;
+    this._lastSubscribedEngine = this.engine;
+    if (!this.engine) {
+      this._tableCellSelectionActive = false;
+      return;
+    }
+    this._tableCellSelectionActive = this.engine.getComponentState('table:cellSelection') != null;
+    this._unsubState = this.engine.events.on('component-state:change', ({ key, value }) => {
+      if (key === 'table:cellSelection') {
+        this._tableCellSelectionActive = value != null;
+      }
+    });
+  }
+
   override render() {
     if (!this.engine || !this.doc) {
       return html`<div class="panel-empty">No document</div>`;
@@ -46,34 +80,46 @@ export class EpistolaInspector extends LitElement {
 
     const def = this.engine.registry.get(node.type);
 
+    // Table cell-selection mode: hide node-level sections so the inspector
+    // only shows cell properties. Table-level controls reappear once the
+    // cell selection is cleared (by selecting the table or another node).
+    const cellMode = node.type === 'table' && this._tableCellSelectionActive;
+
     return html`
       <div class="epistola-inspector">
         <!-- Node info -->
         <div class="inspector-node-info">
-          <div class="inspector-node-label">${def?.label ?? node.type}</div>
+          <div class="inspector-node-label">
+            ${cellMode ? 'Table Cell' : (def?.label ?? node.type)}
+          </div>
           <div class="inspector-node-id">${node.id}</div>
         </div>
 
         <!-- Component-specific inspector (columns, table, etc.) -->
         ${def?.renderInspector ? def.renderInspector({ node, engine: this.engine! }) : nothing}
+        ${cellMode
+          ? nothing
+          : html`
+              <!-- Props -->
+              ${def?.inspector && def.inspector.length > 0
+                ? this._renderInspectorFields(node, def)
+                : nothing}
 
-        <!-- Props -->
-        ${def?.inspector && def.inspector.length > 0
-          ? this._renderInspectorFields(node, def)
-          : nothing}
+              <!-- Style preset -->
+              ${this._hasStyles(def?.applicableStyles)
+                ? this._renderStylePresetSection(node)
+                : nothing}
 
-        <!-- Style preset -->
-        ${this._hasStyles(def?.applicableStyles) ? this._renderStylePresetSection(node) : nothing}
+              <!-- Style properties -->
+              ${this._hasStyles(def?.applicableStyles)
+                ? this._renderNodeStyleGroups(node, def?.applicableStyles)
+                : nothing}
 
-        <!-- Style properties -->
-        ${this._hasStyles(def?.applicableStyles)
-          ? this._renderNodeStyleGroups(node, def?.applicableStyles)
-          : nothing}
-
-        <!-- Delete -->
-        <div class="inspector-delete-section">
-          <button class="ep-btn-danger" @click=${this._handleDelete}>Delete Block</button>
-        </div>
+              <!-- Delete -->
+              <div class="inspector-delete-section">
+                <button class="ep-btn-danger" @click=${this._handleDelete}>Delete Block</button>
+              </div>
+            `}
       </div>
     `;
   }

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -1,8 +1,13 @@
 import { LitElement, html, nothing } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import type { TemplateDocument, NodeId, Node, PageSettings } from '../types/index.js';
 import type { EditorEngine } from '../engine/EditorEngine.js';
-import type { ComponentDefinition, InspectorField, ScopeDeclaration } from '../engine/registry.js';
+import type {
+  ComponentDefinition,
+  InspectorField,
+  InspectorPresentation,
+  ScopeDeclaration,
+} from '../engine/registry.js';
 import type { StyleProperty } from '@epistola.app/epistola-model/generated/style-registry';
 import type { BlockStylePreset } from '@epistola.app/epistola-model/generated/theme';
 import { getNestedValue, setNestedValue } from '../engine/props.js';
@@ -32,13 +37,12 @@ export class EpistolaInspector extends LitElement {
   @property({ attribute: false }) doc?: TemplateDocument;
   @property({ attribute: false }) selectedNodeId: NodeId | null = null;
 
-  @state() private _tableCellSelectionActive = false;
   private _unsubState?: () => void;
   private _lastSubscribedEngine?: EditorEngine;
 
   override updated(changed: Map<string, unknown>): void {
     if (changed.has('engine')) {
-      this._resubscribeCellSelection();
+      this._resubscribeComponentState();
     }
   }
 
@@ -49,20 +53,19 @@ export class EpistolaInspector extends LitElement {
     super.disconnectedCallback();
   }
 
-  private _resubscribeCellSelection(): void {
+  /**
+   * Re-render whenever any component-state changes. The component definition's
+   * `getInspectorPresentation` hook (called from render) decides what to do
+   * with the current state — this inspector stays agnostic of which keys exist.
+   */
+  private _resubscribeComponentState(): void {
     if (this._lastSubscribedEngine === this.engine) return;
     this._unsubState?.();
     this._unsubState = undefined;
     this._lastSubscribedEngine = this.engine;
-    if (!this.engine) {
-      this._tableCellSelectionActive = false;
-      return;
-    }
-    this._tableCellSelectionActive = this.engine.getComponentState('table:cellSelection') != null;
-    this._unsubState = this.engine.events.on('component-state:change', ({ key, value }) => {
-      if (key === 'table:cellSelection') {
-        this._tableCellSelectionActive = value != null;
-      }
+    if (!this.engine) return;
+    this._unsubState = this.engine.events.on('component-state:change', () => {
+      this.requestUpdate();
     });
   }
 
@@ -80,46 +83,50 @@ export class EpistolaInspector extends LitElement {
 
     const def = this.engine.registry.get(node.type);
 
-    // Table cell-selection mode: hide node-level sections so the inspector
-    // only shows cell properties. Table-level controls reappear once the
-    // cell selection is cleared (by selecting the table or another node).
-    const cellMode = node.type === 'table' && this._tableCellSelectionActive;
+    // Components can customise the inspector header label and selectively
+    // hide generic sections via `getInspectorPresentation`. The inspector
+    // itself stays agnostic of any specific component type.
+    const presentation: InspectorPresentation | undefined = def?.getInspectorPresentation?.(
+      node,
+      this.engine,
+    );
+    const label =
+      presentation?.label ?? def?.getLabel?.(node, this.engine) ?? def?.label ?? node.type;
 
     return html`
       <div class="epistola-inspector">
         <!-- Node info -->
         <div class="inspector-node-info">
-          <div class="inspector-node-label">
-            ${cellMode ? 'Table Cell' : (def?.label ?? node.type)}
-          </div>
+          <div class="inspector-node-label">${label}</div>
           <div class="inspector-node-id">${node.id}</div>
         </div>
 
         <!-- Component-specific inspector (columns, table, etc.) -->
         ${def?.renderInspector ? def.renderInspector({ node, engine: this.engine! }) : nothing}
-        ${cellMode
-          ? nothing
-          : html`
-              <!-- Props -->
-              ${def?.inspector && def.inspector.length > 0
-                ? this._renderInspectorFields(node, def)
-                : nothing}
 
-              <!-- Style preset -->
-              ${this._hasStyles(def?.applicableStyles)
-                ? this._renderStylePresetSection(node)
-                : nothing}
+        <!-- Props -->
+        ${!presentation?.suppressPropsSection && def?.inspector && def.inspector.length > 0
+          ? this._renderInspectorFields(node, def)
+          : nothing}
 
-              <!-- Style properties -->
-              ${this._hasStyles(def?.applicableStyles)
-                ? this._renderNodeStyleGroups(node, def?.applicableStyles)
-                : nothing}
+        <!-- Style preset -->
+        ${!presentation?.suppressStylePresetSection && this._hasStyles(def?.applicableStyles)
+          ? this._renderStylePresetSection(node)
+          : nothing}
 
-              <!-- Delete -->
+        <!-- Style properties -->
+        ${!presentation?.suppressStylesSection && this._hasStyles(def?.applicableStyles)
+          ? this._renderNodeStyleGroups(node, def?.applicableStyles)
+          : nothing}
+
+        <!-- Delete -->
+        ${!presentation?.suppressDeleteSection
+          ? html`
               <div class="inspector-delete-section">
                 <button class="ep-btn-danger" @click=${this._handleDelete}>Delete Block</button>
               </div>
-            `}
+            `
+          : nothing}
       </div>
     `;
   }

--- a/modules/editor/src/main/typescript/ui/inputs/BorderInput.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/BorderInput.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_SPACING_UNIT,
 } from './style-inputs.js';
 
-const EMPTY_SIDE: BorderSideValue = { width: '', style: 'solid', color: '' };
+const EMPTY_SIDE: BorderSideValue = { width: '', style: 'none', color: '' };
 
 const BORDER_STYLES = [
   { label: 'None', value: 'none' },
@@ -73,7 +73,19 @@ export class BorderInput extends LitElement {
 
   private _handleSideChange(side: keyof BorderValue, field: keyof BorderSideValue, val: string) {
     const parsed = this._parsed;
-    const updated = { ...parsed[side], [field]: val };
+    let updated: BorderSideValue = { ...parsed[side], [field]: val };
+
+    // When the style is visible, width must be >= 0.5 in the current unit.
+    if (updated.style !== 'none') {
+      const w = parseValueWithUnit(updated.width, this._defaultUnit);
+      if (!updated.width || w.value < 0.5) {
+        updated = {
+          ...updated,
+          width: formatValueWithUnit(0.5, w.unit || this._defaultUnit),
+        };
+      }
+    }
+
     if (this._linked) {
       this._emitChange({
         top: { ...updated },
@@ -130,55 +142,6 @@ export class BorderInput extends LitElement {
       <div class="style-border-side-group">
         <div class="style-border-row">
           <span class="style-border-label">${label}</span>
-          <input
-            type="number"
-            class="ep-input style-border-width"
-            min="0"
-            step="0.5"
-            .value=${String(widthParsed.value || '')}
-            ?disabled=${this.readOnly}
-            @change=${(e: Event) => {
-              const num = parseFloat((e.target as HTMLInputElement).value) || 0;
-              this._handleSideChange(
-                side,
-                'width',
-                num > 0 ? formatValueWithUnit(num, widthParsed.unit) : '',
-              );
-            }}
-          />
-          ${this.units.length > 1
-            ? html`
-                <select
-                  class="ep-select style-border-unit-select"
-                  ?disabled=${this.readOnly}
-                  @change=${(e: Event) => {
-                    const newUnit = (e.target as HTMLSelectElement).value;
-                    const oldUnit = widthParsed.unit;
-                    let newValue = widthParsed.value;
-                    if (oldUnit === 'pt' && newUnit === 'sp') {
-                      newValue = parseFloat(
-                        nearestSpacingStep(widthParsed.value, DEFAULT_SPACING_UNIT),
-                      );
-                    } else if (oldUnit === 'sp' && newUnit === 'pt') {
-                      newValue = widthParsed.value * DEFAULT_SPACING_UNIT;
-                    }
-                    this._handleSideChange(
-                      side,
-                      'width',
-                      newValue > 0 ? formatValueWithUnit(newValue, newUnit) : '',
-                    );
-                  }}
-                >
-                  ${this.units.map(
-                    (u) =>
-                      html`<option .value=${u} ?selected=${u === widthParsed.unit}>${u}</option>`,
-                  )}
-                </select>
-              `
-            : nothing}
-        </div>
-        <div class="style-border-row">
-          <span class="style-border-label"></span>
           <select
             class="ep-select style-border-style-select"
             ?disabled=${this.readOnly}
@@ -192,24 +155,79 @@ export class BorderInput extends LitElement {
                 </option>`,
             )}
           </select>
-          <input
-            type="text"
-            class="ep-input style-border-color-text"
-            .value=${s.color || ''}
-            placeholder="#000000"
-            ?disabled=${this.readOnly}
-            @change=${(e: Event) =>
-              this._handleSideChange(side, 'color', (e.target as HTMLInputElement).value)}
-          />
-          <input
-            type="color"
-            class="style-border-color-picker"
-            .value=${s.color && s.color.startsWith('#') ? s.color : '#000000'}
-            ?disabled=${this.readOnly}
-            @input=${(e: Event) =>
-              this._handleSideChange(side, 'color', (e.target as HTMLInputElement).value)}
-          />
         </div>
+        ${s.style !== 'none'
+          ? html`
+              <div class="style-border-row">
+                <span class="style-border-label"></span>
+                <input
+                  type="number"
+                  class="ep-input style-border-width"
+                  min="0.5"
+                  step="0.5"
+                  .value=${String(widthParsed.value || '')}
+                  ?disabled=${this.readOnly}
+                  @change=${(e: Event) => {
+                    const num = parseFloat((e.target as HTMLInputElement).value) || 0;
+                    this._handleSideChange(
+                      side,
+                      'width',
+                      formatValueWithUnit(num, widthParsed.unit),
+                    );
+                  }}
+                />
+                ${this.units.length > 1
+                  ? html`
+                      <select
+                        class="ep-select style-border-unit-select"
+                        ?disabled=${this.readOnly}
+                        @change=${(e: Event) => {
+                          const newUnit = (e.target as HTMLSelectElement).value;
+                          const oldUnit = widthParsed.unit;
+                          let newValue = widthParsed.value;
+                          if (oldUnit === 'pt' && newUnit === 'sp') {
+                            newValue = parseFloat(
+                              nearestSpacingStep(widthParsed.value, DEFAULT_SPACING_UNIT),
+                            );
+                          } else if (oldUnit === 'sp' && newUnit === 'pt') {
+                            newValue = widthParsed.value * DEFAULT_SPACING_UNIT;
+                          }
+                          this._handleSideChange(
+                            side,
+                            'width',
+                            formatValueWithUnit(newValue, newUnit),
+                          );
+                        }}
+                      >
+                        ${this.units.map(
+                          (u) =>
+                            html`<option .value=${u} ?selected=${u === widthParsed.unit}>
+                              ${u}
+                            </option>`,
+                        )}
+                      </select>
+                    `
+                  : nothing}
+                <input
+                  type="text"
+                  class="ep-input style-border-color-text"
+                  .value=${s.color || ''}
+                  placeholder="#000000"
+                  ?disabled=${this.readOnly}
+                  @change=${(e: Event) =>
+                    this._handleSideChange(side, 'color', (e.target as HTMLInputElement).value)}
+                />
+                <input
+                  type="color"
+                  class="style-border-color-picker"
+                  .value=${s.color && s.color.startsWith('#') ? s.color : '#000000'}
+                  ?disabled=${this.readOnly}
+                  @input=${(e: Event) =>
+                    this._handleSideChange(side, 'color', (e.target as HTMLInputElement).value)}
+                />
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
@@ -205,8 +205,8 @@ describe('parseBorderShorthand', () => {
   });
 
   it('returns empty side for null/empty input', () => {
-    expect(parseBorderShorthand(null)).toEqual({ width: '', style: 'solid', color: '' });
-    expect(parseBorderShorthand('')).toEqual({ width: '', style: 'solid', color: '' });
+    expect(parseBorderShorthand(null)).toEqual({ width: '', style: 'none', color: '' });
+    expect(parseBorderShorthand('')).toEqual({ width: '', style: 'none', color: '' });
   });
 
   it('parses dashed border', () => {
@@ -301,9 +301,9 @@ describe('readBorderFromStyles', () => {
 
     expect(result).toEqual({
       top: { width: '2pt', style: 'solid', color: '#000' },
-      right: { width: '', style: 'solid', color: '' },
+      right: { width: '', style: 'none', color: '' },
       bottom: { width: '1pt', style: 'dashed', color: '#ccc' },
-      left: { width: '', style: 'solid', color: '' },
+      left: { width: '', style: 'none', color: '' },
     });
   });
 
@@ -318,7 +318,7 @@ describe('readBorderFromStyles', () => {
       top: { width: '2pt', style: 'solid', color: '#000000' },
       right: { width: '1pt', style: 'dashed', color: '#cccccc' },
       bottom: { width: '2pt', style: 'solid', color: '#000000' },
-      left: { width: '', style: 'solid', color: '' },
+      left: { width: '', style: 'none', color: '' },
     };
 
     const styles: Record<string, unknown> = {};

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -443,7 +443,7 @@ export interface BorderValue {
   left: BorderSideValue;
 }
 
-const EMPTY_SIDE: BorderSideValue = { width: '', style: 'solid', color: '' };
+const EMPTY_SIDE: BorderSideValue = { width: '', style: 'none', color: '' };
 
 /** Check if all four border sides have equal values. */
 export function areBorderSidesEqual(border: BorderValue): boolean {

--- a/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/catalog.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/epistola-app"
   },
   "release": {
-    "version": "5.1",
-    "releasedAt": "2026-04-21T00:00:00Z"
+    "version": "5.2",
+    "releasedAt": "2026-04-23T00:00:00Z"
   },
   "resources": [
     {
@@ -67,7 +67,7 @@
       "slug": "demo-invoice",
       "name": "Invoice Template",
       "description": "Professional invoice with line items, tax calculation, QR payment code, and conditional notes. Demonstrates datatables, columns, tables, conditionals, and expressions.",
-      "updatedAt": "2026-04-14T00:00:00Z",
+      "updatedAt": "2026-04-23T00:00:00Z",
       "detailUrl": "./resources/templates/demo-invoice.json"
     }
   ]

--- a/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/demo-invoice.json
+++ b/modules/epistola-core/src/main/resources/demo/catalog/resources/templates/demo-invoice.json
@@ -872,7 +872,6 @@
               50,
               50
             ],
-            "borderStyle": "horizontal",
             "headerRows": 0,
             "merges": []
           }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -34,7 +34,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("5.1")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("5.2")
         }
     }
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TableNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/TableNodeRenderer.kt
@@ -2,6 +2,7 @@ package app.epistola.generation.pdf
 
 import app.epistola.template.model.Node
 import app.epistola.template.model.TemplateDocument
+import com.itextpdf.layout.borders.Border
 import com.itextpdf.layout.element.Cell
 import com.itextpdf.layout.element.IElement
 import com.itextpdf.layout.element.Table
@@ -12,11 +13,13 @@ import com.itextpdf.layout.properties.UnitValue
  *
  * Table uses cell slots named "cell-{row}-{col}" (e.g., "cell-0-0", "cell-0-1", "cell-1-0").
  *
+ * Borders: set via the CSS `border*` style properties on the node (outer table border)
+ * or via `cellStyles[row-col].border*` (per-cell override).
+ *
  * Props:
  * - `rows`: Int (number of rows)
  * - `columns`: Int (number of columns)
  * - `columnWidths`: List of Int (optional, relative column widths)
- * - `borderStyle`: String (optional, one of "all", "horizontal", "vertical", "none")
  * - `headerRows`: Int (optional, number of header rows, default 0)
  * - `merges`: List of `{ row, col, rowSpan, colSpan }` (optional, merged cell regions)
  */
@@ -60,13 +63,6 @@ class TableNodeRenderer : NodeRenderer {
             context.spacingUnit,
         )
 
-        // Border style — overridable from props, falls back to rendering defaults
-        val borderStyle = parseBorderStyle(node.props?.get("borderStyle") as? String)
-        val borderColor = (node.props?.get("borderColor") as? String)?.let { StyleApplicator.parseColor(it) }
-            ?: parseHexBorderColor(context.renderingDefaults.tableBorderColorHex)
-        val borderWidth = (node.props?.get("borderWidth") as? Number)?.toFloat()
-            ?: context.renderingDefaults.tableBorderWidth
-
         // Per-cell styles from props
         @Suppress("UNCHECKED_CAST")
         val cellStyles = node.props?.get("cellStyles") as? Map<String, Map<String, Any>>
@@ -100,6 +96,11 @@ class TableNodeRenderer : NodeRenderer {
 
                 val cell = Cell(rowSpan, colSpan)
 
+                // Suppress iText's default cell borders. Borders are opt-in:
+                // table-level `border*` styles draw the outer border on the Table itself,
+                // and per-cell overrides come from `cellStyles` below.
+                cell.setBorder(Border.NO_BORDER)
+
                 // Apply per-cell styles if defined, otherwise use defaults
                 val cellKey = "$row-$col"
                 val perCellStyles = cellStyles?.get(cellKey)
@@ -116,12 +117,6 @@ class TableNodeRenderer : NodeRenderer {
                 // Apply default padding only if no per-cell padding is set
                 if (perCellStyles?.keys?.none { it.startsWith("padding") } != false) {
                     cell.setPadding(context.renderingDefaults.tableCellPadding)
-                }
-
-                // Apply table-level border only if no per-cell borders are set
-                val hasCellBorders = perCellStyles?.keys?.any { it.startsWith("border") } == true
-                if (!hasCellBorders) {
-                    applyCellBorder(cell, borderStyle, borderColor, borderWidth)
                 }
 
                 // Bold for header rows

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DirectPdfRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DirectPdfRendererTest.kt
@@ -497,7 +497,6 @@ class DirectPdfRendererTest {
                 "rows" to 2,
                 "columns" to 2,
                 "headerRows" to 1,
-                "borderStyle" to "all",
             ),
         )
 

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/PdfRenderingRegressionTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/PdfRenderingRegressionTest.kt
@@ -272,7 +272,7 @@ class PdfRenderingRegressionTest {
             id = tableNodeId,
             type = "table",
             slots = tableSlotIds,
-            props = mapOf("rows" to 3, "columns" to 3, "headerRows" to 1, "borderStyle" to "all"),
+            props = mapOf("rows" to 3, "columns" to 3, "headerRows" to 1),
         )
 
         return documentWithChildren(nodes, listOf(tableNodeId), slots)

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TableNodeRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TableNodeRendererTest.kt
@@ -151,13 +151,6 @@ class TableNodeRendererTest {
     }
 
     @Test
-    fun `renders table without any border styles`() {
-        // No node styles, no cell styles: cells render borderless (iText defaults suppressed).
-        val doc = tableDocument(rows = 2, columns = 2)
-        assertValidPdf(renderToBytes(doc))
-    }
-
-    @Test
     fun `renders table with outer border from node styles`() {
         val doc = tableDocument(
             rows = 2,
@@ -409,6 +402,98 @@ class TableNodeRendererTest {
             columns = 2,
             cellStyles = mapOf(
                 "0-0" to mapOf("backgroundColor" to "#f00"),
+            ),
+        )
+        assertValidPdf(renderToBytes(doc))
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-cell border shorthand (borderTop/Right/Bottom/Left via cellStyles)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `renders table with per-cell top border shorthand`() {
+        val doc = tableDocument(
+            rows = 2,
+            columns = 2,
+            cellStyles = mapOf(
+                "0-0" to mapOf("borderTop" to "1pt solid #ff0000"),
+            ),
+        )
+        assertValidPdf(renderToBytes(doc))
+    }
+
+    @Test
+    fun `renders table with per-cell borders on all four sides`() {
+        val doc = tableDocument(
+            rows = 1,
+            columns = 1,
+            cellStyles = mapOf(
+                "0-0" to mapOf(
+                    "borderTop" to "1pt solid #ff0000",
+                    "borderRight" to "1pt solid #00ff00",
+                    "borderBottom" to "1pt solid #0000ff",
+                    "borderLeft" to "1pt solid #888888",
+                ),
+            ),
+        )
+        assertValidPdf(renderToBytes(doc))
+    }
+
+    @Test
+    fun `renders table with per-cell dashed and dotted border styles`() {
+        val doc = tableDocument(
+            rows = 2,
+            columns = 2,
+            cellStyles = mapOf(
+                "0-0" to mapOf("borderBottom" to "1pt dashed #333333"),
+                "1-1" to mapOf("borderTop" to "1pt dotted #333333"),
+            ),
+        )
+        assertValidPdf(renderToBytes(doc))
+    }
+
+    @Test
+    fun `renders table with outer node border and per-cell borders combined`() {
+        val doc = tableDocument(
+            rows = 2,
+            columns = 2,
+            nodeStyles = mapOf(
+                "borderTop" to "1pt solid #000000",
+                "borderRight" to "1pt solid #000000",
+                "borderBottom" to "1pt solid #000000",
+                "borderLeft" to "1pt solid #000000",
+            ),
+            cellStyles = mapOf(
+                "0-0" to mapOf("borderBottom" to "2pt solid #ff0000"),
+            ),
+        )
+        assertValidPdf(renderToBytes(doc))
+    }
+
+    @Test
+    fun `renders table with per-cell border using sp width unit`() {
+        val doc = tableDocument(
+            rows = 2,
+            columns = 2,
+            cellStyles = mapOf(
+                "0-0" to mapOf("borderLeft" to "1sp solid #2563eb"),
+            ),
+        )
+        assertValidPdf(renderToBytes(doc))
+    }
+
+    @Test
+    fun `renders table with per-cell border on merged cell`() {
+        val doc = tableDocument(
+            rows = 2,
+            columns = 2,
+            merges = listOf(mapOf("row" to 0, "col" to 0, "rowSpan" to 2, "colSpan" to 2)),
+            cellStyles = mapOf(
+                "0-0" to mapOf(
+                    "borderTop" to "1pt solid #ff0000",
+                    "borderBottom" to "1pt solid #ff0000",
+                ),
             ),
         )
         assertValidPdf(renderToBytes(doc))

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TableNodeRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TableNodeRendererTest.kt
@@ -47,10 +47,10 @@ class TableNodeRendererTest {
         rows: Int,
         columns: Int,
         columnWidths: List<Int>? = null,
-        borderStyle: String = "all",
         headerRows: Int = 0,
         merges: List<Map<String, Any>> = emptyList(),
         cellStyles: Map<String, Map<String, Any>>? = null,
+        nodeStyles: Map<String, Any?>? = null,
     ): TemplateDocument {
         val tableNodeId = "table1"
         val rootNodeId = "root-1"
@@ -80,7 +80,6 @@ class TableNodeRendererTest {
         val tableProps = mutableMapOf<String, Any?>(
             "rows" to rows,
             "columns" to columns,
-            "borderStyle" to borderStyle,
             "headerRows" to headerRows,
         )
         if (columnWidths != null) {
@@ -98,6 +97,7 @@ class TableNodeRendererTest {
             type = "table",
             slots = tableSlotIds,
             props = tableProps,
+            styles = nodeStyles,
         )
 
         // Root
@@ -151,20 +151,24 @@ class TableNodeRendererTest {
     }
 
     @Test
-    fun `renders table with border style none`() {
-        val doc = tableDocument(rows = 2, columns = 2, borderStyle = "none")
+    fun `renders table without any border styles`() {
+        // No node styles, no cell styles: cells render borderless (iText defaults suppressed).
+        val doc = tableDocument(rows = 2, columns = 2)
         assertValidPdf(renderToBytes(doc))
     }
 
     @Test
-    fun `renders table with border style horizontal`() {
-        val doc = tableDocument(rows = 2, columns = 2, borderStyle = "horizontal")
-        assertValidPdf(renderToBytes(doc))
-    }
-
-    @Test
-    fun `renders table with border style vertical`() {
-        val doc = tableDocument(rows = 2, columns = 2, borderStyle = "vertical")
+    fun `renders table with outer border from node styles`() {
+        val doc = tableDocument(
+            rows = 2,
+            columns = 2,
+            nodeStyles = mapOf(
+                "borderTop" to "1pt solid #000000",
+                "borderRight" to "1pt solid #000000",
+                "borderBottom" to "1pt solid #000000",
+                "borderLeft" to "1pt solid #000000",
+            ),
+        )
         assertValidPdf(renderToBytes(doc))
     }
 
@@ -372,32 +376,15 @@ class TableNodeRendererTest {
     }
 
     @Test
-    fun `renders table with custom border color and width from props`() {
-        val rootSlotId = "slot-root"
-        val tableSlotId = "slot-cell-0-0"
-        val textId = "t-0-0"
-
-        val doc = TemplateDocument(
-            root = "root",
-            nodes = mapOf(
-                "root" to Node(id = "root", type = "root", slots = listOf(rootSlotId)),
-                "table1" to Node(
-                    id = "table1",
-                    type = "table",
-                    slots = listOf(tableSlotId),
-                    props = mapOf(
-                        "rows" to 1,
-                        "columns" to 1,
-                        "borderStyle" to "all",
-                        "borderColor" to "#2563eb",
-                        "borderWidth" to 2.0,
-                    ),
-                ),
-                textId to textNode(textId, "Blue border"),
-            ),
-            slots = mapOf(
-                rootSlotId to Slot(id = rootSlotId, nodeId = "root", name = "children", children = listOf("table1")),
-                tableSlotId to Slot(id = tableSlotId, nodeId = "table1", name = "cell-0-0", children = listOf(textId)),
+    fun `renders table with custom border color and width from node styles`() {
+        val doc = tableDocument(
+            rows = 1,
+            columns = 1,
+            nodeStyles = mapOf(
+                "borderTop" to "2pt solid #2563eb",
+                "borderRight" to "2pt solid #2563eb",
+                "borderBottom" to "2pt solid #2563eb",
+                "borderLeft" to "2pt solid #2563eb",
             ),
         )
         assertValidPdf(renderToBytes(doc))


### PR DESCRIPTION
## Summary

- **Border input UX**: reorganize the per-side border inspector — style select on top, width/unit/color below; hide width/unit/color when style is `None`; new borders default to `None`; clamp width to ≥0.5 in the active unit whenever a style is visible.
- **Table borders via CSS only**: remove the `borderStyle`/`borderColor`/`borderWidth` props on the `table` component (inspector + backend renderer + default props). Borders are now set exclusively via the CSS `border` property — on the node for the outer table border, or on selected cells for per-cell borders. Cells get `NO_BORDER` as baseline so default iText borders don't appear.
- **Cell-scoped inspector**: when a table cell is selected, hide the generic node-level sections (props / style preset / node styles / delete) and scope `TableInspector` to cell-only controls (merge + cell style). When only the table is selected, show the table-level controls as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

> Breaking: the `borderStyle`/`borderColor`/`borderWidth` props are removed from the `table` component. Templates that relied on these props need to use the CSS `border` properties instead. Project is pre-production per CLAUDE.md — no migration path is provided.

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (gradle test)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow Conventional Commits

## Test plan

- [x] Drag a new table onto the canvas — no borders in the generated PDF.
- [x] Select the table (no cell), set \`border: 1pt solid #000\` in the Border inspector — outer table border appears in PDF.
- [x] Select a cell, set \`borderTop: 1pt solid #ff0000\` — only that cell's top border renders red; other cells unaffected.
- [x] Select a cell — inspector shows only Cell Style + merge controls. Click outside or on the table body — inspector switches back to Table Layout + node styles.
- [x] Border input: switch style between \`None\` / \`Solid\` — width/unit/color row appears and disappears; minimum width enforced at 0.5.
- [x] Existing demo invoice still imports and renders (catalog version bumped to 5.2).