### PR TITLE
fix: feedback dialog on editor

### DIFF
--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title th:text="${templateName + ' - Edit - Epistola'}">Edit Template - Epistola</title>
     <th:block th:replace="~{fragments/styles :: styles}" />
+    <th:block th:replace="~{fragments/htmx :: htmx}" />
     <link rel="stylesheet" th:href="@{/css/shell.css}">
     <link rel="stylesheet" th:href="@{/editor/template-editor.css}">
     <!-- AI plugin CSS — loaded conditionally when AI plugin is enabled -->


### PR DESCRIPTION
## Description

The feedback dialog wasn't opening in the editor because the HTMX Thymeleaf fragment (`fragments/htmx :: htmx`) was not included in `editor.html`. This PR adds the missing fragment import.

## Related Issue(s)

Closes #378 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

The fix is a single line addition in `apps/epistola/src/main/resources/templates/templates/editor.html`:
```html
<th:block th:replace="~{fragments/htmx :: htmx}" />
```
