### PR TITLE
fix: pdf rendering issues (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - **Contract publish impact preview**: Breaking contract publishes show a confirmation dialog listing breaking changes and affected template versions with their active environment deployments.
 - **Deployment matrix error handling**: Contract compatibility errors shown inline in the deployment matrix instead of generic "An error occurred" message.
 - **Contract usage overview**: Dialog showing all template versions with their contract version (color-coded: green=current, amber=outdated) and active deployments.
+
 ### Fixed
 
 - **Template deletion discoverability**: The "Delete Template" button now appears in the page header on all template detail tabs, not just buried in Settings > Danger Zone. Extracted the delete form into a reusable fragment (`fragments/template-actions.html`). Added `aria-label` with the template name for accessibility. Fixed a CSS bug where `button[type='submit']` globally overrode `.btn-destructive` styles — now scoped to buttons without an explicit `.btn-*` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 
 - **Template deletion discoverability**: The "Delete Template" button now appears in the page header on all template detail tabs, not just buried in Settings > Danger Zone. Extracted the delete form into a reusable fragment (`fragments/template-actions.html`). Added `aria-label` with the template name for accessibility. Fixed a CSS bug where `button[type='submit']` globally overrode `.btn-destructive` styles — now scoped to buttons without an explicit `.btn-*` class.
+- **Negative sizing not enforced**: All size inputs in the editor now reject negative values (`min="0"` on number inputs, `Math.max(0, ...)` in change handlers). The backend `StyleApplicator.parseSize` and `ImageNodeRenderer.parseToPt` now clamp parsed values to `>= 0` via `coerceAtLeast(0f)`. `parseValueWithUnit` no longer accepts leading minus signs. This fixes a bug where copy/pasting or manually entering negative values broke layout or caused iText errors.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - **Contract publish impact preview**: Breaking contract publishes show a confirmation dialog listing breaking changes and affected template versions with their active environment deployments.
 - **Deployment matrix error handling**: Contract compatibility errors shown inline in the deployment matrix instead of generic "An error occurred" message.
 - **Contract usage overview**: Dialog showing all template versions with their contract version (color-coded: green=current, amber=outdated) and active deployments.
+### Fixed
+
+- **Template deletion discoverability**: The "Delete Template" button now appears in the page header on all template detail tabs, not just buried in Settings > Danger Zone. Extracted the delete form into a reusable fragment (`fragments/template-actions.html`). Added `aria-label` with the template name for accessibility. Fixed a CSS bug where `button[type='submit']` globally overrode `.btn-destructive` styles — now scoped to buttons without an explicit `.btn-*` class.
 
 ### Changed
 

--- a/apps/epistola/src/main/resources/static/css/main.css
+++ b/apps/epistola/src/main/resources/static/css/main.css
@@ -131,7 +131,7 @@ main.regular section {
 }
 
 /* Submit button (uses .btn .btn-primary when available, this is for plain submit) */
-button[type='submit'] {
+button[type='submit']:not([class*='btn-']) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -147,11 +147,11 @@ button[type='submit'] {
   transition: background-color var(--ep-transition-base);
 }
 
-button[type='submit']:hover {
+button[type='submit']:not([class*='btn-']):hover {
   background-color: var(--ep-blue-700);
 }
 
-button[type='submit']:focus-visible {
+button[type='submit']:not([class*='btn-']):focus-visible {
   outline: none;
   box-shadow: var(--ep-ring);
 }

--- a/apps/epistola/src/main/resources/templates/fragments/template-actions.html
+++ b/apps/epistola/src/main/resources/templates/fragments/template-actions.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+    <th:block th:fragment="template-delete-form">
+        <form th:if="${auth.has('TEMPLATE_EDIT') and editable}"
+              th:action="@{/tenants/{tenantId}/templates/{catalogId}/{id}/delete(tenantId=${tenantId},catalogId=${catalogId},id=${template.id})}"
+              method="post" hx-boost="false"
+              onsubmit="return confirm('Are you sure you want to delete this template? This action cannot be undone.')">
+            <button type="submit" class="btn btn-sm btn-destructive"
+                    th:aria-label="'Delete template \'' + ${template.name} + '\''">Delete Template</button>
+        </form>
+    </th:block>
+</body>
+</html>

--- a/apps/epistola/src/main/resources/templates/templates/detail.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail.html
@@ -13,6 +13,9 @@
                     <span class="badge badge-muted">Read-only</span> This template belongs to a subscribed catalog.
                 </p>
             </div>
+            <div style="flex-shrink: 0;">
+                <th:block th:replace="~{fragments/template-actions :: template-delete-form}" />
+            </div>
         </div>
 
         <!-- Tab Navigation -->

--- a/apps/epistola/src/main/resources/templates/templates/detail/settings.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail/settings.html
@@ -69,11 +69,7 @@
                 <p class="text-muted" style="margin-bottom: var(--ep-space-4); font-size: var(--ep-text-sm);">
                     Permanently delete this template and all its variants, versions, and data.
                 </p>
-                <form th:action="@{/tenants/{tenantId}/templates/{catalogId}/{id}/delete(tenantId=${tenantId},catalogId=${catalogId},id=${template.id})}"
-                      method="post" hx-boost="false"
-                      onsubmit="return confirm('Are you sure you want to delete this template? This action cannot be undone.')">
-                    <button type="submit" class="btn btn-sm btn-destructive">Delete Template</button>
-                </form>
+                <th:block th:replace="~{fragments/template-actions :: template-delete-form}" />
             </div>
         </div>
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/TemplateDeleteButtonUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/TemplateDeleteButtonUiTest.kt
@@ -1,0 +1,33 @@
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.templates.commands.CreateDocumentTemplate
+import app.epistola.suite.tenants.commands.CreateTenant
+import app.epistola.suite.testing.TestIdHelpers
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TemplateDeleteButtonUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `delete template button is visible in page header on template detail page`() {
+        val (tenant, template) = withMediator {
+            val tenantKey = TenantKey.of("test-ui-tenant-${System.nanoTime()}")
+            val tenant = CreateTenant(id = tenantKey, name = "UI Test Tenant").execute()
+            val tenantId = TenantId(tenant.id)
+            val template = CreateDocumentTemplate(
+                id = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId)),
+                name = "UI Test Template",
+            ).execute()
+            tenant to template
+        }
+
+        page.navigate("${baseUrl()}/tenants/${tenant.id}/templates/default/${template.id}")
+
+        assertThat(page.locator(".page-header button:has-text('Delete Template')")).isVisible()
+    }
+}

--- a/modules/editor/src/main/typescript/styles/canvas.css
+++ b/modules/editor/src/main/typescript/styles/canvas.css
@@ -77,6 +77,20 @@
     font-weight: 500;
   }
 
+  .canvas-block-hint {
+    font-size: 10px;
+    color: var(--ep-muted-foreground);
+    margin-left: var(--ep-space-1);
+  }
+
+  .canvas-block-hint code {
+    font-family: var(--ep-font-mono);
+    background: var(--ep-gray-100);
+    padding: 1px 3px;
+    border-radius: var(--ep-radius-sm);
+    font-size: 10px;
+  }
+
   .canvas-block-id {
     color: var(--ep-gray-300);
     margin-left: auto;

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
@@ -409,6 +409,9 @@ export class EpistolaCanvas extends LitElement {
               `
             : nothing}
           <span class="canvas-block-label">${label}</span>
+          ${node.type === 'text'
+            ? html`<span class="canvas-block-hint">type <code>{{</code> for expressions</span>`
+            : nothing}
           ${collapsed
             ? html`<span class="canvas-block-child-count"
                 >${(() => {

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -20,7 +20,7 @@ export interface ParsedUnit {
 export function parseValueWithUnit(raw: unknown, defaultUnit: string): ParsedUnit {
   if (raw == null || raw === '') return { value: 0, unit: defaultUnit };
   const str = String(raw);
-  const match = str.match(/^(-?[\d.]+)\s*([a-z%]+)?$/i);
+  const match = str.match(/^([\d.]+)\s*([a-z%]+)?$/i);
   if (!match) return { value: 0, unit: defaultUnit };
   return { value: parseFloat(match[1]), unit: match[2] || defaultUnit };
 }
@@ -46,7 +46,7 @@ export function renderUnitInput(
   const parsed = parseValueWithUnit(value, defaultUnit);
 
   const handleNumberChange = (e: Event) => {
-    const num = parseFloat((e.target as HTMLInputElement).value) || 0;
+    const num = Math.max(0, parseFloat((e.target as HTMLInputElement).value) || 0);
     onChange(num === 0 ? '' : formatValueWithUnit(num, parsed.unit));
   };
 
@@ -70,6 +70,7 @@ export function renderUnitInput(
         class="ep-input style-unit-number"
         id=${inputId ?? nothing}
         step=${parsed.unit === 'sp' ? '0.5' : '1'}
+        min="0"
         .value=${String(parsed.value)}
         ?disabled=${readOnly}
         @change=${handleNumberChange}
@@ -319,7 +320,7 @@ export function renderSpacingInput(
               .value=${String(sideNumber(parsed[side]))}
               ?disabled=${readOnly}
               @change=${(e: Event) => {
-                const num = parseFloat((e.target as HTMLInputElement).value) || 0;
+                const num = Math.max(0, parseFloat((e.target as HTMLInputElement).value) || 0);
                 handleSideChange(side, formatSide(num));
               }}
             />

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
@@ -140,10 +140,11 @@ class ImageNodeRenderer : NodeRenderer {
 
     /** Parse a size value (pt, sp, or unitless) to points. */
     private fun parseToPt(value: String, spacingUnit: Float): Float? {
-        SpacingScale.parseSp(value, spacingUnit)?.let { return it }
-        return when {
+        SpacingScale.parseSp(value, spacingUnit)?.let { return it.coerceAtLeast(0f) }
+        val parsed = when {
             value.endsWith("pt") -> value.removeSuffix("pt").toFloatOrNull()
             else -> value.toFloatOrNull()
         }
+        return parsed?.coerceAtLeast(0f)
     }
 }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
@@ -8,6 +8,7 @@ import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEventHandler
 import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.layout.Canvas
 import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IBlockElement
 import com.itextpdf.layout.element.Image
 
@@ -56,13 +57,28 @@ class PageFooterEventHandler(
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
             val pageContext = context.withInheritedStylesFrom(footerNode).withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(footerNode, document, pageContext)
+
+            // Wrap slot children in a Div so footer node styles (borders, background, padding) apply
+            val wrapper = Div()
+            StyleApplicator.applyStylesWithPreset(
+                wrapper,
+                footerNode.styles?.filterNonNullValues(),
+                footerNode.stylePreset,
+                context.blockStylePresets,
+                context.inheritedStyles,
+                context.fontCache,
+                context.renderingDefaults.componentDefaults("pagefooter"),
+                context.renderingDefaults.baseFontSizePt,
+                context.spacingUnit,
+            )
             for (element in elements) {
                 when (element) {
-                    is IBlockElement -> canvas.add(element)
-                    is Image -> canvas.add(element)
+                    is IBlockElement -> wrapper.add(element)
+                    is Image -> wrapper.add(element)
                     is AreaBreak -> Unit
                 }
             }
+            canvas.add(wrapper)
         }
 
         canvas.close()

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
@@ -8,6 +8,7 @@ import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEventHandler
 import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.layout.Canvas
 import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IBlockElement
 import com.itextpdf.layout.element.Image
 
@@ -59,13 +60,28 @@ class PageHeaderEventHandler(
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
             val pageContext = context.withInheritedStylesFrom(headerNode).withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(headerNode, document, pageContext)
+
+            // Wrap slot children in a Div so header node styles (borders, background, padding) apply
+            val wrapper = Div()
+            StyleApplicator.applyStylesWithPreset(
+                wrapper,
+                headerNode.styles?.filterNonNullValues(),
+                headerNode.stylePreset,
+                context.blockStylePresets,
+                context.inheritedStyles,
+                context.fontCache,
+                context.renderingDefaults.componentDefaults("pageheader"),
+                context.renderingDefaults.baseFontSizePt,
+                context.spacingUnit,
+            )
             for (element in elements) {
                 when (element) {
-                    is IBlockElement -> canvas.add(element)
-                    is Image -> canvas.add(element)
+                    is IBlockElement -> wrapper.add(element)
+                    is Image -> wrapper.add(element)
                     is AreaBreak -> Unit
                 }
             }
+            canvas.add(wrapper)
         }
 
         canvas.close()

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -291,13 +291,15 @@ object StyleApplicator {
 
     internal fun parseSize(size: String, baseFontSizePt: Float = 12f, spacingUnit: Float = SpacingScale.DEFAULT_BASE_UNIT): Float? {
         // Try spacing token first (e.g., "2sp" → 8pt with default base unit)
-        SpacingScale.parseSp(size, spacingUnit)?.let { return it }
+        SpacingScale.parseSp(size, spacingUnit)?.let { return it.coerceAtLeast(0f) }
 
-        return when {
+        val parsed = when {
             size.endsWith("pt") -> size.removeSuffix("pt").toFloatOrNull()
             size.endsWith("mm") -> size.removeSuffix("mm").toFloatOrNull()?.let { it * 2.83465f } // page margins
+            size.endsWith("sp") -> size.removeSuffix("sp").toFloatOrNull()?.let { it * spacingUnit }
             else -> size.toFloatOrNull() // unitless number treated as pt
         }
+        return parsed?.coerceAtLeast(0f)
     }
 
     internal fun parseColor(color: String): DeviceRgb? = try {

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -264,4 +264,23 @@ class StyleApplicatorTest {
         )
         assertEquals(null, div.getProperty<Boolean>(Property.KEEP_TOGETHER))
     }
+
+    // -----------------------------------------------------------------------
+    // parseSize clamping
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `parseSize clamps negative values to zero`() {
+        assertEquals(0f, StyleApplicator.parseSize("-10pt"))
+        assertEquals(0f, StyleApplicator.parseSize("-5"))
+        assertEquals(0f, StyleApplicator.parseSize("-2sp", spacingUnit = 4f))
+        assertEquals(0f, StyleApplicator.parseSize("-1mm"))
+    }
+
+    @Test
+    fun `parseSize preserves positive values`() {
+        assertEquals(10f, StyleApplicator.parseSize("10pt"))
+        assertEquals(5f, StyleApplicator.parseSize("5"))
+        assertEquals(8f, StyleApplicator.parseSize("2sp", spacingUnit = 4f))
+    }
 }


### PR DESCRIPTION
## Description

Fixes four unchecked items from #323 discovered during template creation:

1. **Template deletion discoverability** — The "Delete Template" action was buried under Settings > Danger Zone. Added the delete button to the `.page-header` on all template detail tabs (Variants, Deployments, Data Contract, Settings). Extracted the form into a reusable `fragments/template-actions.html` fragment. Added an `aria-label` with the template name. Fixed a CSS bug where `button[type='submit']` globally overrode `.btn-destructive`; now scoped to `:not([class*='btn-'])`.
2. **Negative sizing enforcement** — Users could enter negative values for width, height, font size, spacing, etc., which broke layout or caused iText errors. Added `min="0"` and `Math.max(0, ...)` clamping in the editor's `renderUnitInput` and `renderSpacingInput`. The `parseValueWithUnit` regex no longer accepts a leading minus sign. On the backend, `StyleApplicator.parseSize` and `ImageNodeRenderer.parseToPt` now clamp via `coerceAtLeast(0f)`.
3. **Expression editor `{{` hint** — Users didn't know they could type `{{` directly in the rich text editor to insert expressions inline. Added a subtle hint to the text block header: "type `{{` for expressions".
4. **Header/footer borders not rendering** — `PageHeaderEventHandler` and `PageFooterEventHandler` rendered slot children directly on a `Canvas`, ignoring the node-level styles (borders, background, padding). Both handlers now wrap slot children in a `Div` and apply styles via `StyleApplicator.applyStylesWithPreset`, so footer/header borders and backgrounds render correctly in the PDF.

## Related Issue(s)

Relates to #323

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

- Tests added: `TemplateDeleteButtonUiTest`, `StyleApplicatorTest` (negative size clamping). Existing `PageHeaderFooterTest` continues to pass.
- The `{{` hint and header/footer border fixes are new additions not yet reflected in `CHANGELOG.md` — happy to add them if needed before merge.
