### PR TITLE
fix: negative sizing enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **Publishing subscribed catalog resources to environments**: Removed incorrect read-only catalog check from `PublishToEnvironment` and `PublishVersion` (for already-published versions). Environment activations are tenant-scoped operations, not catalog modifications.
 - **Header/footer style rendering in PDF**: Page header/footer event handlers now apply node-level styles by wrapping rendered slot content in a styled `Div`, restoring expected borders, background, and padding in generated PDFs.
 - **Expression editor discoverability**: Added a subtle inline hint in text block headers (`type {{ for expressions`) so users can discover inline expression insertion without leaving the editor flow.
+- **Negative sizing enforcement**: Editor size inputs now prevent negative values and clamp on change; backend parsers (`StyleApplicator.parseSize`, `ImageNodeRenderer.parseToPt`) also clamp to `>= 0` to prevent malformed layout and iText failures when invalid values slip through.
 
 ## [0.17.0] - 2026-04-28
 

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -20,7 +20,7 @@ export interface ParsedUnit {
 export function parseValueWithUnit(raw: unknown, defaultUnit: string): ParsedUnit {
   if (raw == null || raw === '') return { value: 0, unit: defaultUnit };
   const str = String(raw);
-  const match = str.match(/^(-?[\d.]+)\s*([a-z%]+)?$/i);
+  const match = str.match(/^([\d.]+)\s*([a-z%]+)?$/i);
   if (!match) return { value: 0, unit: defaultUnit };
   return { value: parseFloat(match[1]), unit: match[2] || defaultUnit };
 }
@@ -54,7 +54,7 @@ export function renderUnitInput(
       onChange(''); // signal nil → caller deletes the key
       return;
     }
-    const num = parseFloat(raw) || 0;
+    const num = Math.max(0, parseFloat(raw) || 0);
     onChange(formatValueWithUnit(num, parsed.unit));
   };
 
@@ -361,7 +361,7 @@ export function renderSpacingInput(
                 if (raw === '') {
                   handleSideChange(side, undefined);
                 } else {
-                  const num = parseFloat(raw) || 0;
+                  const num = Math.max(0, parseFloat(raw) || 0);
                   handleSideChange(side, formatSide(num));
                 }
               }}

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/ImageNodeRenderer.kt
@@ -175,11 +175,12 @@ class ImageNodeRenderer(
 
     /** Parse a size value (pt, sp, or unitless) to points. */
     private fun parseToPt(value: String, spacingUnit: Float): Float? {
-        SpacingScale.parseSp(value, spacingUnit)?.let { return it }
-        return when {
+        SpacingScale.parseSp(value, spacingUnit)?.let { return it.coerceAtLeast(0f) }
+        val parsed = when {
             value.endsWith("pt") -> value.removeSuffix("pt").toFloatOrNull()
             else -> value.toFloatOrNull()
         }
+        return parsed?.coerceAtLeast(0f)
     }
 
     private fun createImageElement(resolution: AssetResolution): Image = when (resolution.mimeType) {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -291,13 +291,15 @@ object StyleApplicator {
 
     internal fun parseSize(size: String, baseFontSizePt: Float = 12f, spacingUnit: Float = SpacingScale.DEFAULT_BASE_UNIT): Float? {
         // Try spacing token first (e.g., "2sp" → 8pt with default base unit)
-        SpacingScale.parseSp(size, spacingUnit)?.let { return it }
+        SpacingScale.parseSp(size, spacingUnit)?.let { return it.coerceAtLeast(0f) }
 
-        return when {
+        val parsed = when {
             size.endsWith("pt") -> size.removeSuffix("pt").toFloatOrNull()
             size.endsWith("mm") -> size.removeSuffix("mm").toFloatOrNull()?.let { it * 2.83465f } // page margins
+            size.endsWith("sp") -> size.removeSuffix("sp").toFloatOrNull()?.let { it * spacingUnit }
             else -> size.toFloatOrNull() // unitless number treated as pt
         }
+        return parsed?.coerceAtLeast(0f)
     }
 
     internal fun parseColor(color: String): DeviceRgb? = try {

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -291,4 +291,23 @@ class StyleApplicatorTest {
     fun `parseSize returns null for unknown unit`() {
         assertEquals(null, StyleApplicator.parseSize("10rem"))
     }
+
+    // -----------------------------------------------------------------------
+    // parseSize clamping
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `parseSize clamps negative values to zero`() {
+        assertEquals(0f, StyleApplicator.parseSize("-10pt"))
+        assertEquals(0f, StyleApplicator.parseSize("-5"))
+        assertEquals(0f, StyleApplicator.parseSize("-2sp", spacingUnit = 4f))
+        assertEquals(0f, StyleApplicator.parseSize("-1mm"))
+    }
+
+    @Test
+    fun `parseSize preserves positive values`() {
+        assertEquals(10f, StyleApplicator.parseSize("10pt"))
+        assertEquals(5f, StyleApplicator.parseSize("5"))
+        assertEquals(8f, StyleApplicator.parseSize("2sp", spacingUnit = 4f))
+    }
 }


### PR DESCRIPTION
## Description

Prevents negative sizing values from being accepted in editor style inputs and clamps parsed size values in backend PDF generation. This avoids invalid layout behavior and rendering errors when negative values are entered or pasted.

## Related Issue(s)

Relates to #323

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

N/A

## Additional Notes

- Frontend enforces `min="0"` and change-time clamping.
- Backend clamps parsed values to `>= 0` as a safety net.
