### PR TITLE
fix: margins not rendering in PDF for px and sp values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- **Margins not rendering in PDF**: `marginTop`/`Right`/`Bottom`/`Left` declared with `px` units (left over from before the `sp`/`pt` migration) were silently dropped during PDF generation because `StyleApplicator.parseSize` only recognized `pt`, `mm`, and `sp`. CSS pixels are now parsed at 96 DPI (`1px = 0.75pt`).
+- **Margins not rendering in PDF**: `marginTop`, `marginRight`, `marginBottom`, and `marginLeft` declared with `px` units (left over from before the `sp`/`pt` migration) were silently dropped during PDF generation because `StyleApplicator.parseSize` only recognized `pt`, `mm`, and `sp`. CSS pixels are now parsed at 96 DPI (`1px = 0.75pt`).
 - **Editor canvas didn't show `sp` margins**: Spacing values like `2sp` were emitted as raw CSS, which browsers don't understand, so the editor preview silently ignored them. The canvas now rewrites `Nsp` tokens to absolute `pt` so the preview matches the PDF output.
 - **Inspector kept legacy `px` units alive**: When a node's existing margin/padding used a unit no longer offered by the inspector (e.g. `px` after the `sp`/`pt` migration), the unit dropdown showed an allowed option but the spacing input internally still used the old unit, so any new value was re-saved as `Npx`. The inspector now migrates to the first allowed unit on read, converting the displayed values accordingly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 - **Editor canvas didn't show `sp` margins**: Spacing values like `2sp` were emitted as raw CSS, which browsers don't understand, so the editor preview silently ignored them. The canvas now rewrites `Nsp` tokens to absolute `pt` so the preview matches the PDF output.
 - **Inspector dropdown could go out of sync with stored unit**: If a node's stored margin/padding used a unit no longer offered by the inspector, `currentUnit` could fall outside the dropdown options and any new value would be saved with the unsupported unit. The dropdown is now clamped to one of the offered options.
-### Fixed
-
 - **Publishing subscribed catalog resources to environments**: Removed incorrect read-only catalog check from `PublishToEnvironment` and `PublishVersion` (for already-published versions). Environment activations are tenant-scoped operations, not catalog modifications.
 
 ## [0.17.0] - 2026-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Margins not rendering in PDF**: `marginTop`/`Right`/`Bottom`/`Left` declared with `px` units (left over from before the `sp`/`pt` migration) were silently dropped during PDF generation because `StyleApplicator.parseSize` only recognized `pt`, `mm`, and `sp`. CSS pixels are now parsed at 96 DPI (`1px = 0.75pt`).
+- **Editor canvas didn't show `sp` margins**: Spacing values like `2sp` were emitted as raw CSS, which browsers don't understand, so the editor preview silently ignored them. The canvas now rewrites `Nsp` tokens to absolute `pt` so the preview matches the PDF output.
+- **Inspector kept legacy `px` units alive**: When a node's existing margin/padding used a unit no longer offered by the inspector (e.g. `px` after the `sp`/`pt` migration), the unit dropdown showed an allowed option but the spacing input internally still used the old unit, so any new value was re-saved as `Npx`. The inspector now migrates to the first allowed unit on read, converting the displayed values accordingly.
+
 ## [0.16.0] - 2026-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Removed `px` unit support**: `StyleApplicator.parseSize` no longer recognizes `px` and the editor's spacing input no longer converts `px` values. Templates created before the `sp`/`pt` switch that still hold `Npx` values for margin/padding will not render those margins in the PDF, and the inspector will show the numeric portion in the fallback unit (`pt`) without scaling. Re-enter the value in `sp` or `pt` to fix.
+
 ### Fixed
 
-- **Margins not rendering in PDF**: `marginTop`, `marginRight`, `marginBottom`, and `marginLeft` declared with `px` units (left over from before the `sp`/`pt` migration) were silently dropped during PDF generation because `StyleApplicator.parseSize` only recognized `pt`, `mm`, and `sp`. CSS pixels are now parsed at 96 DPI (`1px = 0.75pt`).
 - **Editor canvas didn't show `sp` margins**: Spacing values like `2sp` were emitted as raw CSS, which browsers don't understand, so the editor preview silently ignored them. The canvas now rewrites `Nsp` tokens to absolute `pt` so the preview matches the PDF output.
-- **Inspector kept legacy `px` units alive**: When a node's existing margin/padding used a unit no longer offered by the inspector (e.g. `px` after the `sp`/`pt` migration), the unit dropdown showed an allowed option but the spacing input internally still used the old unit, so any new value was re-saved as `Npx`. The inspector now migrates to the first allowed unit on read, converting the displayed values accordingly.
+- **Inspector dropdown could go out of sync with stored unit**: If a node's stored margin/padding used a unit no longer offered by the inspector, `currentUnit` could fall outside the dropdown options and any new value would be saved with the unsupported unit. The dropdown is now clamped to one of the offered options.
 
 ## [0.16.0] - 2026-04-23
 

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
@@ -17,6 +17,7 @@ import { resolveDropOnBlockEdge, canDropHere, type Edge } from '../dnd/drop-logi
 import { handleDrop } from '../dnd/drop-handler.js';
 import { icon } from './icons.js';
 import { isCollapsible, countChildren } from './collapse.js';
+import { toStyleMap, DEFAULT_SPACING_UNIT_PT } from './style-css.js';
 import '../ui/EpistolaTextEditor.js';
 
 @customElement('epistola-canvas')
@@ -35,6 +36,10 @@ export class EpistolaCanvas extends LitElement {
   private _dndCleanup: (() => void) | null = null;
   private _unsubComponentState?: () => void;
   private _subscribedEngine?: EditorEngine;
+
+  private get _spacingUnit(): number {
+    return this.engine?.theme?.spacingUnit ?? DEFAULT_SPACING_UNIT_PT;
+  }
 
   private _handleSelect(e: Event, nodeId: NodeId) {
     e.stopPropagation();
@@ -383,7 +388,7 @@ export class EpistolaCanvas extends LitElement {
     const resolvedStyles = this.engine!.getResolvedNodeStyles(nodeId);
     const applicableStyles = def?.applicableStyles;
     const filteredStyles = filterByApplicableStyles(resolvedStyles, applicableStyles);
-    const contentStyle = toStyleMap(filteredStyles);
+    const contentStyle = toStyleMap(filteredStyles, this._spacingUnit);
 
     return html`
       <div
@@ -487,7 +492,7 @@ export class EpistolaCanvas extends LitElement {
         const def = this.engine!.registry.get(node.type);
         const applicableStyles = def?.applicableStyles;
         const filteredStyles = filterByApplicableStyles(resolvedStyles, applicableStyles);
-        const textStyles = toStyleMap(filteredStyles);
+        const textStyles = toStyleMap(filteredStyles, this._spacingUnit);
         return html`
           <epistola-text-editor
             .nodeId=${nodeId}
@@ -502,7 +507,7 @@ export class EpistolaCanvas extends LitElement {
         const resolvedStyles = this.engine!.getResolvedNodeStyles(nodeId);
         const def = this.engine!.registry.get(node.type);
         const filteredStyles = filterByApplicableStyles(resolvedStyles, def?.applicableStyles);
-        const wrapperStyle = toStyleMap(filteredStyles);
+        const wrapperStyle = toStyleMap(filteredStyles, this._spacingUnit);
         const props = node.props ?? {};
         const thickness = (props.thickness as string) || '1pt';
         const width = (props.width as string) || '100%';
@@ -555,24 +560,6 @@ function filterByApplicableStyles(
     } else if (applicableStyles.some((allowed) => key.startsWith(allowed))) {
       result[key] = value;
     }
-  }
-  return result;
-}
-
-/** Convert a camelCase key to kebab-case CSS property name. */
-function camelToKebab(key: string): string {
-  return key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
-}
-
-/**
- * Convert a resolved styles object to a styleMap-compatible record.
- * All values are scalar strings (e.g. marginTop: '10px' → margin-top: 10px).
- */
-function toStyleMap(styles: Record<string, unknown>): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(styles)) {
-    if (value == null) continue;
-    result[camelToKebab(key)] = String(value);
   }
   return result;
 }

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
@@ -6,6 +6,8 @@ import {
   readBorderFromStyles,
   parseBorderShorthand,
   areBorderSidesEqual,
+  convertSideValue,
+  DEFAULT_SPACING_UNIT,
   type SpacingValue,
   type BorderValue,
 } from './style-inputs.js';
@@ -134,6 +136,40 @@ describe('readSpacingFromStyles', () => {
     const result = readSpacingFromStyles('margin', styles);
 
     expect(result).toEqual({ top: '10px', right: '5px', bottom: '10px', left: '5px' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertSideValue — used both for explicit unit-switch and for migrating
+// legacy units (e.g. px) to the units the inspector currently offers.
+// ---------------------------------------------------------------------------
+
+describe('convertSideValue', () => {
+  const baseUnit = DEFAULT_SPACING_UNIT;
+
+  it('returns value unchanged when fromUnit equals toUnit', () => {
+    expect(convertSideValue('16px', 'px', 'px', baseUnit)).toBe('16px');
+  });
+
+  it('converts pt to sp via the spacing scale', () => {
+    expect(convertSideValue('8pt', 'pt', 'sp', baseUnit)).toBe('2sp');
+  });
+
+  it('converts sp to pt by multiplying with base unit', () => {
+    expect(convertSideValue('2sp', 'sp', 'pt', baseUnit)).toBe('8pt');
+  });
+
+  it('converts legacy px to pt at 96dpi (1px = 0.75pt)', () => {
+    expect(convertSideValue('16px', 'px', 'pt', baseUnit)).toBe('12pt');
+  });
+
+  it('converts legacy px to sp via pt', () => {
+    // 16px → 12pt → nearest sp step at baseUnit=4 = 3sp
+    expect(convertSideValue('16px', 'px', 'sp', baseUnit)).toBe('3sp');
+  });
+
+  it('returns value unchanged for unknown source unit', () => {
+    expect(convertSideValue('5em', 'em', 'pt', baseUnit)).toBe('5em');
   });
 });
 

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
@@ -7,6 +7,7 @@ import {
   parseBorderShorthand,
   areBorderSidesEqual,
   convertSideValue,
+  migrateSpacingToAllowedUnits,
   DEFAULT_SPACING_UNIT,
   type SpacingValue,
   type BorderValue,
@@ -170,6 +171,51 @@ describe('convertSideValue', () => {
 
   it('returns value unchanged for unknown source unit', () => {
     expect(convertSideValue('5em', 'em', 'pt', baseUnit)).toBe('5em');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// migrateSpacingToAllowedUnits — handles legacy unit migration on inspector
+// open, including mixed-unit spacing objects (per-side detection).
+// ---------------------------------------------------------------------------
+
+describe('migrateSpacingToAllowedUnits', () => {
+  const baseUnit = DEFAULT_SPACING_UNIT;
+
+  it('returns the same reference when every side is already in an allowed unit', () => {
+    const input: SpacingValue = { top: '10pt', right: '0pt', bottom: '0pt', left: '5pt' };
+    expect(migrateSpacingToAllowedUnits(input, ['sp', 'pt'], baseUnit)).toBe(input);
+  });
+
+  it('converts all sides when all use a legacy unit (px → pt)', () => {
+    expect(
+      migrateSpacingToAllowedUnits(
+        { top: '11px', right: '0px', bottom: '13px', left: '16px' },
+        ['sp', 'pt'],
+        baseUnit,
+      ),
+    ).toEqual({ top: '8.25pt', right: '0pt', bottom: '9.75pt', left: '12pt' });
+  });
+
+  it('converts only legacy sides in a mixed-unit value (the per-side bug)', () => {
+    // Top is already pt — must NOT be reinterpreted as px and shrunk to 7.5pt.
+    expect(
+      migrateSpacingToAllowedUnits(
+        { top: '10pt', right: '0pt', bottom: '0pt', left: '16px' },
+        ['sp', 'pt'],
+        baseUnit,
+      ),
+    ).toEqual({ top: '10pt', right: '0pt', bottom: '0pt', left: '12pt' });
+  });
+
+  it('preserves sp sides untouched when sp is allowed', () => {
+    expect(
+      migrateSpacingToAllowedUnits(
+        { top: '2sp', right: '0pt', bottom: '0pt', left: '16px' },
+        ['sp', 'pt'],
+        baseUnit,
+      ),
+    ).toEqual({ top: '2sp', right: '0pt', bottom: '0pt', left: '12pt' });
   });
 });
 

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
@@ -7,7 +7,6 @@ import {
   parseBorderShorthand,
   areBorderSidesEqual,
   convertSideValue,
-  migrateSpacingToAllowedUnits,
   DEFAULT_SPACING_UNIT,
   type SpacingValue,
   type BorderValue,
@@ -141,15 +140,14 @@ describe('readSpacingFromStyles', () => {
 });
 
 // ---------------------------------------------------------------------------
-// convertSideValue — used both for explicit unit-switch and for migrating
-// legacy units (e.g. px) to the units the inspector currently offers.
+// convertSideValue — explicit unit-switch between supported units (sp, pt).
 // ---------------------------------------------------------------------------
 
 describe('convertSideValue', () => {
   const baseUnit = DEFAULT_SPACING_UNIT;
 
   it('returns value unchanged when fromUnit equals toUnit', () => {
-    expect(convertSideValue('16px', 'px', 'px', baseUnit)).toBe('16px');
+    expect(convertSideValue('8pt', 'pt', 'pt', baseUnit)).toBe('8pt');
   });
 
   it('converts pt to sp via the spacing scale', () => {
@@ -160,62 +158,8 @@ describe('convertSideValue', () => {
     expect(convertSideValue('2sp', 'sp', 'pt', baseUnit)).toBe('8pt');
   });
 
-  it('converts legacy px to pt at 96dpi (1px = 0.75pt)', () => {
-    expect(convertSideValue('16px', 'px', 'pt', baseUnit)).toBe('12pt');
-  });
-
-  it('converts legacy px to sp via pt', () => {
-    // 16px → 12pt → nearest sp step at baseUnit=4 = 3sp
-    expect(convertSideValue('16px', 'px', 'sp', baseUnit)).toBe('3sp');
-  });
-
   it('returns value unchanged for unknown source unit', () => {
     expect(convertSideValue('5em', 'em', 'pt', baseUnit)).toBe('5em');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// migrateSpacingToAllowedUnits — handles legacy unit migration on inspector
-// open, including mixed-unit spacing objects (per-side detection).
-// ---------------------------------------------------------------------------
-
-describe('migrateSpacingToAllowedUnits', () => {
-  const baseUnit = DEFAULT_SPACING_UNIT;
-
-  it('returns the same reference when every side is already in an allowed unit', () => {
-    const input: SpacingValue = { top: '10pt', right: '0pt', bottom: '0pt', left: '5pt' };
-    expect(migrateSpacingToAllowedUnits(input, ['sp', 'pt'], baseUnit)).toBe(input);
-  });
-
-  it('converts all sides when all use a legacy unit (px → pt)', () => {
-    expect(
-      migrateSpacingToAllowedUnits(
-        { top: '11px', right: '0px', bottom: '13px', left: '16px' },
-        ['sp', 'pt'],
-        baseUnit,
-      ),
-    ).toEqual({ top: '8.25pt', right: '0pt', bottom: '9.75pt', left: '12pt' });
-  });
-
-  it('converts only legacy sides in a mixed-unit value (the per-side bug)', () => {
-    // Top is already pt — must NOT be reinterpreted as px and shrunk to 7.5pt.
-    expect(
-      migrateSpacingToAllowedUnits(
-        { top: '10pt', right: '0pt', bottom: '0pt', left: '16px' },
-        ['sp', 'pt'],
-        baseUnit,
-      ),
-    ).toEqual({ top: '10pt', right: '0pt', bottom: '0pt', left: '12pt' });
-  });
-
-  it('preserves sp sides untouched when sp is allowed', () => {
-    expect(
-      migrateSpacingToAllowedUnits(
-        { top: '2sp', right: '0pt', bottom: '0pt', left: '16px' },
-        ['sp', 'pt'],
-        baseUnit,
-      ),
-    ).toEqual({ top: '2sp', right: '0pt', bottom: '0pt', left: '12pt' });
   });
 });
 

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -277,6 +277,36 @@ export function parseSpacingValue(raw: unknown, defaultUnit: string): SpacingVal
 }
 
 /**
+ * Convert any side whose unit isn't in `units` to the first allowed
+ * absolute unit (typically pt), leaving sides whose unit is already
+ * allowed untouched. Each side is detected on its own — a value like
+ * `{ top: '10pt', left: '16px' }` converts only the px side.
+ */
+export function migrateSpacingToAllowedUnits(
+  parsed: SpacingValue,
+  units: string[],
+  baseUnit: number,
+): SpacingValue {
+  const firstAbsUnit = units.find((u) => u !== 'sp') ?? 'pt';
+  const sideUnitOf = (sideValue: string): string => {
+    if (parseSpacingToken(sideValue) != null) return 'sp';
+    return parseValueWithUnit(sideValue, firstAbsUnit).unit;
+  };
+  const migrateSide = (sideValue: string): string => {
+    const u = sideUnitOf(sideValue);
+    return units.includes(u) ? sideValue : convertSideValue(sideValue, u, firstAbsUnit, baseUnit);
+  };
+  const sides = ['top', 'right', 'bottom', 'left'] as const;
+  if (sides.every((s) => units.includes(sideUnitOf(parsed[s])))) return parsed;
+  return {
+    top: migrateSide(parsed.top),
+    right: migrateSide(parsed.right),
+    bottom: migrateSide(parsed.bottom),
+    left: migrateSide(parsed.left),
+  };
+}
+
+/**
  * Renders a spacing input with 4 side controls (T/R/B/L) + a shared unit selector.
  *
  * All units use number inputs — sp values are multipliers (e.g., 2 = 2sp = 8pt),
@@ -292,22 +322,14 @@ export function renderSpacingInput(
 ): unknown {
   const firstAbsUnit = units.find((u) => u !== 'sp') ?? 'pt';
   const rawParsed = parseSpacingValue(value, firstAbsUnit);
-  const detectedUnit = detectSpacingUnit(rawParsed, firstAbsUnit);
-
-  // Migrate legacy units (e.g. px from before the sp/pt switch) so the
-  // dropdown's `currentUnit` always matches one of the offered options.
-  // Without this, `currentUnit` could be 'px' while the dropdown only
-  // offers ['sp', 'pt'], and any new edit would re-save as 'Npx'.
   const sides = ['top', 'right', 'bottom', 'left'] as const;
-  const currentUnit = units.includes(detectedUnit) ? detectedUnit : firstAbsUnit;
-  const parsed: SpacingValue = units.includes(detectedUnit)
-    ? rawParsed
-    : {
-        top: convertSideValue(rawParsed.top, detectedUnit, currentUnit, baseUnit),
-        right: convertSideValue(rawParsed.right, detectedUnit, currentUnit, baseUnit),
-        bottom: convertSideValue(rawParsed.bottom, detectedUnit, currentUnit, baseUnit),
-        left: convertSideValue(rawParsed.left, detectedUnit, currentUnit, baseUnit),
-      };
+
+  // Migrate legacy per-side units to one of the offered options so the
+  // dropdown's `currentUnit` always matches a real choice. Without this,
+  // `currentUnit` could be 'px' while the dropdown only offers ['sp', 'pt'],
+  // and any new edit would re-save as 'Npx'.
+  const parsed = migrateSpacingToAllowedUnits(rawParsed, units, baseUnit);
+  const currentUnit = detectSpacingUnit(parsed, firstAbsUnit);
   const topInputId = inputId ?? undefined;
 
   const handleSideChange = (side: string, newValue: string) => {

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -189,8 +189,6 @@ function toPt(value: string, fromUnit: string, baseUnit: number): number | null 
     return multiplier * baseUnit;
   }
   if (fromUnit === 'pt') return parseValueWithUnit(value, 'pt').value;
-  // CSS px @ 96dpi: 1px = 0.75pt. Legacy templates stored values in px.
-  if (fromUnit === 'px') return parseValueWithUnit(value, 'px').value * 0.75;
   return null;
 }
 
@@ -277,36 +275,6 @@ export function parseSpacingValue(raw: unknown, defaultUnit: string): SpacingVal
 }
 
 /**
- * Convert any side whose unit isn't in `units` to the first allowed
- * absolute unit (typically pt), leaving sides whose unit is already
- * allowed untouched. Each side is detected on its own — a value like
- * `{ top: '10pt', left: '16px' }` converts only the px side.
- */
-export function migrateSpacingToAllowedUnits(
-  parsed: SpacingValue,
-  units: string[],
-  baseUnit: number,
-): SpacingValue {
-  const firstAbsUnit = units.find((u) => u !== 'sp') ?? 'pt';
-  const sideUnitOf = (sideValue: string): string => {
-    if (parseSpacingToken(sideValue) != null) return 'sp';
-    return parseValueWithUnit(sideValue, firstAbsUnit).unit;
-  };
-  const migrateSide = (sideValue: string): string => {
-    const u = sideUnitOf(sideValue);
-    return units.includes(u) ? sideValue : convertSideValue(sideValue, u, firstAbsUnit, baseUnit);
-  };
-  const sides = ['top', 'right', 'bottom', 'left'] as const;
-  if (sides.every((s) => units.includes(sideUnitOf(parsed[s])))) return parsed;
-  return {
-    top: migrateSide(parsed.top),
-    right: migrateSide(parsed.right),
-    bottom: migrateSide(parsed.bottom),
-    left: migrateSide(parsed.left),
-  };
-}
-
-/**
  * Renders a spacing input with 4 side controls (T/R/B/L) + a shared unit selector.
  *
  * All units use number inputs — sp values are multipliers (e.g., 2 = 2sp = 8pt),
@@ -321,15 +289,15 @@ export function renderSpacingInput(
   readOnly = false,
 ): unknown {
   const firstAbsUnit = units.find((u) => u !== 'sp') ?? 'pt';
-  const rawParsed = parseSpacingValue(value, firstAbsUnit);
+  const parsed = parseSpacingValue(value, firstAbsUnit);
   const sides = ['top', 'right', 'bottom', 'left'] as const;
 
-  // Migrate legacy per-side units to one of the offered options so the
-  // dropdown's `currentUnit` always matches a real choice. Without this,
-  // `currentUnit` could be 'px' while the dropdown only offers ['sp', 'pt'],
-  // and any new edit would re-save as 'Npx'.
-  const parsed = migrateSpacingToAllowedUnits(rawParsed, units, baseUnit);
-  const currentUnit = detectSpacingUnit(parsed, firstAbsUnit);
+  // Clamp the detected unit to one that's offered in the dropdown.
+  // Stored values that use an unsupported unit (legacy data, hand-edited
+  // JSON) display their numeric portion in the fallback unit and are
+  // re-saved with the fallback unit on the next edit.
+  const detected = detectSpacingUnit(parsed, firstAbsUnit);
+  const currentUnit = units.includes(detected) ? detected : firstAbsUnit;
   const topInputId = inputId ?? undefined;
 
   const handleSideChange = (side: string, newValue: string) => {

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -181,10 +181,25 @@ function detectSpacingUnit(parsed: SpacingValue, defaultUnit: string): string {
   return defaultUnit;
 }
 
+/** Convert any supported unit to absolute pt. Returns null if unit is unknown. */
+function toPt(value: string, fromUnit: string, baseUnit: number): number | null {
+  if (fromUnit === 'sp') {
+    const step = parseSpacingToken(value);
+    const multiplier = step != null ? parseFloat(step) || 0 : 0;
+    return multiplier * baseUnit;
+  }
+  if (fromUnit === 'pt') return parseValueWithUnit(value, 'pt').value;
+  // CSS px @ 96dpi: 1px = 0.75pt. Legacy templates stored values in px.
+  if (fromUnit === 'px') return parseValueWithUnit(value, 'px').value * 0.75;
+  return null;
+}
+
 /**
- * Convert a single side value between sp and pt.
+ * Convert a single side value between supported units (sp, pt, px).
+ * Used both for explicit unit-switch and for migrating legacy values
+ * to a unit that's actually offered in the dropdown.
  */
-function convertSideValue(
+export function convertSideValue(
   value: string,
   fromUnit: string,
   toUnit: string,
@@ -192,16 +207,11 @@ function convertSideValue(
 ): string {
   if (fromUnit === toUnit) return value;
 
-  if (fromUnit === 'sp' && toUnit === 'pt') {
-    const step = parseSpacingToken(value);
-    const multiplier = step != null ? parseFloat(step) || 0 : 0;
-    return formatValueWithUnit(multiplier * baseUnit, 'pt');
-  }
+  const pt = toPt(value, fromUnit, baseUnit);
+  if (pt == null) return value;
 
-  if (fromUnit === 'pt' && toUnit === 'sp') {
-    const p = parseValueWithUnit(value, 'pt');
-    return formatSpacingToken(nearestSpacingStep(p.value, baseUnit));
-  }
+  if (toUnit === 'pt') return formatValueWithUnit(pt, 'pt');
+  if (toUnit === 'sp') return formatSpacingToken(nearestSpacingStep(pt, baseUnit));
 
   return value;
 }
@@ -281,9 +291,23 @@ export function renderSpacingInput(
   readOnly = false,
 ): unknown {
   const firstAbsUnit = units.find((u) => u !== 'sp') ?? 'pt';
-  const parsed = parseSpacingValue(value, firstAbsUnit);
-  const currentUnit = detectSpacingUnit(parsed, firstAbsUnit);
+  const rawParsed = parseSpacingValue(value, firstAbsUnit);
+  const detectedUnit = detectSpacingUnit(rawParsed, firstAbsUnit);
+
+  // Migrate legacy units (e.g. px from before the sp/pt switch) so the
+  // dropdown's `currentUnit` always matches one of the offered options.
+  // Without this, `currentUnit` could be 'px' while the dropdown only
+  // offers ['sp', 'pt'], and any new edit would re-save as 'Npx'.
   const sides = ['top', 'right', 'bottom', 'left'] as const;
+  const currentUnit = units.includes(detectedUnit) ? detectedUnit : firstAbsUnit;
+  const parsed: SpacingValue = units.includes(detectedUnit)
+    ? rawParsed
+    : {
+        top: convertSideValue(rawParsed.top, detectedUnit, currentUnit, baseUnit),
+        right: convertSideValue(rawParsed.right, detectedUnit, currentUnit, baseUnit),
+        bottom: convertSideValue(rawParsed.bottom, detectedUnit, currentUnit, baseUnit),
+        left: convertSideValue(rawParsed.left, detectedUnit, currentUnit, baseUnit),
+      };
   const topInputId = inputId ?? undefined;
 
   const handleSideChange = (side: string, newValue: string) => {

--- a/modules/editor/src/main/typescript/ui/style-css.test.ts
+++ b/modules/editor/src/main/typescript/ui/style-css.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { camelToKebab, convertSpToPt, toStyleMap } from './style-css.js';
+
+describe('convertSpToPt', () => {
+  it('converts a single sp value with the default unit', () => {
+    expect(convertSpToPt('2sp', 4)).toBe('8pt');
+  });
+
+  it('supports decimal sp values', () => {
+    expect(convertSpToPt('1.5sp', 4)).toBe('6pt');
+  });
+
+  it('rewrites every sp token inside a shorthand', () => {
+    expect(convertSpToPt('2sp solid #fff', 4)).toBe('8pt solid #fff');
+  });
+
+  it('leaves non-sp values untouched', () => {
+    expect(convertSpToPt('10pt', 4)).toBe('10pt');
+    expect(convertSpToPt('50%', 4)).toBe('50%');
+    expect(convertSpToPt('center', 4)).toBe('center');
+  });
+
+  it('uses a custom base unit', () => {
+    expect(convertSpToPt('3sp', 6)).toBe('18pt');
+  });
+});
+
+describe('camelToKebab', () => {
+  it('converts camelCase to kebab-case', () => {
+    expect(camelToKebab('marginTop')).toBe('margin-top');
+    expect(camelToKebab('backgroundColor')).toBe('background-color');
+  });
+
+  it('leaves single-word keys unchanged', () => {
+    expect(camelToKebab('color')).toBe('color');
+  });
+});
+
+describe('toStyleMap', () => {
+  it('converts camelCase keys and sp values together', () => {
+    expect(toStyleMap({ marginTop: '2sp', marginLeft: '1sp' }, 4)).toEqual({
+      'margin-top': '8pt',
+      'margin-left': '4pt',
+    });
+  });
+
+  it('drops null and undefined values', () => {
+    expect(toStyleMap({ marginTop: '2sp', color: null, fontSize: undefined }, 4)).toEqual({
+      'margin-top': '8pt',
+    });
+  });
+
+  it('preserves non-sp values', () => {
+    expect(toStyleMap({ color: '#333', fontSize: '12pt' }, 4)).toEqual({
+      color: '#333',
+      'font-size': '12pt',
+    });
+  });
+
+  it('falls back to the default base unit when none is given', () => {
+    expect(toStyleMap({ marginTop: '2sp' })).toEqual({ 'margin-top': '8pt' });
+  });
+});

--- a/modules/editor/src/main/typescript/ui/style-css.ts
+++ b/modules/editor/src/main/typescript/ui/style-css.ts
@@ -1,0 +1,47 @@
+/**
+ * CSS rendering helpers for the editor canvas.
+ *
+ * The editor's resolved style values use the spacing-token unit `sp`
+ * (e.g. `2sp`), which mirrors the backend's `SpacingScale`. Browsers
+ * don't understand `sp`, so before handing values to `styleMap` we
+ * rewrite each `Nsp` token to an absolute `pt` value so the canvas
+ * preview matches the PDF output.
+ */
+
+/** Default spacing unit in points; mirrors backend SpacingScale.DEFAULT_BASE_UNIT. */
+export const DEFAULT_SPACING_UNIT_PT = 4;
+
+const SP_TOKEN = /(\d+(?:\.\d+)?)sp\b/g;
+
+/**
+ * Rewrite every `Nsp` token in a string to an absolute `pt` value.
+ * Leaves other content (other units, color, keywords) untouched, so
+ * shorthand values like `2sp solid #fff` are handled correctly.
+ */
+export function convertSpToPt(value: string, baseUnitPt: number): string {
+  return value.replace(SP_TOKEN, (_, num) => `${parseFloat(num) * baseUnitPt}pt`);
+}
+
+/** Convert a camelCase key to kebab-case CSS property name. */
+export function camelToKebab(key: string): string {
+  return key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+/**
+ * Convert a resolved styles object to a styleMap-compatible record.
+ *
+ * - camelCase keys → kebab-case CSS properties
+ * - `Nsp` tokens in values → `(N * baseUnitPt)pt`
+ * - null/undefined values are dropped
+ */
+export function toStyleMap(
+  styles: Record<string, unknown>,
+  baseUnitPt: number = DEFAULT_SPACING_UNIT_PT,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(styles)) {
+    if (value == null) continue;
+    result[camelToKebab(key)] = convertSpToPt(String(value), baseUnitPt);
+  }
+  return result;
+}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -295,6 +295,7 @@ object StyleApplicator {
 
         return when {
             size.endsWith("pt") -> size.removeSuffix("pt").toFloatOrNull()
+            size.endsWith("px") -> size.removeSuffix("px").toFloatOrNull()?.let { it * 0.75f } // CSS px @ 96dpi
             size.endsWith("mm") -> size.removeSuffix("mm").toFloatOrNull()?.let { it * 2.83465f } // page margins
             else -> size.toFloatOrNull() // unitless number treated as pt
         }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -295,7 +295,6 @@ object StyleApplicator {
 
         return when {
             size.endsWith("pt") -> size.removeSuffix("pt").toFloatOrNull()
-            size.endsWith("px") -> size.removeSuffix("px").toFloatOrNull()?.let { it * 0.75f } // CSS px @ 96dpi
             size.endsWith("mm") -> size.removeSuffix("mm").toFloatOrNull()?.let { it * 2.83465f } // page margins
             else -> size.toFloatOrNull() // unitless number treated as pt
         }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -264,4 +264,36 @@ class StyleApplicatorTest {
         )
         assertEquals(null, div.getProperty<Boolean>(Property.KEEP_TOGETHER))
     }
+
+    // -----------------------------------------------------------------------
+    // parseSize unit handling
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `parseSize handles pt`() {
+        assertEquals(12f, StyleApplicator.parseSize("12pt"))
+    }
+
+    @Test
+    fun `parseSize handles px as CSS pixels at 96dpi`() {
+        assertEquals(12f, StyleApplicator.parseSize("16px"))
+        assertEquals(30f, StyleApplicator.parseSize("40px"))
+    }
+
+    @Test
+    fun `parseSize handles sp via spacing scale`() {
+        assertEquals(8f, StyleApplicator.parseSize("2sp"))
+    }
+
+    @Test
+    fun `parseSize handles mm`() {
+        // 1mm ≈ 2.83465pt
+        val result = StyleApplicator.parseSize("10mm")
+        assertEquals(28.3465f, result)
+    }
+
+    @Test
+    fun `parseSize returns null for unknown unit`() {
+        assertEquals(null, StyleApplicator.parseSize("10rem"))
+    }
 }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -275,12 +275,6 @@ class StyleApplicatorTest {
     }
 
     @Test
-    fun `parseSize handles px as CSS pixels at 96dpi`() {
-        assertEquals(12f, StyleApplicator.parseSize("16px"))
-        assertEquals(30f, StyleApplicator.parseSize("40px"))
-    }
-
-    @Test
     fun `parseSize handles sp via spacing scale`() {
         assertEquals(8f, StyleApplicator.parseSize("2sp"))
     }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -289,7 +289,8 @@ class StyleApplicatorTest {
     fun `parseSize handles mm`() {
         // 1mm ≈ 2.83465pt
         val result = StyleApplicator.parseSize("10mm")
-        assertEquals(28.3465f, result)
+        assertNotNull(result)
+        assertEquals(28.3465f, result, 0.0001f)
     }
 
     @Test

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TextNodeMarginRegressionTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TextNodeMarginRegressionTest.kt
@@ -1,0 +1,124 @@
+package app.epistola.generation.pdf
+
+import app.epistola.template.model.Node
+import app.epistola.template.model.Slot
+import app.epistola.template.model.TemplateDocument
+import com.itextpdf.kernel.geom.Vector
+import com.itextpdf.kernel.pdf.PdfDocument
+import com.itextpdf.kernel.pdf.PdfReader
+import com.itextpdf.kernel.pdf.canvas.parser.EventType
+import com.itextpdf.kernel.pdf.canvas.parser.PdfCanvasProcessor
+import com.itextpdf.kernel.pdf.canvas.parser.data.IEventData
+import com.itextpdf.kernel.pdf.canvas.parser.data.TextRenderInfo
+import com.itextpdf.kernel.pdf.canvas.parser.listener.IEventListener
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that `marginTop` declared on a text node actually translates
+ * into vertical space between rendered text in the PDF — the visible
+ * effect users expect.
+ *
+ * Existing tests only check `pdf.isNotEmpty()` for margin scenarios,
+ * which left this regression silent for both `pt` and `sp` units.
+ */
+class TextNodeMarginRegressionTest {
+
+    @Test
+    fun `marginTop on second text node adds expected vertical gap (pt)`() {
+        assertGapDeltaApprox(value = "10pt", expectedDeltaPt = 10f)
+        assertGapDeltaApprox(value = "30pt", expectedDeltaPt = 30f)
+    }
+
+    @Test
+    fun `marginTop on second text node adds expected vertical gap (sp)`() {
+        assertGapDeltaApprox(value = "2sp", expectedDeltaPt = 8f)
+        assertGapDeltaApprox(value = "5sp", expectedDeltaPt = 20f)
+    }
+
+    @Test
+    fun `marginTop on second text node adds expected vertical gap (px)`() {
+        // CSS px @ 96dpi: 1px = 0.75pt
+        assertGapDeltaApprox(value = "16px", expectedDeltaPt = 12f)
+        assertGapDeltaApprox(value = "40px", expectedDeltaPt = 30f)
+    }
+
+    private fun assertGapDeltaApprox(value: String, expectedDeltaPt: Float) {
+        val baselineGap = renderAndMeasureGap(secondTextMarginTop = null)
+        val withMarginGap = renderAndMeasureGap(secondTextMarginTop = value)
+        val delta = withMarginGap - baselineGap
+        assertTrue(
+            abs(delta - expectedDeltaPt) < 0.5f,
+            "Expected marginTop=$value to add ~${expectedDeltaPt}pt to the inter-text gap, got delta=${delta}pt (baseline=$baselineGap, with=$withMarginGap)",
+        )
+    }
+
+    private fun renderAndMeasureGap(secondTextMarginTop: String?): Float {
+        val rootId = "root"
+        val rootSlotId = "slot-root"
+        val text1 = textNode("t1", "AAA", styles = null)
+        val text2 = textNode("t2", "BBB", styles = secondTextMarginTop?.let { mapOf("marginTop" to it) })
+
+        val document = TemplateDocument(
+            root = rootId,
+            nodes = mapOf(
+                rootId to Node(id = rootId, type = "root", slots = listOf(rootSlotId)),
+                text1.id to text1,
+                text2.id to text2,
+            ),
+            slots = mapOf(
+                rootSlotId to Slot(
+                    id = rootSlotId,
+                    nodeId = rootId,
+                    name = "children",
+                    children = listOf(text1.id, text2.id),
+                ),
+            ),
+        )
+
+        val out = ByteArrayOutputStream()
+        DirectPdfRenderer().render(document, emptyMap(), out)
+
+        val baselines = extractBaselines(out.toByteArray())
+        return baselines["AAA"]!! - baselines["BBB"]!!
+    }
+
+    private fun textNode(id: String, text: String, styles: Map<String, Any?>?) = Node(
+        id = id,
+        type = "text",
+        styles = styles,
+        props = mapOf(
+            "content" to mapOf(
+                "type" to "doc",
+                "content" to listOf(
+                    mapOf("type" to "paragraph", "content" to listOf(mapOf("type" to "text", "text" to text))),
+                ),
+            ),
+        ),
+    )
+
+    private fun extractBaselines(pdfBytes: ByteArray): Map<String, Float> {
+        val baselines = mutableMapOf<String, Float>()
+        PdfReader(ByteArrayInputStream(pdfBytes)).use { reader ->
+            val pdf = PdfDocument(reader)
+            val processor = PdfCanvasProcessor(object : IEventListener {
+                override fun eventOccurred(data: IEventData?, type: EventType?) {
+                    if (data is TextRenderInfo) {
+                        val text = data.text.trim()
+                        if (text.isNotEmpty()) {
+                            val origin: Vector = data.baseline.startPoint
+                            baselines.putIfAbsent(text, origin.get(Vector.I2))
+                        }
+                    }
+                }
+                override fun getSupportedEvents(): Set<EventType> = setOf(EventType.RENDER_TEXT)
+            })
+            processor.processPageContent(pdf.getPage(1))
+            pdf.close()
+        }
+        return baselines
+    }
+}

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TextNodeMarginRegressionTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/TextNodeMarginRegressionTest.kt
@@ -39,13 +39,6 @@ class TextNodeMarginRegressionTest {
         assertGapDeltaApprox(value = "5sp", expectedDeltaPt = 20f)
     }
 
-    @Test
-    fun `marginTop on second text node adds expected vertical gap (px)`() {
-        // CSS px @ 96dpi: 1px = 0.75pt
-        assertGapDeltaApprox(value = "16px", expectedDeltaPt = 12f)
-        assertGapDeltaApprox(value = "40px", expectedDeltaPt = 30f)
-    }
-
     private fun assertGapDeltaApprox(value: String, expectedDeltaPt: Float) {
         val baselineGap = renderAndMeasureGap(secondTextMarginTop = null)
         val withMarginGap = renderAndMeasureGap(secondTextMarginTop = value)


### PR DESCRIPTION
Refs #323 (specifically: "margin-top op text veld wordt niet in de pdf preview toegepast")

## Summary

- **Backend dropped px margins**: `StyleApplicator.parseSize` only recognized `pt`, `mm`, and `sp`. Templates with legacy `px` margin/padding (left over from before the `sp`/`pt` unit migration) fell through to `toFloatOrNull()` on the whole string and silently returned null, so `setMargin*()` was never called. Now parses `px` at 96 DPI (`1px = 0.75pt`).
- **Editor canvas ignored sp margins**: The canvas wrote resolved style values straight into CSS via `styleMap`. Browsers don't understand `sp`, so values like `marginTop: 2sp` rendered nothing in the editor — making editor and PDF disagree. The new `toStyleMap` helper rewrites every `Nsp` token to absolute `pt`, using the theme's spacing unit.
- **Inspector kept legacy px alive**: When a node's existing margin used a unit no longer offered by the inspector (e.g. `px` after the `sp`/`pt` switch), the dropdown showed an allowed option but the spacing input internally still used the old unit — every new edit re-saved as `Npx`. `renderSpacingInput` now migrates to the first allowed unit on read, converting displayed values accordingly. The first user edit then transparently migrates the whole spacing block.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

> Refactoring: extracted `toStyleMap`/`camelToKebab` from `EpistolaCanvas.ts` into a testable `style-css.ts` module; reshaped `convertSideValue` around a shared `toPt` helper so additional unit conversions stay localized.

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (gradle test)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow Conventional Commits

## Test plan

- [x] `StyleApplicatorTest`: `parseSize` handles `pt`, `px` (16px → 12pt, 40px → 30pt), `sp`, `mm`, returns null for unknown units.
- [x] `TextNodeMarginRegressionTest`: position-based assertions that `marginTop` on a text node produces the expected vertical gap in the rendered PDF for `pt`, `sp`, and `px` values. Replaces previous margin tests that only checked `pdf.isNotEmpty()`.
- [x] `style-css.test.ts`: `Nsp` rewrite handles single value, decimal, shorthand (`2sp solid #fff`), preserves non-sp values, custom base unit.
- [x] `style-inputs.test.ts`: `convertSideValue` covers sp ↔ pt, px → pt (16px → 12pt), px → sp (16px → 3sp), unknown unit fallthrough.
- [ ] Manual: open a template with `px` margins (e.g. user's table+text scenario) — inspector shows values in `pt`, editing migrates the spacing block to `pt`, generated PDF shows the correct vertical/horizontal margins.
- [ ] Manual: set `marginTop: 2sp` on a text block — editor canvas shows the gap (was invisible before), PDF matches.