### PR TITLE
fix(generation): support svg/webp image rendering in PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
 ### Fixed
 
 - **Theme cascade catalog key**: `ThemeStyleResolver` now passes `defaultThemeCatalogKey` through the cascade, preventing "Expected zero to one elements" errors when the same theme ID exists in multiple catalogs.
+### Added
+
+- **SVG and WEBP image support in PDF**: The PDF renderer now supports SVG (via iText SVG converter) and WEBP (via TwelveMonkeys ImageIO) image formats in addition to PNG and JPEG.
+- **Render mode (STRICT/PREVIEW)**: New `RenderMode` controls error handling during PDF generation. STRICT mode fails fast on corrupt assets (for production renders), PREVIEW mode renders a visible error placeholder (for editor previews). Live cascade renders default to PREVIEW; snapshot renders default to STRICT.
+
+### Changed
+
+- **SVG converter decoupled from RenderContext**: SVG image conversion is now injected into `ImageNodeRenderer` via a `SvgImageConverter` fun interface, keeping `RenderContext` library-agnostic for future non-iText PDF renderers.
 
 ## [0.16.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - **Theme cascade catalog key**: `ThemeStyleResolver` now passes `defaultThemeCatalogKey` through the cascade, preventing "Expected zero to one elements" errors when the same theme ID exists in multiple catalogs.
+
 ### Added
 
 - **SVG and WEBP image support in PDF**: The PDF renderer now supports SVG (via iText SVG converter) and WEBP (via TwelveMonkeys ImageIO) image formats in addition to PNG and JPEG.

--- a/apps/epistola/src/main/resources/templates/assets/new.html
+++ b/apps/epistola/src/main/resources/templates/assets/new.html
@@ -10,7 +10,7 @@
 
         <div class="card create-form-card">
             <div class="card-content">
-                <form th:hx-post="@{/tenants/{tenantId}/assets(tenantId=${tenantId})}" hx-encoding="multipart/form-data">
+                <form id="asset-upload-form" th:hx-post="@{/tenants/{tenantId}/assets(tenantId=${tenantId})}" hx-encoding="multipart/form-data">
                     <div th:if="${catalogs != null && !catalogs.isEmpty()}" class="form-group">
                         <label class="ep-label" for="catalog">Catalog</label>
                         <select id="catalog" name="catalog" class="ep-input" required>
@@ -38,7 +38,7 @@
                         <div id="file-preview" style="display: none; margin-top: var(--ep-space-3);">
                             <span id="file-name" class="text-sm"></span>
                         </div>
-                        <span class="form-error" th:if="${error != null}" th:text="${error}"></span>
+                        <span id="asset-upload-error" class="form-error" th:text="${error}"></span>
                     </div>
                     <div class="form-actions">
                         <button type="submit" class="btn btn-primary">Upload</button>
@@ -49,15 +49,37 @@
         </div>
 
         <script>
+            var uploadForm = document.getElementById('asset-upload-form');
+            var uploadError = document.getElementById('asset-upload-error');
+
             document.getElementById('asset-file-input').addEventListener('change', function() {
                 var preview = document.getElementById('file-preview');
                 var fileName = document.getElementById('file-name');
                 if (this.files.length > 0) {
                     fileName.textContent = this.files[0].name;
                     preview.style.display = 'block';
+                    uploadError.textContent = '';
                 } else {
                     preview.style.display = 'none';
                 }
+            });
+
+            uploadForm.addEventListener('htmx:responseError', function(event) {
+                var xhr = event.detail && event.detail.xhr;
+                if (!xhr || xhr.status < 400) {
+                    return;
+                }
+
+                try {
+                    var body = JSON.parse(xhr.responseText || '{}');
+                    uploadError.textContent = body.error || 'Failed to upload asset. Please try again.';
+                } catch (e) {
+                    uploadError.textContent = 'Failed to upload asset. Please try again.';
+                }
+            });
+
+            uploadForm.addEventListener('htmx:beforeRequest', function() {
+                uploadError.textContent = '';
             });
 
             function handleFileDrop(event) {

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -139,7 +139,10 @@
                         headers: { 'Accept': 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
                         body: formData,
                     });
-                    if (!resp.ok) throw new Error('Failed to upload asset');
+                    if (!resp.ok) {
+                        const err = await resp.json().catch(() => ({}));
+                        throw new Error(err.error || 'Failed to upload asset');
+                    }
                     return await resp.json();
                 },
             },

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/assets/AssetRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/assets/AssetRoutesTest.kt
@@ -1,0 +1,68 @@
+package app.epistola.suite.assets
+
+import app.epistola.suite.BaseIntegrationTest
+import app.epistola.suite.EpistolaSuiteApplication
+import app.epistola.suite.tenants.Tenant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+
+@SpringBootTest(classes = [EpistolaSuiteApplication::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+class AssetRoutesTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @Test
+    fun `POST assets returns validation error for unsupported media type`() = fixture {
+        lateinit var testTenant: Tenant
+
+        given {
+            testTenant = tenant("Asset Tenant")
+        }
+
+        whenever {
+            val headers = HttpHeaders()
+            headers.contentType = MediaType.MULTIPART_FORM_DATA
+            headers.accept = listOf(MediaType.APPLICATION_JSON)
+
+            val payload = LinkedMultiValueMap<String, Any>()
+            payload.add(
+                "file",
+                HttpEntity(
+                    object : ByteArrayResource("not-an-image".toByteArray()) {
+                        override fun getFilename(): String = "report.xlsx"
+                    },
+                    HttpHeaders().apply {
+                        contentType = MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+                    },
+                ),
+            )
+            payload.add("catalog", "default")
+
+            restTemplate.postForEntity(
+                "/tenants/${testTenant.id}/assets",
+                HttpEntity(payload, headers),
+                String::class.java,
+            )
+        }
+
+        then {
+            val response = result<org.springframework.http.ResponseEntity<String>>()
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.headers.contentType).isEqualTo(MediaType.APPLICATION_JSON)
+            assertThat(response.body).contains("Unsupported asset media type")
+            assertThat(response.body).contains("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        }
+    }
+}

--- a/modules/editor/src/main/typescript/components/image/asset-picker-dialog.ts
+++ b/modules/editor/src/main/typescript/components/image/asset-picker-dialog.ts
@@ -35,6 +35,7 @@ export function openAssetPickerDialog(callbacks: AssetPickerCallbacks): Promise<
         <div class="asset-picker-upload-zone" id="asset-picker-upload">
           <p>Drop image here or <label class="asset-picker-upload-link" for="asset-picker-file">browse</label></p>
           <p class="asset-picker-upload-hint">PNG, JPEG, WebP, SVG — max 5MB</p>
+          <p class="asset-picker-upload-error" id="asset-picker-upload-error" role="alert" aria-live="polite"></p>
           <input type="file" id="asset-picker-file"
                  accept="image/png,image/jpeg,image/webp,image/svg+xml"
                  style="display: none;" />
@@ -54,6 +55,7 @@ export function openAssetPickerDialog(callbacks: AssetPickerCallbacks): Promise<
     const grid = dialog.querySelector<HTMLElement>('#asset-picker-grid')!;
     const uploadZone = dialog.querySelector<HTMLElement>('#asset-picker-upload')!;
     const fileInput = dialog.querySelector<HTMLInputElement>('#asset-picker-file')!;
+    const uploadError = dialog.querySelector<HTMLElement>('#asset-picker-upload-error')!;
     const closeBtn = dialog.querySelector<HTMLElement>('.asset-picker-close')!;
     const cancelBtn = dialog.querySelector<HTMLElement>('.cancel')!;
     const insertBtn = dialog.querySelector<HTMLButtonElement>('.insert')!;
@@ -113,6 +115,7 @@ export function openAssetPickerDialog(callbacks: AssetPickerCallbacks): Promise<
 
     // Upload handling
     const handleUpload = async (file: File) => {
+      uploadError.textContent = '';
       uploadZone.classList.add('uploading');
       try {
         const asset = await callbacks.uploadAsset(file);
@@ -128,6 +131,7 @@ export function openAssetPickerDialog(callbacks: AssetPickerCallbacks): Promise<
         }
       } catch (err) {
         console.error('Asset upload failed:', err);
+        uploadError.textContent = err instanceof Error ? err.message : 'Failed to upload asset.';
       } finally {
         uploadZone.classList.remove('uploading');
       }

--- a/modules/editor/src/main/typescript/components/image/image.css
+++ b/modules/editor/src/main/typescript/components/image/image.css
@@ -115,6 +115,23 @@
   font-size: var(--ep-text-xs);
 }
 
+.asset-picker-upload-error {
+  display: none;
+  text-align: left;
+  padding: var(--ep-space-2) var(--ep-space-3);
+  border-radius: var(--ep-radius-sm);
+  border: 1px solid var(--ep-red-500);
+  background: var(--ep-red-50);
+  color: var(--ep-red-700);
+  font-size: var(--ep-text-xs);
+  margin-top: var(--ep-space-1);
+  line-height: 1.4;
+}
+
+.asset-picker-upload-error:not(:empty) {
+  display: block;
+}
+
 .asset-picker-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/GenerationService.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/GenerationService.kt
@@ -3,6 +3,7 @@ package app.epistola.suite.generation
 import app.epistola.generation.pdf.AssetResolver
 import app.epistola.generation.pdf.DirectPdfRenderer
 import app.epistola.generation.pdf.PdfMetadata
+import app.epistola.generation.pdf.RenderMode
 import app.epistola.generation.pdf.RenderingDefaults
 import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TemplateKey
@@ -92,6 +93,7 @@ class GenerationService(
             assetResolver = assetResolver,
             renderingDefaults = renderingDefaults,
             spacingUnit = resolvedStyles.spacingUnit,
+            renderMode = RenderMode.PREVIEW,
         )
     }
 

--- a/modules/generation/build.gradle.kts
+++ b/modules/generation/build.gradle.kts
@@ -7,7 +7,11 @@ dependencies {
     implementation(libs.epistola.model)
 
     // iText 9 for PDF generation
-    implementation("com.itextpdf:itext-core:9.5.0")
+    implementation("com.itextpdf:itext-core:9.6.0")
+    implementation("com.itextpdf:svg:9.6.0")
+
+    // WEBP decoding for PDF image rendering
+    implementation("com.twelvemonkeys.imageio:imageio-webp:3.13.1")
 
     // Kotlin reflection for expression evaluation
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
@@ -33,7 +33,6 @@ import java.io.OutputStream
  */
 class DirectPdfRenderer(
     private val expressionEvaluator: CompositeExpressionEvaluator = CompositeExpressionEvaluator(),
-    private val nodeRendererRegistry: NodeRendererRegistry = createDefaultRegistry(),
     private val defaultExpressionLanguage: ExpressionLanguage = ExpressionLanguage.jsonata,
 ) {
 
@@ -62,6 +61,7 @@ class DirectPdfRenderer(
         assetResolver: AssetResolver? = null,
         renderingDefaults: RenderingDefaults = RenderingDefaults.CURRENT,
         spacingUnit: Float = SpacingScale.DEFAULT_BASE_UNIT,
+        renderMode: RenderMode = RenderMode.STRICT,
     ) {
         TwoPassAnalyzer.validate(document)
 
@@ -79,6 +79,7 @@ class DirectPdfRenderer(
                 assetResolver = assetResolver,
                 renderingDefaults = renderingDefaults,
                 spacingUnit = spacingUnit,
+                renderMode = renderMode,
                 headerNode = headerNode,
                 footerNode = footerNode,
             )
@@ -94,6 +95,7 @@ class DirectPdfRenderer(
                 assetResolver = assetResolver,
                 renderingDefaults = renderingDefaults,
                 spacingUnit = spacingUnit,
+                renderMode = renderMode,
             )
         }
     }
@@ -107,6 +109,7 @@ class DirectPdfRenderer(
         assetResolver: AssetResolver?,
         renderingDefaults: RenderingDefaults,
         spacingUnit: Float,
+        renderMode: RenderMode,
     ): RenderContext {
         val fontCache = FontCache(pdfaCompliant)
         val tipTapConverter = TipTapConverter(expressionEvaluator, defaultExpressionLanguage, renderingDefaults)
@@ -121,6 +124,7 @@ class DirectPdfRenderer(
             blockStylePresets = blockStylePresets,
             document = document,
             assetResolver = assetResolver,
+            renderMode = renderMode,
             renderingDefaults = renderingDefaults,
             spacingUnit = spacingUnit,
             systemParams = SystemParameterRegistry.buildGlobalParams(),
@@ -138,6 +142,7 @@ class DirectPdfRenderer(
         assetResolver: AssetResolver?,
         renderingDefaults: RenderingDefaults,
         spacingUnit: Float,
+        renderMode: RenderMode,
     ) {
         val pageSettings = document.pageSettingsOverride ?: renderingDefaults.defaultPageSettings
         val margins = pageSettings.margins
@@ -153,6 +158,7 @@ class DirectPdfRenderer(
             assetResolver = assetResolver,
             renderingDefaults = renderingDefaults,
             spacingUnit = spacingUnit,
+            renderMode = renderMode,
         )
 
         val headerNode = document.nodes.values.firstOrNull { it.type == "pageheader" }
@@ -198,6 +204,7 @@ class DirectPdfRenderer(
         assetResolver: AssetResolver?,
         renderingDefaults: RenderingDefaults,
         spacingUnit: Float,
+        renderMode: RenderMode,
         headerNode: Node?,
         footerNode: Node?,
     ) {
@@ -216,6 +223,7 @@ class DirectPdfRenderer(
             assetResolver = assetResolver,
             renderingDefaults = renderingDefaults,
             spacingUnit = spacingUnit,
+            renderMode = renderMode,
         )
 
         val headerHeight = headerNode?.let {
@@ -244,6 +252,7 @@ class DirectPdfRenderer(
             assetResolver = assetResolver,
             renderingDefaults = renderingDefaults,
             spacingUnit = spacingUnit,
+            renderMode = renderMode,
         ).withTotalPages(FIRST_PASS_PAGE_TOTAL_PLACEHOLDER)
         val totalPages = performRenderWithContext(
             outputStream = tempOutput,
@@ -273,6 +282,7 @@ class DirectPdfRenderer(
             assetResolver = assetResolver,
             renderingDefaults = renderingDefaults,
             spacingUnit = spacingUnit,
+            renderMode = renderMode,
         ).withTotalPages(totalPages)
 
         performRenderWithContext(
@@ -312,6 +322,8 @@ class DirectPdfRenderer(
         val pdfDocument = createPdfDocument(writer, enablePdfA)
         if (enableMetadata) applyMetadata(pdfDocument, metadata)
 
+        val nodeRendererRegistry = createDefaultRegistry(pdfDocument)
+
         val pageSize = getPageSize(pageSettings.format, pageSettings.orientation)
         val iTextDocument = Document(pdfDocument, pageSize)
         iTextDocument.setFont(context.fontCache.regular)
@@ -350,8 +362,7 @@ class DirectPdfRenderer(
             )
         }
 
-        val documentContext = context.copy(pdfDocument = pdfDocument)
-        val elements = nodeRendererRegistry.renderNode(renderDocument.root, renderDocument, documentContext)
+        val elements = nodeRendererRegistry.renderNode(renderDocument.root, renderDocument, context)
         for (element in elements) {
             when (element) {
                 is com.itextpdf.layout.element.IBlockElement -> iTextDocument.add(element)
@@ -419,29 +430,37 @@ class DirectPdfRenderer(
 
         /**
          * Creates the default node renderer registry with all built-in renderers.
+         * The [pdfDocument] is used to wire iText-specific SVG conversion into the image renderer.
          */
-        fun createDefaultRegistry(): NodeRendererRegistry = NodeRendererRegistry(
-            mapOf(
-                "root" to ContainerNodeRenderer(),
-                "text" to TextNodeRenderer(),
-                "container" to ContainerNodeRenderer(),
-                "stencil" to ContainerNodeRenderer(),
-                "columns" to ColumnsNodeRenderer(),
-                "table" to TableNodeRenderer(),
-                "conditional" to ConditionalNodeRenderer(),
-                "loop" to LoopNodeRenderer(),
-                "datalist" to DataListNodeRenderer(),
-                "datatable" to DatatableNodeRenderer(),
-                "datatable-column" to DatatableColumnNodeRenderer(),
-                "image" to ImageNodeRenderer(),
-                "qrcode" to QrCodeNodeRenderer(),
-                "separator" to SeparatorNodeRenderer(),
-                "pagebreak" to PageBreakNodeRenderer(),
-                "pageheader" to PageHeaderNodeRenderer(),
-                "pagefooter" to PageFooterNodeRenderer(),
-                "addressblock" to AddressBlockNodeRenderer(),
-            ),
-        )
+        fun createDefaultRegistry(pdfDocument: PdfDocument): NodeRendererRegistry {
+            val svgConverter = ImageNodeRenderer.SvgImageConverter { svgBytes ->
+                java.io.ByteArrayInputStream(svgBytes).use { svgStream ->
+                    com.itextpdf.svg.converter.SvgConverter.convertToImage(svgStream, pdfDocument)
+                }
+            }
+            return NodeRendererRegistry(
+                mapOf(
+                    "root" to ContainerNodeRenderer(),
+                    "text" to TextNodeRenderer(),
+                    "container" to ContainerNodeRenderer(),
+                    "stencil" to ContainerNodeRenderer(),
+                    "columns" to ColumnsNodeRenderer(),
+                    "table" to TableNodeRenderer(),
+                    "conditional" to ConditionalNodeRenderer(),
+                    "loop" to LoopNodeRenderer(),
+                    "datalist" to DataListNodeRenderer(),
+                    "datatable" to DatatableNodeRenderer(),
+                    "datatable-column" to DatatableColumnNodeRenderer(),
+                    "image" to ImageNodeRenderer(svgConverter),
+                    "qrcode" to QrCodeNodeRenderer(),
+                    "separator" to SeparatorNodeRenderer(),
+                    "pagebreak" to PageBreakNodeRenderer(),
+                    "pageheader" to PageHeaderNodeRenderer(),
+                    "pagefooter" to PageFooterNodeRenderer(),
+                    "addressblock" to AddressBlockNodeRenderer(),
+                ),
+            )
+        }
     }
 
     /**

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/DirectPdfRenderer.kt
@@ -350,7 +350,8 @@ class DirectPdfRenderer(
             )
         }
 
-        val elements = nodeRendererRegistry.renderNode(renderDocument.root, renderDocument, context)
+        val documentContext = context.copy(pdfDocument = pdfDocument)
+        val elements = nodeRendererRegistry.renderNode(renderDocument.root, renderDocument, documentContext)
         for (element in elements) {
             when (element) {
                 is com.itextpdf.layout.element.IBlockElement -> iTextDocument.add(element)

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ErrorPlaceholder.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ErrorPlaceholder.kt
@@ -1,0 +1,33 @@
+package app.epistola.generation.pdf
+
+import com.itextpdf.kernel.colors.ColorConstants
+import com.itextpdf.kernel.colors.DeviceRgb
+import com.itextpdf.layout.borders.DashedBorder
+import com.itextpdf.layout.element.Div
+import com.itextpdf.layout.element.IElement
+import com.itextpdf.layout.element.Paragraph
+
+/**
+ * Renders a visible error placeholder for use in [RenderMode.PREVIEW].
+ * Shows a light grey box with a dashed red border and error message,
+ * making it clear to the user that something failed without crashing the render.
+ */
+object ErrorPlaceholder {
+
+    private val BACKGROUND_COLOR = DeviceRgb(245, 245, 245)
+    private val BORDER = DashedBorder(ColorConstants.RED, 1f)
+    private const val FONT_SIZE = 8f
+    private const val PADDING = 6f
+
+    fun render(message: String): List<IElement> {
+        val div = Div()
+            .setBackgroundColor(BACKGROUND_COLOR)
+            .setBorder(BORDER)
+            .setPadding(PADDING)
+        val paragraph = Paragraph(message)
+            .setFontSize(FONT_SIZE)
+            .setFontColor(ColorConstants.RED)
+        div.add(paragraph)
+        return listOf(div)
+    }
+}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
@@ -7,7 +7,10 @@ import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IElement
 import com.itextpdf.layout.element.Image
 import com.itextpdf.layout.properties.UnitValue
+import com.itextpdf.svg.converter.SvgConverter
 import org.slf4j.LoggerFactory
+import java.io.ByteArrayInputStream
+import javax.imageio.ImageIO
 
 /**
  * Renders an "image" node to an iText Image element.
@@ -45,28 +48,31 @@ class ImageNodeRenderer : NodeRenderer {
             return emptyList()
         }
 
-        val imageData = ImageDataFactory.create(resolution.content)
-        val image = Image(imageData)
+        val image = createImageElement(resolution, context)
 
         // Apply width/height from props
         val widthStr = props["width"] as? String
         val heightStr = props["height"] as? String
         val hasWidth = !widthStr.isNullOrBlank()
         val hasHeight = !heightStr.isNullOrBlank()
+        val width = widthStr?.takeIf { it.isNotBlank() }
+        val height = heightStr?.takeIf { it.isNotBlank() }
 
         val spacingUnit = context.spacingUnit
         when {
             hasWidth && hasHeight -> {
-                applyDimension(widthStr!!, isWidth = true, image, spacingUnit)
-                applyDimension(heightStr!!, isWidth = false, image, spacingUnit)
+                applyDimension(requireNotNull(width), isWidth = true, image, spacingUnit)
+                applyDimension(requireNotNull(height), isWidth = false, image, spacingUnit)
             }
             hasWidth -> {
-                applyDimension(widthStr!!, isWidth = true, image, spacingUnit)
-                scaleProportionally(widthStr, isWidthGiven = true, image, imageData, spacingUnit)
+                val widthValue = requireNotNull(width)
+                applyDimension(widthValue, isWidth = true, image, spacingUnit)
+                scaleProportionally(widthValue, isWidthGiven = true, image, spacingUnit)
             }
             hasHeight -> {
-                applyDimension(heightStr!!, isWidth = false, image, spacingUnit)
-                scaleProportionally(heightStr, isWidthGiven = false, image, imageData, spacingUnit)
+                val heightValue = requireNotNull(height)
+                applyDimension(heightValue, isWidth = false, image, spacingUnit)
+                scaleProportionally(heightValue, isWidthGiven = false, image, spacingUnit)
             }
             else -> {
                 // No dimensions specified: auto-scale to fit available width
@@ -119,14 +125,13 @@ class ImageNodeRenderer : NodeRenderer {
         value: String,
         isWidthGiven: Boolean,
         image: Image,
-        imageData: com.itextpdf.io.image.ImageData,
         spacingUnit: Float,
     ) {
         if (value.endsWith("%")) return // let iText handle percentage layout
 
         val pt = parseToPt(value, spacingUnit) ?: return
-        val intrinsicWidth = imageData.width // in points
-        val intrinsicHeight = imageData.height // in points
+        val intrinsicWidth = image.imageWidth
+        val intrinsicHeight = image.imageHeight
         if (intrinsicWidth <= 0 || intrinsicHeight <= 0) return
 
         if (isWidthGiven) {
@@ -145,5 +150,27 @@ class ImageNodeRenderer : NodeRenderer {
             value.endsWith("pt") -> value.removeSuffix("pt").toFloatOrNull()
             else -> value.toFloatOrNull()
         }
+    }
+
+    private fun createImageElement(resolution: AssetResolution, context: RenderContext): Image = when (resolution.mimeType) {
+        "image/svg+xml" -> createSvgImage(resolution.content, context)
+        "image/webp" -> createWebpImage(resolution.content)
+        else -> Image(ImageDataFactory.create(resolution.content))
+    }
+
+    private fun createSvgImage(content: ByteArray, context: RenderContext): Image {
+        val pdfDocument = context.pdfDocument
+            ?: throw IllegalStateException("PDF document context is required for SVG conversion")
+        return ByteArrayInputStream(content).use { svgStream ->
+            SvgConverter.convertToImage(svgStream, pdfDocument)
+        }
+    }
+
+    private fun createWebpImage(content: ByteArray): Image {
+        val bufferedImage = ByteArrayInputStream(content).use { webpStream ->
+            ImageIO.read(webpStream)
+        } ?: throw IllegalArgumentException("Failed to decode WEBP image content")
+        val imageData = ImageDataFactory.create(bufferedImage, null)
+        return Image(imageData)
     }
 }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
@@ -7,10 +7,12 @@ import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IElement
 import com.itextpdf.layout.element.Image
 import com.itextpdf.layout.properties.UnitValue
-import com.itextpdf.svg.converter.SvgConverter
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import javax.imageio.ImageIO
+
+/** Thrown in [RenderMode.STRICT] when an image asset cannot be decoded. */
+class ImageRenderException(message: String, cause: Throwable) : RuntimeException(message, cause)
 
 /**
  * Renders an "image" node to an iText Image element.
@@ -19,7 +21,24 @@ import javax.imageio.ImageIO
  * [RenderContext] to load the image bytes. Gracefully skips if no resolver is
  * available, no assetId is specified, or the asset cannot be found.
  */
-class ImageNodeRenderer : NodeRenderer {
+class ImageNodeRenderer(
+    private val svgConverter: SvgImageConverter = SvgImageConverter.UNSUPPORTED,
+) : NodeRenderer {
+
+    /**
+     * Converts raw SVG bytes to an iText [Image]. The conversion strategy is
+     * injected so that [ImageNodeRenderer] stays independent of any specific
+     * PDF library's SVG support (e.g., iText's `SvgConverter` requires a
+     * `PdfDocument` that only the concrete renderer owns).
+     */
+    fun interface SvgImageConverter {
+        fun convert(svgBytes: ByteArray): Image
+
+        companion object {
+            /** Default no-op converter that rejects SVG input. */
+            val UNSUPPORTED = SvgImageConverter { throw UnsupportedOperationException("SVG rendering is not supported by this renderer") }
+        }
+    }
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -48,7 +67,18 @@ class ImageNodeRenderer : NodeRenderer {
             return emptyList()
         }
 
-        val image = createImageElement(resolution, context)
+        val image = try {
+            createImageElement(resolution)
+        } catch (e: Exception) {
+            logger.warn("Failed to decode image asset {} ({}): {}", assetId, resolution.mimeType, e.message)
+            return when (context.renderMode) {
+                RenderMode.STRICT -> throw ImageRenderException(
+                    "Failed to render image node '${node.id}' (asset=$assetId, type=${resolution.mimeType}): ${e.message}",
+                    e,
+                )
+                RenderMode.PREVIEW -> ErrorPlaceholder.render("Image failed: ${e.message}")
+            }
+        }
 
         // Apply width/height from props
         val widthStr = props["width"] as? String
@@ -152,18 +182,10 @@ class ImageNodeRenderer : NodeRenderer {
         }
     }
 
-    private fun createImageElement(resolution: AssetResolution, context: RenderContext): Image = when (resolution.mimeType) {
-        "image/svg+xml" -> createSvgImage(resolution.content, context)
+    private fun createImageElement(resolution: AssetResolution): Image = when (resolution.mimeType) {
+        "image/svg+xml" -> svgConverter.convert(resolution.content)
         "image/webp" -> createWebpImage(resolution.content)
         else -> Image(ImageDataFactory.create(resolution.content))
-    }
-
-    private fun createSvgImage(content: ByteArray, context: RenderContext): Image {
-        val pdfDocument = context.pdfDocument
-            ?: throw IllegalStateException("PDF document context is required for SVG conversion")
-        return ByteArrayInputStream(content).use { svgStream ->
-            SvgConverter.convertToImage(svgStream, pdfDocument)
-        }
     }
 
     private fun createWebpImage(content: ByteArray): Image {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderContext.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderContext.kt
@@ -6,8 +6,6 @@ import app.epistola.generation.expression.CompositeExpressionEvaluator
 import app.epistola.template.model.DocumentStyles
 import app.epistola.template.model.ExpressionLanguage
 import app.epistola.template.model.TemplateDocument
-import com.itextpdf.kernel.pdf.PdfDocument
-
 /**
  * Context passed to node renderers during PDF generation.
  */
@@ -27,8 +25,8 @@ data class RenderContext(
     val document: TemplateDocument,
     /** Optional asset resolver for loading image content during rendering */
     val assetResolver: AssetResolver? = null,
-    /** Active PdfDocument for renderers that require document-bound conversion (e.g., SVG). */
-    val pdfDocument: PdfDocument? = null,
+    /** Controls error handling behavior (fail vs placeholder). */
+    val renderMode: RenderMode = RenderMode.STRICT,
     /** Versioned rendering defaults (font sizes, spacing, borders, etc.) */
     val renderingDefaults: RenderingDefaults = RenderingDefaults.CURRENT,
     /** Theme-configurable spacing base unit in points (see [SpacingScale]). */

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderContext.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderContext.kt
@@ -6,6 +6,7 @@ import app.epistola.generation.expression.CompositeExpressionEvaluator
 import app.epistola.template.model.DocumentStyles
 import app.epistola.template.model.ExpressionLanguage
 import app.epistola.template.model.TemplateDocument
+import com.itextpdf.kernel.pdf.PdfDocument
 
 /**
  * Context passed to node renderers during PDF generation.
@@ -26,6 +27,8 @@ data class RenderContext(
     val document: TemplateDocument,
     /** Optional asset resolver for loading image content during rendering */
     val assetResolver: AssetResolver? = null,
+    /** Active PdfDocument for renderers that require document-bound conversion (e.g., SVG). */
+    val pdfDocument: PdfDocument? = null,
     /** Versioned rendering defaults (font sizes, spacing, borders, etc.) */
     val renderingDefaults: RenderingDefaults = RenderingDefaults.CURRENT,
     /** Theme-configurable spacing base unit in points (see [SpacingScale]). */

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderMode.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/RenderMode.kt
@@ -1,0 +1,12 @@
+package app.epistola.generation.pdf
+
+/**
+ * Controls error handling behavior during PDF rendering.
+ */
+enum class RenderMode {
+    /** Production rendering: fail on errors (corrupt assets, missing required data). */
+    STRICT,
+
+    /** Preview/draft rendering: render a visible placeholder on errors so the user sees what's broken. */
+    PREVIEW,
+}

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/ImageNodeRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/ImageNodeRendererTest.kt
@@ -3,7 +3,10 @@ package app.epistola.generation.pdf
 import app.epistola.template.model.Node
 import app.epistola.template.model.Slot
 import app.epistola.template.model.TemplateDocument
+import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
+import java.util.Base64
+import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -48,6 +51,14 @@ class ImageNodeRendererTest {
         header + ihdr + idat + iend
     }
 
+    private val testJpegBytes: ByteArray = run {
+        val image = BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB)
+        image.setRGB(0, 0, 0xFF0000)
+        val output = ByteArrayOutputStream()
+        ImageIO.write(image, "jpeg", output)
+        output.toByteArray()
+    }
+
     private fun documentWithImageNode(
         imageProps: Map<String, Any?>,
     ): TemplateDocument {
@@ -80,16 +91,32 @@ class ImageNodeRendererTest {
         }
     }
 
-    @Test
-    fun `renders image node with valid asset`() {
-        val document = documentWithImageNode(mapOf("assetId" to "asset-123"))
-
+    private fun assertRenderedPdf(document: TemplateDocument, resolver: AssetResolver?) {
         val output = ByteArrayOutputStream()
-        renderer.render(document, emptyMap(), output, assetResolver = resolverWithTestPng)
+        renderer.render(document, emptyMap(), output, assetResolver = resolver)
 
         val pdfBytes = output.toByteArray()
         assertTrue(pdfBytes.isNotEmpty())
         assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+    }
+
+    @Test
+    fun `renders PNG image asset`() {
+        val document = documentWithImageNode(mapOf("assetId" to "asset-123"))
+        assertRenderedPdf(document, resolverWithTestPng)
+    }
+
+    @Test
+    fun `renders JPEG image asset`() {
+        val resolver = AssetResolver { assetId ->
+            if (assetId == "asset-jpeg") {
+                AssetResolution(content = testJpegBytes, mimeType = "image/jpeg")
+            } else {
+                null
+            }
+        }
+        val document = documentWithImageNode(mapOf("assetId" to "asset-jpeg"))
+        assertRenderedPdf(document, resolver)
     }
 
     @Test
@@ -97,13 +124,7 @@ class ImageNodeRendererTest {
         val document = documentWithImageNode(
             mapOf("assetId" to "asset-123", "width" to "200px", "height" to "100px"),
         )
-
-        val output = ByteArrayOutputStream()
-        renderer.render(document, emptyMap(), output, assetResolver = resolverWithTestPng)
-
-        val pdfBytes = output.toByteArray()
-        assertTrue(pdfBytes.isNotEmpty())
-        assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+        assertRenderedPdf(document, resolverWithTestPng)
     }
 
     @Test
@@ -111,48 +132,56 @@ class ImageNodeRendererTest {
         val document = documentWithImageNode(
             mapOf("assetId" to "asset-123", "width" to "50%"),
         )
-
-        val output = ByteArrayOutputStream()
-        renderer.render(document, emptyMap(), output, assetResolver = resolverWithTestPng)
-
-        val pdfBytes = output.toByteArray()
-        assertTrue(pdfBytes.isNotEmpty())
-        assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+        assertRenderedPdf(document, resolverWithTestPng)
     }
 
     @Test
     fun `skips gracefully when no assetId`() {
         val document = documentWithImageNode(mapOf("alt" to "placeholder"))
-
-        val output = ByteArrayOutputStream()
-        renderer.render(document, emptyMap(), output, assetResolver = resolverWithTestPng)
-
-        val pdfBytes = output.toByteArray()
-        assertTrue(pdfBytes.isNotEmpty())
-        assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+        assertRenderedPdf(document, resolverWithTestPng)
     }
 
     @Test
     fun `skips gracefully when asset not found`() {
         val document = documentWithImageNode(mapOf("assetId" to "non-existent"))
-
-        val output = ByteArrayOutputStream()
-        renderer.render(document, emptyMap(), output, assetResolver = resolverWithTestPng)
-
-        val pdfBytes = output.toByteArray()
-        assertTrue(pdfBytes.isNotEmpty())
-        assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+        assertRenderedPdf(document, resolverWithTestPng)
     }
 
     @Test
     fun `skips gracefully when no resolver`() {
         val document = documentWithImageNode(mapOf("assetId" to "asset-123"))
+        assertRenderedPdf(document, null)
+    }
 
-        val output = ByteArrayOutputStream()
-        renderer.render(document, emptyMap(), output, assetResolver = null)
+    @Test
+    fun `renders SVG image asset`() {
+        val svgBytes = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+              <rect width="10" height="10" fill="red" />
+            </svg>
+        """.trimIndent().toByteArray()
+        val resolver = AssetResolver { assetId ->
+            if (assetId == "asset-svg") {
+                AssetResolution(content = svgBytes, mimeType = "image/svg+xml")
+            } else {
+                null
+            }
+        }
+        val document = documentWithImageNode(mapOf("assetId" to "asset-svg"))
+        assertRenderedPdf(document, resolver)
+    }
 
-        val pdfBytes = output.toByteArray()
-        assertTrue(pdfBytes.isNotEmpty())
-        assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+    @Test
+    fun `renders WEBP image asset`() {
+        val webpBytes = Base64.getDecoder().decode("UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA=")
+        val resolver = AssetResolver { assetId ->
+            if (assetId == "asset-webp") {
+                AssetResolution(content = webpBytes, mimeType = "image/webp")
+            } else {
+                null
+            }
+        }
+        val document = documentWithImageNode(mapOf("assetId" to "asset-webp"))
+        assertRenderedPdf(document, resolver)
     }
 }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/ImageNodeRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/ImageNodeRendererTest.kt
@@ -8,6 +8,7 @@ import java.io.ByteArrayOutputStream
 import java.util.Base64
 import javax.imageio.ImageIO
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ImageNodeRendererTest {
@@ -91,9 +92,13 @@ class ImageNodeRendererTest {
         }
     }
 
-    private fun assertRenderedPdf(document: TemplateDocument, resolver: AssetResolver?) {
+    private fun assertRenderedPdf(
+        document: TemplateDocument,
+        resolver: AssetResolver?,
+        renderMode: RenderMode = RenderMode.STRICT,
+    ) {
         val output = ByteArrayOutputStream()
-        renderer.render(document, emptyMap(), output, assetResolver = resolver)
+        renderer.render(document, emptyMap(), output, assetResolver = resolver, renderMode = renderMode)
 
         val pdfBytes = output.toByteArray()
         assertTrue(pdfBytes.isNotEmpty())
@@ -173,6 +178,7 @@ class ImageNodeRendererTest {
 
     @Test
     fun `renders WEBP image asset`() {
+        // 8x8 red pixel WEBP
         val webpBytes = Base64.getDecoder().decode("UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA=")
         val resolver = AssetResolver { assetId ->
             if (assetId == "asset-webp") {
@@ -183,5 +189,57 @@ class ImageNodeRendererTest {
         }
         val document = documentWithImageNode(mapOf("assetId" to "asset-webp"))
         assertRenderedPdf(document, resolver)
+    }
+
+    // -- RenderMode.STRICT: corrupt assets throw --
+
+    @Test
+    fun `strict mode throws on corrupt PNG`() {
+        val resolver = AssetResolver { AssetResolution(content = byteArrayOf(0, 1, 2, 3), mimeType = "image/png") }
+        val document = documentWithImageNode(mapOf("assetId" to "bad"))
+        assertFailsWith<ImageRenderException> {
+            assertRenderedPdf(document, resolver, RenderMode.STRICT)
+        }
+    }
+
+    @Test
+    fun `strict mode throws on malformed SVG`() {
+        val resolver = AssetResolver { AssetResolution(content = "not svg".toByteArray(), mimeType = "image/svg+xml") }
+        val document = documentWithImageNode(mapOf("assetId" to "bad"))
+        assertFailsWith<ImageRenderException> {
+            assertRenderedPdf(document, resolver, RenderMode.STRICT)
+        }
+    }
+
+    @Test
+    fun `strict mode throws on corrupt WEBP`() {
+        val resolver = AssetResolver { AssetResolution(content = byteArrayOf(0, 1, 2, 3), mimeType = "image/webp") }
+        val document = documentWithImageNode(mapOf("assetId" to "bad"))
+        assertFailsWith<ImageRenderException> {
+            assertRenderedPdf(document, resolver, RenderMode.STRICT)
+        }
+    }
+
+    // -- RenderMode.PREVIEW: corrupt assets render placeholder --
+
+    @Test
+    fun `preview mode renders placeholder for corrupt PNG`() {
+        val resolver = AssetResolver { AssetResolution(content = byteArrayOf(0, 1, 2, 3), mimeType = "image/png") }
+        val document = documentWithImageNode(mapOf("assetId" to "bad"))
+        assertRenderedPdf(document, resolver, RenderMode.PREVIEW)
+    }
+
+    @Test
+    fun `preview mode renders placeholder for malformed SVG`() {
+        val resolver = AssetResolver { AssetResolution(content = "not svg".toByteArray(), mimeType = "image/svg+xml") }
+        val document = documentWithImageNode(mapOf("assetId" to "bad"))
+        assertRenderedPdf(document, resolver, RenderMode.PREVIEW)
+    }
+
+    @Test
+    fun `preview mode renders placeholder for corrupt WEBP`() {
+        val resolver = AssetResolver { AssetResolution(content = byteArrayOf(0, 1, 2, 3), mimeType = "image/webp") }
+        val document = documentWithImageNode(mapOf("assetId" to "bad"))
+        assertRenderedPdf(document, resolver, RenderMode.PREVIEW)
     }
 }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/NodeRendererRegistryTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/NodeRendererRegistryTest.kt
@@ -12,7 +12,12 @@ import kotlin.test.assertFailsWith
 
 class NodeRendererRegistryTest {
 
-    private val registry = DirectPdfRenderer.createDefaultRegistry()
+    private val registry = NodeRendererRegistry(
+        mapOf(
+            "root" to ContainerNodeRenderer(),
+            "text" to TextNodeRenderer(),
+        ),
+    )
     private val evaluator = CompositeExpressionEvaluator()
     private val fontCache = FontCache(pdfaCompliant = false)
     private val tipTapConverter = TipTapConverter(evaluator)


### PR DESCRIPTION
## Description

Fixes PDF generation failures when templates include uploaded `image/svg+xml` or `image/webp` assets.

This change updates the generation pipeline to render allowed image MIME types end-to-end:

- `image/png` and `image/jpeg` continue to render via iText image data.
- `image/svg+xml` now renders via iText SVG conversion, injected through a `SvgImageConverter` fun interface.
- `image/webp` now decodes through ImageIO (TwelveMonkeys WebP plugin) and renders as an iText image.

### SVG converter decoupling

SVG conversion requires an iText `PdfDocument` reference, but `RenderContext` must stay library-agnostic to support future non-iText PDF renderers. Instead of adding `PdfDocument` to `RenderContext`, the SVG conversion strategy is injected into `ImageNodeRenderer` via a `SvgImageConverter` fun interface. `DirectPdfRenderer` wires the iText-specific implementation per render.

### RenderMode (STRICT / PREVIEW)

Introduces a `RenderMode` enum on `RenderContext` to control error handling globally:

- **STRICT** (default): Throws `ImageRenderException` on corrupt/invalid assets. Used for production/snapshot renders.
- **PREVIEW**: Renders a visible error placeholder (grey box, dashed red border, error message) so the user sees what's broken without crashing the preview.

`GenerationService.renderPdf()` (live cascade / editor previews) defaults to PREVIEW. `renderPdfWithSnapshot()` (published versions) defaults to STRICT.

### Implementation details

- Added MIME-aware image creation in `ImageNodeRenderer` with `SvgImageConverter` constructor injection.
- Added `RenderMode` enum and `ErrorPlaceholder` helper (reusable by any node renderer).
- Passed `renderMode` through the full render chain: `DirectPdfRenderer` → `RenderContext` → node renderers.
- `NodeRendererRegistryTest` no longer depends on iText.
- Tests cover all image formats (PNG, JPEG, SVG, WEBP) plus error paths for both STRICT (throws) and PREVIEW (placeholder) modes.

## Related Issue(s)

Closes #337

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [ ] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

N/A (backend rendering fix)