### PR TITLE
feat(editor): distinguish nil vs explicit 0 in numeric style inputs

### DIFF
--- a/modules/editor/src/main/typescript/theme-editor/ThemeEditorState.test.ts
+++ b/modules/editor/src/main/typescript/theme-editor/ThemeEditorState.test.ts
@@ -204,16 +204,16 @@ describe('ThemeEditorState', () => {
         'margin',
         {
           top: '10px',
-          right: '0px',
+          right: undefined,
           bottom: '16px',
-          left: '0px',
+          left: undefined,
         },
         'spacing',
       );
       const styles = state.theme.blockStylePresets.heading.styles as Record<string, unknown>;
       expect(styles.marginTop).toBe('10px');
       expect(styles.marginBottom).toBe('16px');
-      expect(styles.marginRight).toBeUndefined(); // zero values removed
+      expect(styles.marginRight).toBeUndefined(); // undefined sides not stored
       expect(styles.marginLeft).toBeUndefined();
       expect(styles.margin).toBeUndefined(); // compound key removed
     });

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -429,8 +429,12 @@ export class EpistolaInspector extends LitElement {
             type="number"
             class="ep-input"
             id=${inputId}
-            .value=${String(value ?? '')}
-            @change=${(e: Event) => onChange(Number((e.target as HTMLInputElement).value))}
+            placeholder="—"
+            .value=${value == null ? '' : String(value)}
+            @change=${(e: Event) => {
+              const raw = (e.target as HTMLInputElement).value;
+              onChange(raw === '' ? undefined : Number(raw));
+            }}
           />
         `;
       case 'boolean':
@@ -503,9 +507,12 @@ export class EpistolaInspector extends LitElement {
               type="number"
               class="ep-input"
               id=${fieldId}
-              .value=${String(value ?? 0)}
-              @change=${(e: Event) =>
-                this._handlePropChange(field.key, Number((e.target as HTMLInputElement).value))}
+              placeholder="—"
+              .value=${value == null ? '' : String(value)}
+              @change=${(e: Event) => {
+                const raw = (e.target as HTMLInputElement).value;
+                this._handlePropChange(field.key, raw === '' ? undefined : Number(raw));
+              }}
             />
           </div>
         `;

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.test.ts
@@ -45,9 +45,14 @@ describe('expandSpacingToStyles', () => {
     });
   });
 
-  it('removes the compound key if it existed', () => {
+  it('removes the legacy compound key when expanding individual sides', () => {
     const styles: Record<string, unknown> = { margin: { top: '10px' } };
-    const spacing: SpacingValue = { top: '10px', right: '0px', bottom: '0px', left: '0px' };
+    const spacing: SpacingValue = {
+      top: '10px',
+      right: undefined,
+      bottom: undefined,
+      left: undefined,
+    };
 
     expandSpacingToStyles('margin', spacing, styles);
 
@@ -55,27 +60,56 @@ describe('expandSpacingToStyles', () => {
     expect(styles.marginTop).toBe('10px');
   });
 
-  it('deletes zero-value keys instead of storing them', () => {
-    const styles: Record<string, unknown> = { marginTop: '10px', marginRight: '5px' };
-    const spacing: SpacingValue = { top: '10px', right: '0px', bottom: '0px', left: '0px' };
+  it('deletes only undefined sides (explicit "0pt" is stored as override)', () => {
+    const styles: Record<string, unknown> = { marginTop: '10pt', marginRight: '5pt' };
+    const spacing: SpacingValue = {
+      top: '10pt',
+      right: '0pt',
+      bottom: undefined,
+      left: undefined,
+    };
 
     expandSpacingToStyles('margin', spacing, styles);
 
-    expect(styles.marginTop).toBe('10px');
-    expect(styles.marginRight).toBeUndefined();
+    expect(styles.marginTop).toBe('10pt');
+    expect(styles.marginRight).toBe('0pt'); // explicit zero is preserved
     expect(styles.marginBottom).toBeUndefined();
     expect(styles.marginLeft).toBeUndefined();
   });
 
-  it('treats 0em and 0rem as zero values', () => {
+  it('preserves explicit "0sp" / "0pt" / "0px" as stored override values', () => {
     const styles: Record<string, unknown> = {};
-    const spacing: SpacingValue = { top: '0em', right: '0rem', bottom: '5px', left: '0px' };
+    const spacing: SpacingValue = { top: '0sp', right: '0pt', bottom: '0px', left: '5pt' };
+
+    expandSpacingToStyles('margin', spacing, styles);
+
+    expect(styles).toEqual({
+      marginTop: '0sp',
+      marginRight: '0pt',
+      marginBottom: '0px',
+      marginLeft: '5pt',
+    });
+  });
+
+  it('deletes pre-existing keys when the SpacingValue side is undefined', () => {
+    const styles: Record<string, unknown> = {
+      marginTop: '10pt',
+      marginRight: '5pt',
+      marginBottom: '8pt',
+      marginLeft: '5pt',
+    };
+    const spacing: SpacingValue = {
+      top: undefined,
+      right: undefined,
+      bottom: undefined,
+      left: undefined,
+    };
 
     expandSpacingToStyles('margin', spacing, styles);
 
     expect(styles.marginTop).toBeUndefined();
     expect(styles.marginRight).toBeUndefined();
-    expect(styles.marginBottom).toBe('5px');
+    expect(styles.marginBottom).toBeUndefined();
     expect(styles.marginLeft).toBeUndefined();
   });
 });
@@ -98,12 +132,17 @@ describe('readSpacingFromStyles', () => {
     expect(result).toEqual({ top: '10px', right: '5px', bottom: '8px', left: '5px' });
   });
 
-  it('defaults missing sides to 0px', () => {
+  it('returns undefined per side when the key is missing (nil)', () => {
     const styles = { marginBottom: '12px' };
 
     const result = readSpacingFromStyles('margin', styles);
 
-    expect(result).toEqual({ top: '0px', right: '0px', bottom: '12px', left: '0px' });
+    expect(result).toEqual({
+      top: undefined,
+      right: undefined,
+      bottom: '12px',
+      left: undefined,
+    });
   });
 
   it('returns undefined when no individual keys are set', () => {
@@ -114,12 +153,17 @@ describe('readSpacingFromStyles', () => {
     expect(result).toBeUndefined();
   });
 
-  it('uses the provided default unit', () => {
-    const styles = { paddingTop: '2em' };
+  it('preserves an explicit "0pt" stored value as an override (distinct from nil)', () => {
+    const styles = { marginTop: '0pt', marginBottom: '5pt' };
 
-    const result = readSpacingFromStyles('padding', styles, 'em');
+    const result = readSpacingFromStyles('margin', styles);
 
-    expect(result).toEqual({ top: '2em', right: '0em', bottom: '0em', left: '0em' });
+    expect(result).toEqual({
+      top: '0pt',
+      right: undefined,
+      bottom: '5pt',
+      left: undefined,
+    });
   });
 
   it('reads padding keys', () => {
@@ -127,7 +171,12 @@ describe('readSpacingFromStyles', () => {
 
     const result = readSpacingFromStyles('padding', styles);
 
-    expect(result).toEqual({ top: '5px', right: '0px', bottom: '10px', left: '0px' });
+    expect(result).toEqual({
+      top: '5px',
+      right: undefined,
+      bottom: '10px',
+      left: undefined,
+    });
   });
 
   it('handles legacy compound object as fallback', () => {

--- a/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/style-inputs.ts
@@ -44,23 +44,35 @@ export function renderUnitInput(
 ): unknown {
   const defaultUnit = units[0] ?? 'pt';
   const parsed = parseValueWithUnit(value, defaultUnit);
+  // Whether the caller actually has a stored value. nil → empty input + placeholder;
+  // an explicit '0pt' / '0sp' is a stored override and renders as "0".
+  const isSet = value != null && value !== '';
 
   const handleNumberChange = (e: Event) => {
-    const num = parseFloat((e.target as HTMLInputElement).value) || 0;
-    onChange(num === 0 ? '' : formatValueWithUnit(num, parsed.unit));
+    const raw = (e.target as HTMLInputElement).value;
+    if (raw === '') {
+      onChange(''); // signal nil → caller deletes the key
+      return;
+    }
+    const num = parseFloat(raw) || 0;
+    onChange(formatValueWithUnit(num, parsed.unit));
   };
 
   const handleUnitChange = (e: Event) => {
     const newUnit = (e.target as HTMLSelectElement).value;
+    if (!isSet) {
+      // No stored value: just propagate the unit choice without inventing a 0.
+      onChange('');
+      return;
+    }
     const oldUnit = parsed.unit;
     let newValue = parsed.value;
-    // Convert between sp and pt
     if (oldUnit === 'pt' && newUnit === 'sp') {
       newValue = parseFloat(nearestSpacingStep(parsed.value, baseUnit));
     } else if (oldUnit === 'sp' && newUnit === 'pt') {
       newValue = parsed.value * baseUnit;
     }
-    onChange(newValue === 0 ? '' : formatValueWithUnit(newValue, newUnit));
+    onChange(formatValueWithUnit(newValue, newUnit));
   };
 
   return html`
@@ -70,7 +82,9 @@ export function renderUnitInput(
         class="ep-input style-unit-number"
         id=${inputId ?? nothing}
         step=${parsed.unit === 'sp' ? '0.5' : '1'}
-        .value=${String(parsed.value)}
+        min="0"
+        placeholder="—"
+        .value=${isSet ? String(parsed.value) : ''}
         ?disabled=${readOnly}
         @change=${handleNumberChange}
       />
@@ -196,13 +210,16 @@ function toPt(value: string, fromUnit: string, baseUnit: number): number | null 
  * Convert a single side value between supported units (sp, pt, px).
  * Used both for explicit unit-switch and for migrating legacy values
  * to a unit that's actually offered in the dropdown.
+ *
+ * Passes through `undefined` (= nil) and unknown source units unchanged.
  */
 export function convertSideValue(
-  value: string,
+  value: string | undefined,
   fromUnit: string,
   toUnit: string,
   baseUnit: number,
-): string {
+): string | undefined {
+  if (value === undefined) return undefined;
   if (fromUnit === toUnit) return value;
 
   const pt = toPt(value, fromUnit, baseUnit);
@@ -234,31 +251,31 @@ export function formatSpacingToken(step: string): string {
 // Spacing input: 4-value (top/right/bottom/left)
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-side spacing value. `undefined` means nil (no value set — falls back
+ * through the cascade to component defaults / preset). An explicit `'0pt'`
+ * or `'0sp'` is a stored override that forces 0, beating the cascade.
+ */
 export interface SpacingValue {
-  top: string;
-  right: string;
-  bottom: string;
-  left: string;
+  top: string | undefined;
+  right: string | undefined;
+  bottom: string | undefined;
+  left: string | undefined;
 }
 
 /** Parse a spacing value — can be a string shorthand or an object. */
-export function parseSpacingValue(raw: unknown, defaultUnit: string): SpacingValue {
+export function parseSpacingValue(raw: unknown): SpacingValue {
   if (raw == null) {
-    return {
-      top: `0${defaultUnit}`,
-      right: `0${defaultUnit}`,
-      bottom: `0${defaultUnit}`,
-      left: `0${defaultUnit}`,
-    };
+    return { top: undefined, right: undefined, bottom: undefined, left: undefined };
   }
 
   if (typeof raw === 'object' && raw !== null) {
     const obj = raw as Record<string, unknown>;
     return {
-      top: obj.top != null ? String(obj.top) : `0${defaultUnit}`,
-      right: obj.right != null ? String(obj.right) : `0${defaultUnit}`,
-      bottom: obj.bottom != null ? String(obj.bottom) : `0${defaultUnit}`,
-      left: obj.left != null ? String(obj.left) : `0${defaultUnit}`,
+      top: obj.top != null ? String(obj.top) : undefined,
+      right: obj.right != null ? String(obj.right) : undefined,
+      bottom: obj.bottom != null ? String(obj.bottom) : undefined,
+      left: obj.left != null ? String(obj.left) : undefined,
     };
   }
 
@@ -289,7 +306,7 @@ export function renderSpacingInput(
   readOnly = false,
 ): unknown {
   const firstAbsUnit = units.find((u) => u !== 'sp') ?? 'pt';
-  const parsed = parseSpacingValue(value, firstAbsUnit);
+  const parsed = parseSpacingValue(value);
   const sides = ['top', 'right', 'bottom', 'left'] as const;
 
   // Clamp the detected unit to one that's offered in the dropdown.
@@ -300,12 +317,17 @@ export function renderSpacingInput(
   const currentUnit = units.includes(detected) ? detected : firstAbsUnit;
   const topInputId = inputId ?? undefined;
 
-  const handleSideChange = (side: string, newValue: string) => {
+  const handleSideChange = (side: string, newValue: string | undefined) => {
     onChange({ ...parsed, [side]: newValue });
   };
 
-  /** Extract numeric value from a side, whether sp or pt. */
-  const sideNumber = (sideValue: string): number => {
+  /**
+   * Numeric value for the input. Returns `undefined` when the side is nil
+   * so the input renders as empty (placeholder visible). An explicit '0pt'
+   * or '0sp' returns 0 — distinct from nil.
+   */
+  const sideNumber = (sideValue: string | undefined): number | undefined => {
+    if (sideValue === undefined) return undefined;
     if (currentUnit === 'sp') {
       return parseFloat(parseSpacingToken(sideValue) ?? '0') || 0;
     }
@@ -320,8 +342,9 @@ export function renderSpacingInput(
 
   return html`
     <div class="style-spacing-input">
-      ${sides.map(
-        (side) => html`
+      ${sides.map((side) => {
+        const n = sideNumber(parsed[side]);
+        return html`
           <div class="style-spacing-side">
             <span class="style-spacing-label">${side[0].toUpperCase()}</span>
             <input
@@ -330,16 +353,22 @@ export function renderSpacingInput(
               id=${side === 'top' && topInputId ? topInputId : nothing}
               step=${currentUnit === 'sp' ? '0.5' : '1'}
               min="0"
-              .value=${String(sideNumber(parsed[side]))}
+              placeholder="—"
+              .value=${n === undefined ? '' : String(n)}
               ?disabled=${readOnly}
               @change=${(e: Event) => {
-                const num = parseFloat((e.target as HTMLInputElement).value) || 0;
-                handleSideChange(side, formatSide(num));
+                const raw = (e.target as HTMLInputElement).value;
+                if (raw === '') {
+                  handleSideChange(side, undefined);
+                } else {
+                  const num = parseFloat(raw) || 0;
+                  handleSideChange(side, formatSide(num));
+                }
               }}
             />
           </div>
-        `,
-      )}
+        `;
+      })}
       ${units.length > 1
         ? html`
             <div class="style-spacing-side">
@@ -349,7 +378,12 @@ export function renderSpacingInput(
                 ?disabled=${readOnly}
                 @change=${(e: Event) => {
                   const newUnit = (e.target as HTMLSelectElement).value;
-                  const result: SpacingValue = { top: '', right: '', bottom: '', left: '' };
+                  const result: SpacingValue = {
+                    top: undefined,
+                    right: undefined,
+                    bottom: undefined,
+                    left: undefined,
+                  };
                   for (const side of sides) {
                     result[side] = convertSideValue(parsed[side], currentUnit, newUnit, baseUnit);
                   }
@@ -383,7 +417,7 @@ export function expandSpacingToStyles(
   value: SpacingValue,
   styles: Record<string, unknown>,
 ): void {
-  const sides: Record<string, string> = {
+  const sides: Record<string, string | undefined> = {
     Top: value.top,
     Right: value.right,
     Bottom: value.bottom,
@@ -391,7 +425,9 @@ export function expandSpacingToStyles(
   };
   for (const [suffix, sideValue] of Object.entries(sides)) {
     const key = `${prefix}${suffix}`;
-    if (sideValue && !/^0(?:\.\d+)?[a-z]*$/.test(sideValue)) {
+    // undefined or empty string → nil → delete key (cascade applies)
+    // any other value (including '0pt' / '0sp') → store as explicit override
+    if (sideValue !== undefined && sideValue !== '') {
       styles[key] = sideValue;
     } else {
       delete styles[key];
@@ -404,15 +440,18 @@ export function expandSpacingToStyles(
 /**
  * Read individual style keys back into a compound SpacingValue.
  *
- * e.g. readSpacingFromStyles('margin', { marginTop: '10px', marginBottom: '5px' })
- * → { top: '10px', right: '0px', bottom: '5px', left: '0px' }
+ * Missing sides become `undefined` so the inspector can render them as
+ * "nil" (empty input + placeholder), distinct from an explicit '0pt'
+ * stored value.
+ *
+ * e.g. readSpacingFromStyles('margin', { marginTop: '10pt', marginBottom: '0pt' })
+ * → { top: '10pt', right: undefined, bottom: '0pt', left: undefined }
  *
  * Returns undefined if no individual keys are set.
  */
 export function readSpacingFromStyles(
   prefix: string,
   styles: Record<string, unknown>,
-  defaultUnit = 'px',
 ): SpacingValue | undefined {
   const top = styles[`${prefix}Top`];
   const right = styles[`${prefix}Right`];
@@ -428,15 +467,14 @@ export function readSpacingFromStyles(
 
   // If a legacy compound object is present, read from it
   if (compound != null && typeof compound === 'object') {
-    return parseSpacingValue(compound, defaultUnit);
+    return parseSpacingValue(compound);
   }
 
-  const zero = `0${defaultUnit}`;
   return {
-    top: top != null ? String(top) : zero,
-    right: right != null ? String(right) : zero,
-    bottom: bottom != null ? String(bottom) : zero,
-    left: left != null ? String(left) : zero,
+    top: top != null ? String(top) : undefined,
+    right: right != null ? String(right) : undefined,
+    bottom: bottom != null ? String(bottom) : undefined,
+    left: left != null ? String(left) : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

Numeric inspector inputs (margin/padding spacing, font-size & border-radius unit input, generic style-prop 'number', component-specific field-prop 'number') now treat **\"no value\"** and **\"explicit 0\"** as distinct states.

- A field with no stored value renders empty with a grey \`—\` (em-dash) placeholder. The cascade falls back to component defaults / preset.
- An explicitly typed \`0\` stores \`0pt\` / \`0sp\` / \`0\` as an override that beats the cascade.

### Storage refactor

\`SpacingValue\` and the helpers around it stop conflating zero with absence:

- \`SpacingValue.{top,right,bottom,left}\` is now \`string | undefined\`. \`undefined\` per side = nil, an explicit \`'0pt'\` is a stored override.
- \`parseSpacingValue\` / \`readSpacingFromStyles\` drop their \`defaultUnit\` parameter and return \`undefined\` per side for missing keys (was \`'0\${defaultUnit}'\`).
- \`expandSpacingToStyles\` preserves any non-empty side value, including \`'0pt'\` / \`'0sp'\`. Only \`undefined\` or \`''\` triggers key deletion.
- \`convertSideValue\` accepts and passes through \`undefined\` for unit-switches between sp/pt.

### UX

When a user clears an input, the field shows the \`—\` placeholder and the storage drops the key — so the cascade in the renderer can fall through to the next layer (preset → component default → engine defaults).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

> The \`SpacingValue\` shape change is a breaking edit at the TypeScript-types level for any consumer that types its own \`SpacingValue\`, but only the editor module uses it. Pre-prod, no migration provided per CLAUDE.md.

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (oxfmt, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (\`pnpm --filter @epistola/editor test\`)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow Conventional Commits

## Test plan

- [x] \`style-inputs.test.ts\` updated and extended:
  - \`expandSpacingToStyles preserves explicit \"0pt\" as stored value\`
  - \`expandSpacingToStyles deletes undefined sides\`
  - \`readSpacingFromStyles returns undefined per side when not set\`
  - \`readSpacingFromStyles preserves explicit \"0pt\" as override\`
- [x] \`ThemeEditorState.test.ts\`: existing \"deletes 0 values\" assertion inverted to \"undefined sides not stored\".
- [x] Manual: select a text node, clear \`marginTop\` in the inspector → field shows \`—\` placeholder; rendered PDF cascades to component default. Type \`0\` explicitly → field shows \`0\`; rendered PDF forces 0 (overrides default).
- [x] Manual: same flow for a unit input (e.g. \`borderRadius\`) and the generic \`number\` style prop (e.g. component opacity if exposed).