### PR TITLE
fix: template delete discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - **Publishing subscribed catalog resources to environments**: Removed incorrect read-only catalog check from `PublishToEnvironment` and `PublishVersion` (for already-published versions). Environment activations are tenant-scoped operations, not catalog modifications.
+- **Template deletion discoverability**: The "Delete Template" action now appears in the template page header across detail tabs (not only in Settings > Danger Zone), using a shared `fragments/template-actions.html` fragment. Also fixed submit-button CSS scoping so `.btn-destructive` styles are not overridden by the global submit rule.
 
 ## [0.17.0] - 2026-04-28
 
@@ -24,6 +25,7 @@
 - **Contract publish impact preview**: Breaking contract publishes show a confirmation dialog listing breaking changes and affected template versions with their active environment deployments.
 - **Deployment matrix error handling**: Contract compatibility errors shown inline in the deployment matrix instead of generic "An error occurred" message.
 - **Contract usage overview**: Dialog showing all template versions with their contract version (color-coded: green=current, amber=outdated) and active deployments.
+
 ### Fixed
 
 - **Template deletion discoverability**: The "Delete Template" button now appears in the page header on all template detail tabs, not just buried in Settings > Danger Zone. Extracted the delete form into a reusable fragment (`fragments/template-actions.html`). Added `aria-label` with the template name for accessibility. Fixed a CSS bug where `button[type='submit']` globally overrode `.btn-destructive` styles — now scoped to buttons without an explicit `.btn-*` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,6 @@
 - **Deployment matrix error handling**: Contract compatibility errors shown inline in the deployment matrix instead of generic "An error occurred" message.
 - **Contract usage overview**: Dialog showing all template versions with their contract version (color-coded: green=current, amber=outdated) and active deployments.
 
-### Fixed
-
-- **Template deletion discoverability**: The "Delete Template" button now appears in the page header on all template detail tabs, not just buried in Settings > Danger Zone. Extracted the delete form into a reusable fragment (`fragments/template-actions.html`). Added `aria-label` with the template name for accessibility. Fixed a CSS bug where `button[type='submit']` globally overrode `.btn-destructive` styles — now scoped to buttons without an explicit `.btn-*` class.
-
 ### Changed
 
 - **Renovate PR consolidation**: GitHub Actions updates (digests + majors) grouped into a single PR; major dependency updates merged into the non-major PR; lock file maintenance merged into the non-major PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - **Contract publish impact preview**: Breaking contract publishes show a confirmation dialog listing breaking changes and affected template versions with their active environment deployments.
 - **Deployment matrix error handling**: Contract compatibility errors shown inline in the deployment matrix instead of generic "An error occurred" message.
 - **Contract usage overview**: Dialog showing all template versions with their contract version (color-coded: green=current, amber=outdated) and active deployments.
+### Fixed
+
+- **Template deletion discoverability**: The "Delete Template" button now appears in the page header on all template detail tabs, not just buried in Settings > Danger Zone. Extracted the delete form into a reusable fragment (`fragments/template-actions.html`). Added `aria-label` with the template name for accessibility. Fixed a CSS bug where `button[type='submit']` globally overrode `.btn-destructive` styles — now scoped to buttons without an explicit `.btn-*` class.
 
 ### Changed
 

--- a/apps/epistola/src/main/resources/static/css/main.css
+++ b/apps/epistola/src/main/resources/static/css/main.css
@@ -131,7 +131,7 @@ main.regular section {
 }
 
 /* Submit button (uses .btn .btn-primary when available, this is for plain submit) */
-button[type='submit'] {
+button[type='submit']:not([class*='btn-']) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -147,11 +147,11 @@ button[type='submit'] {
   transition: background-color var(--ep-transition-base);
 }
 
-button[type='submit']:hover {
+button[type='submit']:not([class*='btn-']):hover {
   background-color: var(--ep-blue-700);
 }
 
-button[type='submit']:focus-visible {
+button[type='submit']:not([class*='btn-']):focus-visible {
   outline: none;
   box-shadow: var(--ep-ring);
 }

--- a/apps/epistola/src/main/resources/templates/fragments/template-actions.html
+++ b/apps/epistola/src/main/resources/templates/fragments/template-actions.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+    <th:block th:fragment="template-delete-form">
+        <form th:if="${auth.has('TEMPLATE_EDIT') and editable}"
+              th:action="@{/tenants/{tenantId}/templates/{catalogId}/{id}/delete(tenantId=${tenantId},catalogId=${catalogId},id=${template.id})}"
+              method="post" hx-boost="false"
+              onsubmit="return confirm('Are you sure you want to delete this template? This action cannot be undone.')">
+            <button type="submit" class="btn btn-sm btn-destructive"
+                    th:aria-label="'Delete template \'' + ${template.name} + '\''">Delete Template</button>
+        </form>
+    </th:block>
+</body>
+</html>

--- a/apps/epistola/src/main/resources/templates/templates/detail.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail.html
@@ -13,6 +13,9 @@
                     <span class="badge badge-muted">Read-only</span> This template belongs to a subscribed catalog.
                 </p>
             </div>
+            <div style="flex-shrink: 0;">
+                <th:block th:replace="~{fragments/template-actions :: template-delete-form}" />
+            </div>
         </div>
 
         <!-- Tab Navigation -->

--- a/apps/epistola/src/main/resources/templates/templates/detail/settings.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail/settings.html
@@ -69,11 +69,7 @@
                 <p class="text-muted" style="margin-bottom: var(--ep-space-4); font-size: var(--ep-text-sm);">
                     Permanently delete this template and all its variants, versions, and data.
                 </p>
-                <form th:action="@{/tenants/{tenantId}/templates/{catalogId}/{id}/delete(tenantId=${tenantId},catalogId=${catalogId},id=${template.id})}"
-                      method="post" hx-boost="false"
-                      onsubmit="return confirm('Are you sure you want to delete this template? This action cannot be undone.')">
-                    <button type="submit" class="btn btn-sm btn-destructive">Delete Template</button>
-                </form>
+                <th:block th:replace="~{fragments/template-actions :: template-delete-form}" />
             </div>
         </div>
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/TemplateDeleteButtonUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/TemplateDeleteButtonUiTest.kt
@@ -1,0 +1,33 @@
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.templates.commands.CreateDocumentTemplate
+import app.epistola.suite.tenants.commands.CreateTenant
+import app.epistola.suite.testing.TestIdHelpers
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TemplateDeleteButtonUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `delete template button is visible in page header on template detail page`() {
+        val (tenant, template) = withMediator {
+            val tenantKey = TenantKey.of("test-ui-tenant-${System.nanoTime()}")
+            val tenant = CreateTenant(id = tenantKey, name = "UI Test Tenant").execute()
+            val tenantId = TenantId(tenant.id)
+            val template = CreateDocumentTemplate(
+                id = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId)),
+                name = "UI Test Template",
+            ).execute()
+            tenant to template
+        }
+
+        page.navigate("${baseUrl()}/tenants/${tenant.id}/templates/default/${template.id}")
+
+        assertThat(page.locator(".page-header button:has-text('Delete Template')")).isVisible()
+    }
+}


### PR DESCRIPTION
## Description

Adds the "Delete Template" action to the template detail page header so it is visible across tabs, instead of being hidden only in Settings > Danger Zone. Also extracts the delete form into a reusable fragment and fixes submit-button CSS scoping so `.btn-destructive` styling is preserved.

## Related Issue(s)

Relates to #323

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [ ] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

N/A

## Additional Notes

- Added UI coverage for delete button visibility on the template detail page.
