### PR TITLE
feat(forms): auto-generate slug from name on create forms

### DIFF
--- a/apps/epistola/src/main/resources/static/js/slug-auto.js
+++ b/apps/epistola/src/main/resources/static/js/slug-auto.js
@@ -1,0 +1,70 @@
+(function () {
+  var ALLOWED_KEYS = ['Backspace', 'Delete', 'Enter', 'Escape', 'Tab', 'Home', 'End'];
+
+  function nameToSlug(name) {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+
+  function isValidSlugKey(key) {
+    return key.length === 1 && /^[a-z0-9-]$/.test(key);
+  }
+
+  function wireup(nameInput) {
+    var slugId = nameInput.getAttribute('data-slug-source');
+    var slugInput = document.getElementById(slugId);
+    if (!slugInput) return;
+
+    var slugManuallyEdited = false;
+
+    nameInput.addEventListener('input', function () {
+      if (!slugManuallyEdited) {
+        slugInput.value = nameToSlug(nameInput.value);
+      }
+    });
+
+    slugInput.addEventListener('input', function () {
+      var cleaned = slugInput.value.replace(/[^a-z0-9-]/g, '');
+      if (cleaned !== slugInput.value) {
+        slugInput.value = cleaned;
+      }
+      slugManuallyEdited = slugInput.value !== nameToSlug(nameInput.value);
+    });
+
+    slugInput.addEventListener('keydown', function (e) {
+      if (
+        ALLOWED_KEYS.indexOf(e.key) !== -1 ||
+        e.key.startsWith('Arrow') ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.altKey
+      ) {
+        return;
+      }
+
+      if (!isValidSlugKey(e.key)) {
+        e.preventDefault();
+      }
+    });
+  }
+
+  document.querySelectorAll('[data-slug-source]').forEach(wireup);
+
+  var observer = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      mutation.addedNodes.forEach(function (node) {
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+        if (node.matches && node.matches('[data-slug-source]')) {
+          wireup(node);
+        }
+        if (node.querySelectorAll) {
+          node.querySelectorAll('[data-slug-source]').forEach(wireup);
+        }
+      });
+    });
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+})();

--- a/apps/epistola/src/main/resources/static/js/slug-auto.js
+++ b/apps/epistola/src/main/resources/static/js/slug-auto.js
@@ -17,7 +17,8 @@
     var slugInput = document.getElementById(slugId);
     if (!slugInput) return;
 
-    var slugManuallyEdited = false;
+    var slugManuallyEdited =
+      slugInput.value !== '' && slugInput.value !== nameToSlug(nameInput.value);
 
     nameInput.addEventListener('input', function () {
       if (!slugManuallyEdited) {

--- a/apps/epistola/src/main/resources/templates/attributes/new.html
+++ b/apps/epistola/src/main/resources/templates/attributes/new.html
@@ -20,6 +20,13 @@
                                     th:selected="${formData?.catalog == cat.id.toString()}"></option>
                         </select>
                     </div>
+                    <div class="form-group" th:classappend="${errors?.containsKey('displayName')} ? 'error' : ''">
+                        <label class="ep-label" for="displayName">Display Name</label>
+                        <input type="text" id="displayName" name="displayName" class="ep-input"
+                               required placeholder="Language" data-slug-source="slug"
+                               th:value="${formData?.displayName}">
+                        <span class="form-error" th:if="${errors?.containsKey('displayName')}" th:text="${errors.displayName}"></span>
+                    </div>
                     <div class="form-group" th:classappend="${errors?.containsKey('slug')} ? 'error' : ''">
                         <label class="ep-label" for="slug">Attribute ID (Slug)</label>
                         <input type="text" id="slug" name="slug" class="ep-input"
@@ -29,13 +36,6 @@
                                th:value="${formData?.slug}">
                         <span class="form-hint">3-50 characters, lowercase letters, numbers, and hyphens only</span>
                         <span class="form-error" th:if="${errors?.containsKey('slug')}" th:text="${errors.slug}"></span>
-                    </div>
-                    <div class="form-group" th:classappend="${errors?.containsKey('displayName')} ? 'error' : ''">
-                        <label class="ep-label" for="displayName">Display Name</label>
-                        <input type="text" id="displayName" name="displayName" class="ep-input"
-                               required placeholder="Language"
-                               th:value="${formData?.displayName}">
-                        <span class="form-error" th:if="${errors?.containsKey('displayName')}" th:text="${errors.displayName}"></span>
                     </div>
                     <div class="form-group" th:classappend="${errors?.containsKey('allowedValues')} ? 'error' : ''">
                         <label class="ep-label" for="allowedValues">Allowed Values (one per line, leave empty for any value)</label>

--- a/apps/epistola/src/main/resources/templates/catalogs/list.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/list.html
@@ -98,17 +98,17 @@
                   hx-swap="outerHTML">
                 <div class="ep-dialog-body">
                     <div class="form-group">
+                        <label class="ep-label" for="catalogName">Name</label>
+                        <input type="text" id="catalogName" name="name" class="ep-input"
+                               required placeholder="My Templates" data-slug-source="catalogSlug">
+                    </div>
+                    <div class="form-group">
                         <label class="ep-label" for="catalogSlug">Catalog ID (Slug)</label>
                         <input type="text" id="catalogSlug" name="slug" class="ep-input"
                                required pattern="^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
                                minlength="3" maxlength="50"
                                placeholder="my-templates">
                         <span class="form-hint">3-50 characters, lowercase letters, numbers, and hyphens only</span>
-                    </div>
-                    <div class="form-group">
-                        <label class="ep-label" for="catalogName">Name</label>
-                        <input type="text" id="catalogName" name="name" class="ep-input"
-                               required placeholder="My Templates">
                     </div>
                 </div>
                 <div class="ep-dialog-footer">

--- a/apps/epistola/src/main/resources/templates/environments/new.html
+++ b/apps/epistola/src/main/resources/templates/environments/new.html
@@ -11,6 +11,13 @@
         <div class="card create-form-card">
             <div class="card-content">
                 <form th:action="@{/tenants/{tenantId}/environments(tenantId=${tenantId})}" method="post">
+                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
+                        <label class="ep-label" for="name">Name</label>
+                        <input type="text" id="name" name="name" class="ep-input"
+                               required placeholder="Production" data-slug-source="slug"
+                               th:value="${formData?.name}">
+                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
+                    </div>
                     <div class="form-group" th:classappend="${errors?.containsKey('slug')} ? 'error' : ''">
                         <label class="ep-label" for="slug">Environment ID (Slug)</label>
                         <input type="text" id="slug" name="slug" class="ep-input"
@@ -20,13 +27,6 @@
                                th:value="${formData?.slug}">
                         <span class="form-hint">3-30 characters, lowercase letters, numbers, and hyphens only</span>
                         <span class="form-error" th:if="${errors?.containsKey('slug')}" th:text="${errors.slug}"></span>
-                    </div>
-                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
-                        <label class="ep-label" for="name">Name</label>
-                        <input type="text" id="name" name="name" class="ep-input"
-                               required placeholder="Production"
-                               th:value="${formData?.name}">
-                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
                     </div>
                     <div class="form-actions">
                         <button type="submit" class="btn btn-primary">Create Environment</button>

--- a/apps/epistola/src/main/resources/templates/fragments/footer.html
+++ b/apps/epistola/src/main/resources/templates/fragments/footer.html
@@ -44,6 +44,8 @@
             </script>
         </th:block>
 
+        <script th:src="@{/js/slug-auto.js}"></script>
+
         <!-- Feedback FAB + console capture (tenant-scoped pages only) -->
         <th:block th:if="${tenantId != null and feedbackEnabled}" sec:authorize="isAuthenticated()">
             <script th:src="@{/feedback/feedback-capture.js}"></script>

--- a/apps/epistola/src/main/resources/templates/stencils/new.html
+++ b/apps/epistola/src/main/resources/templates/stencils/new.html
@@ -20,6 +20,13 @@
                                     th:selected="${formData?.catalog == cat.id.toString()}"></option>
                         </select>
                     </div>
+                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
+                        <label class="ep-label" for="name">Name</label>
+                        <input type="text" id="name" name="name" class="ep-input"
+                               required placeholder="Corporate Header" data-slug-source="slug"
+                               th:value="${formData?.name}">
+                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
+                    </div>
                     <div class="form-group" th:classappend="${errors?.containsKey('slug')} ? 'error' : ''">
                         <label class="ep-label" for="slug">Stencil ID (Slug)</label>
                         <input type="text" id="slug" name="slug" class="ep-input"
@@ -29,13 +36,6 @@
                                th:value="${formData?.slug}">
                         <span class="form-hint">3-50 characters, lowercase letters, numbers, and hyphens only</span>
                         <span class="form-error" th:if="${errors?.containsKey('slug')}" th:text="${errors.slug}"></span>
-                    </div>
-                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
-                        <label class="ep-label" for="name">Name</label>
-                        <input type="text" id="name" name="name" class="ep-input"
-                               required placeholder="Corporate Header"
-                               th:value="${formData?.name}">
-                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
                     </div>
                     <div class="form-group">
                         <label class="ep-label" for="description">Description (optional)</label>

--- a/apps/epistola/src/main/resources/templates/templates/new.html
+++ b/apps/epistola/src/main/resources/templates/templates/new.html
@@ -19,6 +19,13 @@
                                     th:text="${cat.name}"></option>
                         </select>
                     </div>
+                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
+                        <label class="ep-label" for="name">Name</label>
+                        <input type="text" id="name" name="name" class="ep-input"
+                               required placeholder="Monthly Invoice" data-slug-source="slug"
+                               th:value="${formData?.name}">
+                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
+                    </div>
                     <div class="form-group" th:classappend="${errors?.containsKey('slug')} ? 'error' : ''">
                         <label class="ep-label" for="slug">Template ID (Slug)</label>
                         <input type="text" id="slug" name="slug" class="ep-input"
@@ -28,13 +35,6 @@
                                th:value="${formData?.slug}">
                         <span class="form-hint">3-50 characters, lowercase letters, numbers, and hyphens only</span>
                         <span class="form-error" th:if="${errors?.containsKey('slug')}" th:text="${errors.slug}"></span>
-                    </div>
-                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
-                        <label class="ep-label" for="name">Name</label>
-                        <input type="text" id="name" name="name" class="ep-input"
-                               required placeholder="Monthly Invoice"
-                               th:value="${formData?.name}">
-                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
                     </div>
                     <div class="form-actions">
                         <button type="submit" class="btn btn-primary">Create Template</button>

--- a/apps/epistola/src/main/resources/templates/tenants/list.html
+++ b/apps/epistola/src/main/resources/templates/tenants/list.html
@@ -19,6 +19,13 @@
                       hx-target="#tenant-rows"
                       hx-swap="innerHTML"
                       hx-on::after-request="if(event.detail.successful) this.reset()">
+                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
+                        <label for="name">Name</label>
+                        <input type="text" id="name" name="name" required placeholder="Tenant name"
+                               data-slug-source="slug"
+                               th:value="${formData?.name}">
+                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
+                    </div>
                     <div class="form-group" th:classappend="${errors?.containsKey('slug')} ? 'error' : ''">
                         <label for="slug">Slug (ID)</label>
                         <input type="text" id="slug" name="slug" required placeholder="my-company"
@@ -26,12 +33,6 @@
                                th:value="${formData?.slug}">
                         <span class="form-hint">3-63 characters, lowercase letters, numbers, and hyphens only</span>
                         <span class="form-error" th:if="${errors?.containsKey('slug')}" th:text="${errors.slug}"></span>
-                    </div>
-                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
-                        <label for="name">Name</label>
-                        <input type="text" id="name" name="name" required placeholder="Tenant name"
-                               th:value="${formData?.name}">
-                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
                     </div>
                     <button type="submit" class="btn btn-primary">Create Tenant</button>
                 </form>

--- a/apps/epistola/src/main/resources/templates/themes/new.html
+++ b/apps/epistola/src/main/resources/templates/themes/new.html
@@ -20,6 +20,13 @@
                                     th:selected="${formData?.catalog == cat.id.toString()}"></option>
                         </select>
                     </div>
+                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
+                        <label class="ep-label" for="name">Name</label>
+                        <input type="text" id="name" name="name" class="ep-input"
+                               required placeholder="Corporate Theme" data-slug-source="slug"
+                               th:value="${formData?.name}">
+                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
+                    </div>
                     <div class="form-group" th:classappend="${errors?.containsKey('slug')} ? 'error' : ''">
                         <label class="ep-label" for="slug">Theme ID (Slug)</label>
                         <input type="text" id="slug" name="slug" class="ep-input"
@@ -29,13 +36,6 @@
                                th:value="${formData?.slug}">
                         <span class="form-hint">3-20 characters, lowercase letters, numbers, and hyphens only</span>
                         <span class="form-error" th:if="${errors?.containsKey('slug')}" th:text="${errors.slug}"></span>
-                    </div>
-                    <div class="form-group" th:classappend="${errors?.containsKey('name')} ? 'error' : ''">
-                        <label class="ep-label" for="name">Name</label>
-                        <input type="text" id="name" name="name" class="ep-input"
-                               required placeholder="Corporate Theme"
-                               th:value="${formData?.name}">
-                        <span class="form-error" th:if="${errors?.containsKey('name')}" th:text="${errors.name}"></span>
                     </div>
                     <div class="form-group">
                         <label class="ep-label" for="description">Description (optional)</label>

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/SlugAutoFillUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/SlugAutoFillUiTest.kt
@@ -1,22 +1,13 @@
 package app.epistola.suite.ui
 
-import app.epistola.suite.common.ids.TenantKey
-import app.epistola.suite.mediator.execute
 import app.epistola.suite.tenants.Tenant
-import app.epistola.suite.tenants.commands.CreateTenant
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class SlugAutoFillUiTest : BasePlaywrightTest() {
 
-    private fun createTestTenant(): Tenant = withMediator {
-        CreateTenant(
-            id = TenantKey.of("slugtest-${System.nanoTime()}"),
-            name = "Slug AutoFill Test",
-        ).execute()
-    }
+    private fun createTestTenant(): Tenant = createTenant("Slug AutoFill Test")
 
     @Test
     fun `slug field should reject invalid characters`() {
@@ -66,16 +57,6 @@ class SlugAutoFillUiTest : BasePlaywrightTest() {
 
         page.locator("#dynamic-name").fill("Hello World")
 
-        val slugValue = page.locator("#dynamic-slug").inputValue()
-
-        assertTrue(
-            slugValue.isNotEmpty(),
-            "Expected slug to be auto-filled but got empty value",
-        )
-        assertEquals(
-            "hello-world",
-            slugValue,
-            "Expected slug to be 'hello-world' but got: '$slugValue'",
-        )
+        assertThat(page.locator("#dynamic-slug")).hasValue("hello-world")
     }
 }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/SlugAutoFillUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/SlugAutoFillUiTest.kt
@@ -1,0 +1,81 @@
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.tenants.Tenant
+import app.epistola.suite.tenants.commands.CreateTenant
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SlugAutoFillUiTest : BasePlaywrightTest() {
+
+    private fun createTestTenant(): Tenant = withMediator {
+        CreateTenant(
+            id = TenantKey.of("slugtest-${System.nanoTime()}"),
+            name = "Slug AutoFill Test",
+        ).execute()
+    }
+
+    @Test
+    fun `slug field should reject invalid characters`() {
+        val tenant = createTestTenant()
+
+        page.navigate("${baseUrl()}/tenants/${tenant.id}/templates/new")
+        page.waitForSelector("#slug")
+
+        val slugInput = page.locator("#slug")
+        slugInput.click()
+        page.keyboard().press("Control+A")
+        page.keyboard().type("HELLO_WORLD!")
+
+        val slugValue = slugInput.inputValue()
+
+        assertTrue(
+            slugValue.matches(Regex("^[a-z0-9-]*$")),
+            "Expected slug to contain only [a-z0-9-] but got: '$slugValue'",
+        )
+    }
+
+    @Test
+    fun `slug auto-fill should work for elements added after page load`() {
+        val tenant = createTestTenant()
+
+        page.navigate("${baseUrl()}/tenants/${tenant.id}/templates/new")
+        page.waitForSelector("#slug")
+
+        page.evaluate(
+            """
+            () => {
+                var div = document.createElement('div');
+                div.innerHTML =
+                    '<div class="card create-form-card"><div class="card-content">' +
+                    '<input type="text" id="dynamic-name" name="name" class="ep-input"' +
+                    ' placeholder="Dynamic Name" data-slug-source="dynamic-slug">' +
+                    '<input type="text" id="dynamic-slug" name="slug" class="ep-input"' +
+                    ' placeholder="dynamic-slug">' +
+                    '</div></div>';
+                document.querySelector('main').appendChild(div);
+            }
+        """,
+        )
+
+        assertThat(page.locator("#dynamic-name")).isVisible()
+        assertThat(page.locator("#dynamic-slug")).isVisible()
+
+        page.locator("#dynamic-name").fill("Hello World")
+
+        val slugValue = page.locator("#dynamic-slug").inputValue()
+
+        assertTrue(
+            slugValue.isNotEmpty(),
+            "Expected slug to be auto-filled but got empty value",
+        )
+        assertEquals(
+            "hello-world",
+            slugValue,
+            "Expected slug to be 'hello-world' but got: '$slugValue'",
+        )
+    }
+}


### PR DESCRIPTION
## Description

Adds client-side slug auto-generation to all create forms. When the user types a name/title, the slug field auto-fills with a slugified version (using the same `nameToSlug` logic already present in the stencil picker dialog). If the user manually edits the slug, further name changes stop updating it.

Implements a reusable `slug-auto.js` (IIFE) that wires up any input with `data-slug-source` pointing to a slug input. The script is included via the footer fragment so it's available on every page.

## Related Issue(s)

Closes #376

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] Frontend (Editor/TypeScript)

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes