### PR TITLE
fix: header footer style rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - **Publishing subscribed catalog resources to environments**: Removed incorrect read-only catalog check from `PublishToEnvironment` and `PublishVersion` (for already-published versions). Environment activations are tenant-scoped operations, not catalog modifications.
+- **Header/footer style rendering in PDF**: Page header/footer event handlers now apply node-level styles by wrapping rendered slot content in a styled `Div`, restoring expected borders, background, and padding in generated PDFs.
 
 ## [0.17.0] - 2026-04-28
 

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageFooterEventHandler.kt
@@ -8,6 +8,7 @@ import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEventHandler
 import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.layout.Canvas
 import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IBlockElement
 import com.itextpdf.layout.element.Image
 
@@ -56,13 +57,28 @@ class PageFooterEventHandler(
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
             val pageContext = context.withInheritedStylesFrom(footerNode).withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(footerNode, document, pageContext)
+
+            // Wrap slot children in a Div so footer node styles (borders, background, padding) apply
+            val wrapper = Div()
+            StyleApplicator.applyStylesWithPreset(
+                wrapper,
+                footerNode.styles?.filterNonNullValues(),
+                footerNode.stylePreset,
+                context.blockStylePresets,
+                context.inheritedStyles,
+                context.fontCache,
+                context.renderingDefaults.componentDefaults("pagefooter"),
+                context.renderingDefaults.baseFontSizePt,
+                context.spacingUnit,
+            )
             for (element in elements) {
                 when (element) {
-                    is IBlockElement -> canvas.add(element)
-                    is Image -> canvas.add(element)
+                    is IBlockElement -> wrapper.add(element)
+                    is Image -> wrapper.add(element)
                     is AreaBreak -> Unit
                 }
             }
+            canvas.add(wrapper)
         }
 
         canvas.close()

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/PageHeaderEventHandler.kt
@@ -8,6 +8,7 @@ import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEventHandler
 import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.layout.Canvas
 import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.IBlockElement
 import com.itextpdf.layout.element.Image
 
@@ -59,13 +60,28 @@ class PageHeaderEventHandler(
             val totalPages = context.totalPages ?: pdfDoc.numberOfPages
             val pageContext = context.withInheritedStylesFrom(headerNode).withPageParams(pageNumber, totalPages)
             val elements = registry.renderSlots(headerNode, document, pageContext)
+
+            // Wrap slot children in a Div so header node styles (borders, background, padding) apply
+            val wrapper = Div()
+            StyleApplicator.applyStylesWithPreset(
+                wrapper,
+                headerNode.styles?.filterNonNullValues(),
+                headerNode.stylePreset,
+                context.blockStylePresets,
+                context.inheritedStyles,
+                context.fontCache,
+                context.renderingDefaults.componentDefaults("pageheader"),
+                context.renderingDefaults.baseFontSizePt,
+                context.spacingUnit,
+            )
             for (element in elements) {
                 when (element) {
-                    is IBlockElement -> canvas.add(element)
-                    is Image -> canvas.add(element)
+                    is IBlockElement -> wrapper.add(element)
+                    is Image -> wrapper.add(element)
                     is AreaBreak -> Unit
                 }
             }
+            canvas.add(wrapper)
         }
 
         canvas.close()


### PR DESCRIPTION
## Description

Fixes PDF header/footer rendering so node-level styles (such as border, background, and padding) are correctly applied. Header/footer slot content is now wrapped and styled before being added to the page canvas.

## Related Issue(s)

Relates to #323

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [ ] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

N/A

## Additional Notes

- Existing header/footer PDF tests continue to pass with this change.
