### PR TITLE
fix: editor expression hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Clear error on missing contract version**: `UpdateDraft`, `CreateVariant`, and `CreateVersion` now throw a descriptive `IllegalStateException` instead of a raw `NullPointerException` when no contract version exists.
 - **Publishing subscribed catalog resources to environments**: Removed incorrect read-only catalog check from `PublishToEnvironment` and `PublishVersion` (for already-published versions). Environment activations are tenant-scoped operations, not catalog modifications.
 - **Header/footer style rendering in PDF**: Page header/footer event handlers now apply node-level styles by wrapping rendered slot content in a styled `Div`, restoring expected borders, background, and padding in generated PDFs.
+- **Expression editor discoverability**: Added a subtle inline hint in text block headers (`type {{ for expressions`) so users can discover inline expression insertion without leaving the editor flow.
 
 ## [0.17.0] - 2026-04-28
 

--- a/modules/editor/src/main/typescript/styles/canvas.css
+++ b/modules/editor/src/main/typescript/styles/canvas.css
@@ -77,6 +77,20 @@
     font-weight: 500;
   }
 
+  .canvas-block-hint {
+    font-size: 10px;
+    color: var(--ep-muted-foreground);
+    margin-left: var(--ep-space-1);
+  }
+
+  .canvas-block-hint code {
+    font-family: var(--ep-font-mono);
+    background: var(--ep-gray-100);
+    padding: 1px 3px;
+    border-radius: var(--ep-radius-sm);
+    font-size: 10px;
+  }
+
   .canvas-block-id {
     color: var(--ep-gray-300);
     margin-left: auto;

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
@@ -414,6 +414,9 @@ export class EpistolaCanvas extends LitElement {
               `
             : nothing}
           <span class="canvas-block-label">${label}</span>
+          ${node.type === 'text'
+            ? html`<span class="canvas-block-hint">type <code>{{</code> for expressions</span>`
+            : nothing}
           ${collapsed
             ? html`<span class="canvas-block-child-count"
                 >${(() => {


### PR DESCRIPTION
## Description

Adds a subtle inline hint in text block headers in the editor: `type {{ for expressions}`. This improves discoverability of inline expression insertion without changing editor behavior.

## Related Issue(s)

Relates to #323

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

N/A

## Additional Notes

- UI-only discoverability improvement; no data model or rendering behavior changes.
