### PR TITLE
fix: rich text support related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The remaining follow-ups now that the bundled system catalog and catalog-protoco
 - **ProseMirror double border fixed.** Removed redundant border between ProseMirror container and its parent element.
 - **Rich-text example inputs no longer overflow.** Fixed sizing so rich-text ProseMirror editors in the data example form can grow with their content.
 - **Migration detection handles `$ref` property types.** `detectMigrations` now delegates to the ref-type registry's `shallowShapeCheck` for `$ref`-only properties (where `propSchema.type` is `undefined`), avoiding false `TYPE_MISMATCH` for metadata-only changes like required↔optional. `formatValue` classifies rich-text docs via the registry instead of dumping raw ProseMirror JSON.
+- **Expression dialog preview shows actual rich-text content.** The expression dialog's live preview was rendering a static `[rich text value]` placeholder for resolved rich-text docs instead of showing the text. Replaced `formatBindingPreviewPlaceholder` with `formatBindingPreview`, which walks the ProseMirror doc tree (paragraphs → text nodes) and extracts readable plain text. Hard breaks render as spaces; multi-paragraph docs are joined; malformed docs return `(empty)`.
+- **Rich Text Block canvas no longer overflows long text.** Added `word-break: break-word` and `overflow-wrap: break-word` to the canvas wrapper, the rendered `<p>` elements, and the placeholder `<code>` element so long unbroken strings wrap instead of bleeding outside the block.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ The remaining follow-ups now that the bundled system catalog and catalog-protoco
 
 - **Duplicate CSS rules merged.** The two competing `.btn-sm` definitions in `components.css` are now one. The two `.canvas-placeholder--default-edit` rules in `placeholder.css` are now one.
 
+- **Label click now focuses rich-text ProseMirror editor in data examples.** Custom elements are not "labelable" per HTML spec, so `<label for>` clicks on `<epistola-rich-text-input>` were silently ignored. Replaced `<label for>` with a `<span>` click handler that calls `.focus()` on the custom element, which forwards to the ProseMirror view. Added `tabIndex = -1` and `focus()` override to `EpistolaRichTextInput`.
+- **Rich-text block empty state styled with design tokens.** Moved from inlined Lit styles to a proper `richtextvar.css` with `@layer components`, using `--ep-muted-foreground` and `--ep-text-xs`. Block label title-cased ("Rich Text Block"), shows bound variable name via `getLabel`.
+- **ProseMirror double border fixed.** Removed redundant border between ProseMirror container and its parent element.
+- **Rich-text example inputs no longer overflow.** Fixed sizing so rich-text ProseMirror editors in the data example form can grow with their content.
+- **Migration detection handles `$ref` property types.** `detectMigrations` now delegates to the ref-type registry's `shallowShapeCheck` for `$ref`-only properties (where `propSchema.type` is `undefined`), avoiding false `TYPE_MISMATCH` for metadata-only changes like required↔optional. `formatValue` classifies rich-text docs via the registry instead of dumping raw ProseMirror JSON.
+
 ### Changed
 
 - **Security scan now publishes vulnerability details.** The daily Trivy scan workflow (`.github/workflows/security-scan.yml`) previously counted CRITICAL/HIGH findings for the README badge but discarded the per-CVE details on the runner. It now also produces SARIF, uploads it to GitHub Code Scanning (Security tab → Code scanning), and uploads the JSON + SARIF results as a 30-day `trivy-scan-results` workflow artifact.

--- a/modules/design-system/base.css
+++ b/modules/design-system/base.css
@@ -34,7 +34,7 @@
   }
 
   /* Global focus-visible ring */
-  :focus-visible {
+  :focus-visible:not(.ProseMirror) {
     outline: none;
     box-shadow: var(--ep-ring);
   }

--- a/modules/editor/src/main/typescript/components/richTextVariable/EpistolaRichTextVariablePreview.ts
+++ b/modules/editor/src/main/typescript/components/richTextVariable/EpistolaRichTextVariablePreview.ts
@@ -76,15 +76,14 @@ export class EpistolaRichTextVariablePreview extends LitElement {
     if (!this.binding) {
       return html`
         <div class="rich-text-variable-empty">
-          <span>Rich text variable</span>
-          <small>Set a binding in the inspector.</small>
+          <span>Set a binding in the inspector.</span>
         </div>
       `;
     }
     if (!this._isRichTextDoc(this._resolved)) {
       return html`
         <div class="rich-text-variable-placeholder" data-binding=${this.binding}>
-          <span class="rich-text-variable-label">Rich text:</span>
+          <span class="rich-text-variable-label">Rich Text:</span>
           <code>${this.binding}</code>
         </div>
       `;

--- a/modules/editor/src/main/typescript/components/richTextVariable/richtextvar-registration.ts
+++ b/modules/editor/src/main/typescript/components/richTextVariable/richtextvar-registration.ts
@@ -12,7 +12,11 @@ import './EpistolaRichTextVariablePreview.js';
 export function createRichTextVariableDefinition(): ComponentDefinition {
   return {
     type: 'richTextVariable',
-    label: 'Rich text block',
+    label: 'Rich Text Block',
+    getLabel: (node, _eng) => {
+      const binding = (node.props?.binding as string | undefined) ?? '';
+      return binding ? `Rich Text Block — ${binding}` : 'Rich Text Block';
+    },
     icon: 'type',
     category: 'content',
     slots: [],

--- a/modules/editor/src/main/typescript/components/richTextVariable/richtextvar.css
+++ b/modules/editor/src/main/typescript/components/richTextVariable/richtextvar.css
@@ -1,6 +1,11 @@
 /* ── Rich Text Variable block canvas styles ──────────────────────────── */
 
 @layer components {
+  .rich-text-variable-canvas {
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
   .rich-text-variable-empty {
     display: flex;
     align-items: center;
@@ -9,5 +14,15 @@
     font-size: var(--ep-text-xs);
     text-align: center;
     padding: var(--ep-space-3) 0;
+  }
+
+  .rich-text-variable-placeholder code {
+    word-break: break-word;
+  }
+
+  .rich-text-variable-rendered {
+    p {
+      word-break: break-word;
+    }
   }
 }

--- a/modules/editor/src/main/typescript/components/richTextVariable/richtextvar.css
+++ b/modules/editor/src/main/typescript/components/richTextVariable/richtextvar.css
@@ -1,0 +1,13 @@
+/* ── Rich Text Variable block canvas styles ──────────────────────────── */
+
+@layer components {
+  .rich-text-variable-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ep-muted-foreground);
+    font-size: var(--ep-text-xs);
+    text-align: center;
+    padding: var(--ep-space-3) 0;
+  }
+}

--- a/modules/editor/src/main/typescript/data-contract/binding-compatibility.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/binding-compatibility.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  formatBindingPreviewPlaceholder,
+  formatBindingPreview,
   formatFieldPathTypeLabel,
   inlineExpressionPathDisabled,
   richTextVariablePathDisabled,
@@ -51,33 +51,69 @@ describe('richTextVariablePathDisabled', () => {
   });
 });
 
-describe('formatBindingPreviewPlaceholder', () => {
-  it('returns "[rich text value]" for a single-paragraph doc', () => {
+describe('formatBindingPreview', () => {
+  it('extracts text from a single-paragraph doc', () => {
     expect(
-      formatBindingPreviewPlaceholder({
+      formatBindingPreview({
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }],
+      }),
+    ).toBe('Hello');
+  });
+
+  it('extracts text from a multi-paragraph doc', () => {
+    expect(
+      formatBindingPreview({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'First' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Second' }] },
+        ],
+      }),
+    ).toBe('First Second');
+  });
+
+  it('returns "(empty)" for a doc with no text', () => {
+    expect(
+      formatBindingPreview({
         type: 'doc',
         content: [{ type: 'paragraph' }],
       }),
-    ).toBe('[rich text value]');
+    ).toBe('(empty)');
   });
 
-  it('returns "[rich text value]" for a multi-paragraph doc', () => {
+  it('returns "(empty)" for a doc with non-array content', () => {
     expect(
-      formatBindingPreviewPlaceholder({
+      formatBindingPreview({
+        type: 'doc',
+        content: 'not-an-array',
+      }),
+    ).toBe('(empty)');
+  });
+
+  it('handles hard_break as a space', () => {
+    expect(
+      formatBindingPreview({
         type: 'doc',
         content: [
-          { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
-          { type: 'bullet_list', content: [] },
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'Line 1' },
+              { type: 'hard_break' },
+              { type: 'text', text: 'Line 2' },
+            ],
+          },
         ],
       }),
-    ).toBe('[rich text value]');
+    ).toBe('Line 1 Line 2');
   });
 
   it('returns null for non-rich-text values so the caller can format normally', () => {
-    expect(formatBindingPreviewPlaceholder('plain string')).toBeNull();
-    expect(formatBindingPreviewPlaceholder(42)).toBeNull();
-    expect(formatBindingPreviewPlaceholder(null)).toBeNull();
-    expect(formatBindingPreviewPlaceholder({ name: 'John' })).toBeNull();
-    expect(formatBindingPreviewPlaceholder([1, 2, 3])).toBeNull();
+    expect(formatBindingPreview('plain string')).toBeNull();
+    expect(formatBindingPreview(42)).toBeNull();
+    expect(formatBindingPreview(null)).toBeNull();
+    expect(formatBindingPreview({ name: 'John' })).toBeNull();
+    expect(formatBindingPreview([1, 2, 3])).toBeNull();
   });
 });

--- a/modules/editor/src/main/typescript/data-contract/binding-compatibility.ts
+++ b/modules/editor/src/main/typescript/data-contract/binding-compatibility.ts
@@ -57,13 +57,31 @@ export function formatFieldPathTypeLabel(fp: FieldPath): string {
 }
 
 /**
- * Display-side helper for the expression dialog's resolved-value preview.
- * For values that match a registered ref type (e.g. a rich-text doc) the raw
- * JSON is unhelpful — render a stable placeholder instead so authors know
- * the binding resolved without seeing a wall of ProseMirror JSON. Returns
- * `null` when the value isn't a ref-shaped value; the caller then falls back
- * to its generic formatter (`formatForPreview`).
+ * Extract a readable plain-text preview from a resolved expression value.
+ * For rich-text ProseMirror docs, walks paragraphs → text nodes and joins
+ * their text content. Returns `null` when the value isn't a registered ref
+ * type, so the caller can fall back to its generic formatter
+ * (`formatForPreview`).
  */
-export function formatBindingPreviewPlaceholder(value: unknown): string | null {
-  return classifyValue(value) !== null ? '[rich text value]' : null;
+export function formatBindingPreview(value: unknown): string | null {
+  const refType = classifyValue(value);
+  if (refType === null) return null;
+
+  const doc = value as { content?: unknown };
+  if (!Array.isArray(doc.content)) return '(empty)';
+  const paragraphs: string[] = [];
+  for (const block of doc.content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as { type?: string; content?: unknown[] };
+    if (b.type !== 'paragraph' || !Array.isArray(b.content)) continue;
+    const texts: string[] = [];
+    for (const node of b.content) {
+      if (!node || typeof node !== 'object') continue;
+      const n = node as { type?: string; text?: string };
+      if (n.type === 'text' && n.text) texts.push(n.text);
+      else if (n.type === 'hard_break') texts.push(' ');
+    }
+    if (texts.length > 0) paragraphs.push(texts.join(''));
+  }
+  return paragraphs.length > 0 ? paragraphs.join(' ') : '(empty)';
 }

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -574,6 +574,12 @@
     display: block;
     width: 100%;
 
+    &.dc-tree-input,
+    &.dc-array-item-input {
+      height: auto;
+      padding: 0;
+    }
+
     .dc-rich-text-container {
       min-height: var(--ep-h-9);
       font-size: var(--ep-text-sm);

--- a/modules/editor/src/main/typescript/data-contract/sections/EpistolaRichTextInput.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/EpistolaRichTextInput.ts
@@ -48,6 +48,16 @@ export class EpistolaRichTextInput extends LitElement {
   @property({ type: String }) placeholder = '';
   @property({ type: String }) mode: RichTextInputMode = 'block';
 
+  /** Accept programmatic focus (e.g. from a label's for attribute) and forward to ProseMirror. */
+  override focus(): void {
+    this._view?.focus();
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.tabIndex = -1;
+  }
+
   private _view: EditorView | null = null;
   private _container: HTMLDivElement | null = null;
   private _lastEmittedJson = '';

--- a/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
@@ -358,7 +358,15 @@ function renderFormField(
     case 'richTextBlock':
       return html`
         <div class="dc-tree-row dc-tree-row-rich-text">
-          ${label}
+          <span
+            class="dc-tree-label"
+            role="label"
+            @click=${() => document.getElementById(fieldId)?.focus()}
+          >
+            ${name}${isRequired
+              ? html`<span class="dc-required-mark" aria-hidden="true">*</span>`
+              : nothing}
+          </span>
           <div class="dc-tree-input-wrapper">
             <epistola-rich-text-input
               class="dc-tree-input ${fieldError ? 'dc-input-error' : ''}"

--- a/modules/editor/src/main/typescript/data-contract/sections/MigrationAssistant.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/MigrationAssistant.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { render } from 'lit';
+import { formatValue, migrationKey, renderMigrationDialog } from './MigrationAssistant.js';
+import type { MigrationSuggestion } from '../utils/schemaMigration.js';
+
+describe('formatValue', () => {
+  it('null -> "null"', () => {
+    expect(formatValue(null)).toBe('null');
+  });
+
+  it('undefined -> "undefined"', () => {
+    expect(formatValue(undefined)).toBe('undefined');
+  });
+
+  it('string -> quoted', () => {
+    expect(formatValue('hello')).toBe('"hello"');
+  });
+
+  it('number -> string', () => {
+    expect(formatValue(42)).toBe('42');
+    expect(formatValue(3.14)).toBe('3.14');
+  });
+
+  it('boolean -> string', () => {
+    expect(formatValue(true)).toBe('true');
+    expect(formatValue(false)).toBe('false');
+  });
+
+  it('single-paragraph doc -> "Rich text (inline)"', () => {
+    expect(
+      formatValue({
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hi' }] }],
+      }),
+    ).toBe('Rich text (inline)');
+  });
+
+  it('multi-paragraph doc -> "Rich text (block)"', () => {
+    expect(
+      formatValue({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'A' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'B' }] },
+        ],
+      }),
+    ).toBe('Rich text (block)');
+  });
+
+  it('doc with bullet_list -> "Rich text (block)"', () => {
+    expect(
+      formatValue({
+        type: 'doc',
+        content: [{ type: 'paragraph' }, { type: 'bullet_list', content: [] }],
+      }),
+    ).toBe('Rich text (block)');
+  });
+
+  it('doc with marks -> "Rich text (inline)"', () => {
+    expect(
+      formatValue({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'bold', marks: [{ type: 'strong' }] },
+              {
+                type: 'text',
+                text: 'link',
+                marks: [{ type: 'link', attrs: { href: 'https://x.com' } }],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe('Rich text (inline)');
+  });
+
+  it('empty array -> "0 items"', () => {
+    expect(formatValue([])).toBe('0 items');
+  });
+
+  it('single-item array -> "1 item"', () => {
+    expect(formatValue([42])).toBe('1 item');
+  });
+
+  it('multi-item array -> pluralized', () => {
+    expect(formatValue([1, 2, 3])).toBe('3 items');
+  });
+
+  it('plain object -> "Object"', () => {
+    expect(formatValue({ name: 'John', age: 30 })).toBe('Object');
+  });
+
+  it('nested plain object -> "Object"', () => {
+    expect(formatValue({ address: { street: 'Main', city: 'NYC' } })).toBe('Object');
+  });
+});
+
+// ===========================================================================
+// renderMigrationDialog — DOM rendering tests
+// ===========================================================================
+
+type Callbacks = Parameters<typeof renderMigrationDialog>[2];
+
+function noop() {}
+
+const stubCallbacks: Callbacks = {
+  onApply: noop,
+  onForceSave: noop,
+  onCancel: noop,
+  onToggleMigration: noop,
+  onSelectAll: noop,
+  onSelectNone: noop,
+};
+
+function makeMigration(overrides: Partial<MigrationSuggestion> = {}): MigrationSuggestion {
+  return {
+    exampleId: 'e1',
+    exampleName: 'Example 1',
+    path: '$.field1',
+    issue: 'TYPE_MISMATCH',
+    currentValue: 'hello',
+    expectedType: 'integer',
+    suggestedValue: null,
+    autoMigratable: false,
+    ...overrides,
+  };
+}
+
+function renderDialog(
+  migrations: MigrationSuggestion[],
+  selected = new Set<string>(),
+): HTMLElement {
+  const div = document.createElement('div');
+  const result = renderMigrationDialog(migrations, selected, stubCallbacks);
+  render(result, div);
+  return div;
+}
+
+describe('renderMigrationDialog', () => {
+  it('returns nothing when no migrations', () => {
+    const div = renderDialog([]);
+    expect(div.textContent?.trim()).toBe('');
+  });
+
+  it('renders title', () => {
+    const div = renderDialog([makeMigration()]);
+    expect(div.querySelector('.dc-migration-title')?.textContent).toBe('Schema Changes Detected');
+  });
+
+  it('renders issue count in subtitle', () => {
+    const div = renderDialog([makeMigration()]);
+    const text = div.querySelector('.dc-migration-subtitle')?.textContent ?? '';
+    expect(text).toContain('1 issue');
+    expect(text).toContain('1 example');
+  });
+
+  it('renders plural subtitle for multiple issues', () => {
+    const div = renderDialog([makeMigration(), makeMigration({ path: '$.field2' })]);
+    const text = div.querySelector('.dc-migration-subtitle')?.textContent ?? '';
+    expect(text).toContain('2 issues');
+  });
+
+  it('renders "None can be auto-fixed" when none are auto-migratable', () => {
+    const div = renderDialog([makeMigration()]);
+    const text = div.querySelector('.dc-migration-subtitle')?.textContent ?? '';
+    expect(text).toContain('None can be auto-fixed');
+  });
+
+  it('renders auto-fixable count when applicable', () => {
+    const div = renderDialog([makeMigration({ autoMigratable: true, suggestedValue: 'x' })]);
+    const text = div.querySelector('.dc-migration-subtitle')?.textContent ?? '';
+    expect(text).toContain('1 can be auto-fixed');
+  });
+
+  it('renders Select all / Select none buttons', () => {
+    const div = renderDialog([makeMigration({ autoMigratable: true, suggestedValue: 'x' })]);
+    expect(div.textContent).toContain('Select all');
+    expect(div.textContent).toContain('Select none');
+  });
+
+  it('does not render select controls when nothing auto-migratable', () => {
+    const div = renderDialog([makeMigration()]);
+    expect(div.textContent).not.toContain('Select all');
+  });
+
+  it('renders Save Anyway and Cancel buttons', () => {
+    const div = renderDialog([makeMigration()]);
+    expect(div.textContent).toContain('Save Anyway');
+    expect(div.textContent).toContain('Cancel');
+  });
+
+  it('renders Apply button when auto-migratable exists', () => {
+    const div = renderDialog([makeMigration({ autoMigratable: true, suggestedValue: 'x' })]);
+    expect(div.textContent).toContain('Apply');
+  });
+
+  it('renders TYPE_MISMATCH with current-to-expected conversion', () => {
+    const div = renderDialog([makeMigration()]);
+    const text = div.querySelector('.dc-migration-item-conversion')?.textContent ?? '';
+    expect(text).toContain('"hello"');
+    expect(text).toContain('integer');
+  });
+
+  it('renders TYPE_MISMATCH issue badge', () => {
+    const div = renderDialog([makeMigration()]);
+    expect(div.querySelector('.dc-migration-issue-badge')?.textContent?.trim()).toBe(
+      'Type mismatch',
+    );
+  });
+
+  it('renders MISSING_REQUIRED issue badge', () => {
+    const div = renderDialog([
+      makeMigration({
+        issue: 'MISSING_REQUIRED',
+        currentValue: undefined as unknown as string,
+      }),
+    ]);
+    expect(div.querySelector('.dc-migration-issue-badge')?.textContent?.trim()).toBe(
+      'Missing required',
+    );
+  });
+
+  it('renders UNKNOWN_FIELD issue badge', () => {
+    const div = renderDialog([makeMigration({ issue: 'UNKNOWN_FIELD' })]);
+    expect(div.querySelector('.dc-migration-issue-badge')?.textContent?.trim()).toBe(
+      'Unknown field',
+    );
+  });
+
+  it('renders MISSING_REQUIRED expected type info', () => {
+    const div = renderDialog([
+      makeMigration({
+        issue: 'MISSING_REQUIRED',
+        currentValue: undefined as unknown as string,
+        expectedType: 'string',
+      }),
+    ]);
+    expect(div.querySelector('.dc-migration-item-info')?.textContent).toContain('string');
+  });
+
+  it('shows deselectable checkbox for auto-migratable item', () => {
+    const m = makeMigration({ autoMigratable: true, suggestedValue: 'x' });
+    const div = renderDialog([m], new Set([migrationKey(m)]));
+    const checkbox = div.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('shows non-auto-fix icon and "Save Anyway" when no auto-migratable', () => {
+    const div = renderDialog([makeMigration()]);
+    const icon = div.querySelector('.dc-migration-item-icon');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('title')).toBe('Cannot be auto-fixed');
+  });
+
+  it('renders suggested value when auto-migratable', () => {
+    const div = renderDialog([
+      makeMigration({
+        autoMigratable: true,
+        suggestedValue: 'converted-value',
+      }),
+    ]);
+    expect(div.querySelector('.dc-migration-suggested')?.textContent).toBe('"converted-value"');
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/sections/MigrationAssistant.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/MigrationAssistant.ts
@@ -8,6 +8,7 @@
 
 import { html, nothing } from 'lit';
 import type { MigrationSuggestion, MigrationIssueType } from '../utils/schemaMigration.js';
+import { classifyValue } from '../ref-types.js';
 
 export interface MigrationDialogCallbacks {
   onApply: (selectedMigrations: MigrationSuggestion[]) => void;
@@ -213,10 +214,21 @@ export function migrationKey(m: MigrationSuggestion): string {
   return `${m.exampleId}:${m.path}:${m.issue}`;
 }
 
-/** Format a JSON value for display. */
-function formatValue(value: unknown): string {
+/** Format a JSON value for display in migration items. */
+export function formatValue(value: unknown): string {
   if (value === null) return 'null';
   if (value === undefined) return 'undefined';
   if (typeof value === 'string') return `"${value}"`;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'object') {
+    const refType = classifyValue(value);
+    if (refType !== null) return refType.label;
+    if (Array.isArray(value)) return pluralize(value.length, 'item');
+    return 'Object';
+  }
   return String(value);
+}
+
+function pluralize(count: number, word: string): string {
+  return `${count} ${word}${count === 1 ? '' : 's'}`;
 }

--- a/modules/editor/src/main/typescript/data-contract/utils/SchemaMigrationComprehensive.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/SchemaMigrationComprehensive.test.ts
@@ -1,0 +1,634 @@
+/**
+ * Migration detection — comprehensive test suite.
+ *
+ * Covers all field-type change scenarios: non-$ref types (string, number,
+ * integer, boolean, object, array) and $ref-based types (richTextInline,
+ * richTextBlock). Validates that required/optional-only changes do NOT
+ * trigger false TYPE_MISMATCH for any type.
+ *
+ * Run: npx vitest run SchemaMigrationComprehensive.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { detectMigrations, type MigrationSuggestion } from './schemaMigration.js';
+import type { DataExample, JsonObject, JsonSchema } from '../types.js';
+import { RICH_TEXT_BLOCK_SCHEMA_REF, RICH_TEXT_INLINE_SCHEMA_REF } from '../types.js';
+import { formatValue } from '../sections/MigrationAssistant.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ex = (id: string, data: JsonObject): DataExample => ({ id, name: id, data });
+
+const inlineDoc = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello world' }] }],
+};
+
+const blockDoc = {
+  type: 'doc' as const,
+  content: [
+    { type: 'paragraph', content: [{ type: 'text', text: 'Para 1' }] },
+    { type: 'paragraph', content: [{ type: 'text', text: 'Para 2' }] },
+  ],
+};
+
+function dump(m: MigrationSuggestion): string {
+  return [
+    `path=${m.path}`,
+    `issue=${m.issue}`,
+    `current=${formatValue(m.currentValue)}`,
+    `expected=${m.expectedType}`,
+    `auto=${m.autoMigratable}`,
+  ].join('  ');
+}
+
+// ===========================================================================
+// G. Edge cases — uncovered lines in schemaMigration.ts
+// ===========================================================================
+
+describe('Edge cases for coverage', () => {
+  it('schema with no properties returns compatible', () => {
+    const schema: JsonSchema = { type: 'object' };
+    const examples = [ex('e1', { field: 'value' } as JsonObject) as unknown as DataExample];
+    const { compatible } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(compatible).toBe(true);
+  });
+
+  it('non-object root schema returns compatible (line 80)', () => {
+    const schema = { type: 'array', items: { type: 'string' } } as unknown as JsonSchema;
+    const examples = [ex('e1', { field: 'value' } as JsonObject) as unknown as DataExample];
+    const { compatible } = detectMigrations(schema, examples);
+    expect(compatible).toBe(true);
+  });
+
+  it('array field type mismatched to non-array value hits tryConvert default (line 292)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { items: { type: 'array', items: { type: 'string' } } },
+    };
+    const examples = [ex('e1', { items: 'not-an-array' } as JsonObject) as unknown as DataExample];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    // TYPE_MISMATCH: actual 'string' vs expected 'array' → tryConvertValue default
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].expectedType).toBe('array');
+    expect(migrations[0].autoMigratable).toBe(false);
+  });
+
+  it('string→boolean conversion is auto-migratable (tryConvertToBoolean line 333)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { active: { type: 'boolean' } },
+    };
+    // 'true'/'yes'/'1' → true, 'false'/'no'/'0' → false
+    const examples = [
+      ex('e1', { active: 'yes' as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].autoMigratable).toBe(true);
+    expect(migrations[0].suggestedValue).toBe(true);
+  });
+
+  it('integer→string conversion is auto-migratable via String() (tryConvertToString line 303)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    const examples = [
+      ex('e1', { name: 42 as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].autoMigratable).toBe(true);
+    expect(migrations[0].suggestedValue).toBe('42');
+  });
+
+  it('boolean→string conversion is auto-migratable (tryConvertToString line 303)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    const examples = [
+      ex('e1', { name: true as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].autoMigratable).toBe(true);
+    expect(migrations[0].suggestedValue).toBe('true');
+  });
+
+  it('string→number conversion is auto-migratable (tryConvertToNumber line 317)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { count: { type: 'number' } },
+    };
+    const examples = [
+      ex('e1', { count: '42' as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].autoMigratable).toBe(true);
+    expect(migrations[0].suggestedValue).toBe(42);
+  });
+
+  it('string→integer conversion via parseInt (tryConvertToNumber integer branch)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { count: { type: 'integer' } },
+    };
+    const examples = [
+      ex('e1', { count: '42' as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations[0].suggestedValue).toBe(42);
+  });
+
+  it('array of $ref with invalid item shape (lines 172-174)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        greetings: {
+          type: 'array',
+          items: { $ref: RICH_TEXT_INLINE_SCHEMA_REF },
+        },
+      },
+    };
+    const examples = [
+      ex('e1', {
+        greetings: [
+          inlineDoc, // valid
+          'not-a-doc', // invalid — should be flagged
+        ] as unknown as JsonObject,
+      } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log('array-$ref-items:', `${migrations.length} migration(s)`);
+    for (const m of migrations) console.log('  ', dump(m));
+    // The invalid item should produce a migration
+    const invalidItem = migrations.find((m) => m.path.includes('[1]'));
+    expect(invalidItem).toBeDefined();
+    expect(invalidItem?.expectedType).toBe('Rich text (inline)');
+  });
+
+  it('string→number where string is not parsable → not auto-migratable', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { count: { type: 'number' } },
+    };
+    const examples = [
+      ex('e1', { count: 'abc' as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].autoMigratable).toBe(false);
+    expect(migrations[0].suggestedValue).toBeNull();
+  });
+
+  it('number→string conversion handles float (tryConvertToString line 303)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    const examples = [
+      ex('e1', { name: 3.14 as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations[0].suggestedValue).toBe('3.14');
+  });
+});
+
+describe('Non-$ref: no migration when field unchanged', () => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'integer' },
+      active: { type: 'boolean' },
+    },
+    required: ['name'],
+  };
+  const examples = [ex('e1', { name: 'John', age: 30, active: true }) as JsonObject as DataExample];
+
+  it('detects zero migrations', () => {
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(compatible).toBe(true);
+    if (migrations.length > 0) {
+      for (const m of migrations) console.log('  UNEXPECTED', dump(m));
+    }
+    expect(migrations).toHaveLength(0);
+  });
+});
+
+describe('Non-$ref: no migration on metadata-only changes', () => {
+  it('string required→optional with existing value', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      // not required
+    };
+    const examples = [ex('e1', { name: 'John' }) as JsonObject as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('string optional→required with value present', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    };
+    const examples = [ex('e1', { name: 'John' }) as JsonObject as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('string optional→required with value missing → MISSING_REQUIRED', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    };
+    const examples = [ex('e1', {}) as JsonObject as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(compatible).toBe(false);
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].issue).toBe('MISSING_REQUIRED');
+    expect(migrations[0].path).toBe('$.name');
+  });
+
+  it('integer required→optional with existing value', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { age: { type: 'integer' } },
+    };
+    const examples = [ex('e1', { age: 42 }) as JsonObject as DataExample];
+    const { compatible } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(compatible).toBe(true);
+  });
+});
+
+// ===========================================================================
+// B. Non-$ref types — REAL type mismatches
+// ===========================================================================
+
+describe('Non-$ref: real type mismatches', () => {
+  it('string→number: value "hello"', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { score: { type: 'number' } },
+    };
+    const examples = [
+      ex('e1', { score: 'hello' as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].issue).toBe('TYPE_MISMATCH');
+    expect(migrations[0].currentValue).toBe('hello');
+    expect(migrations[0].expectedType).toBe('number');
+  });
+
+  it('number→string: value 42', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    const examples = [
+      ex('e1', { name: 42 as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].issue).toBe('TYPE_MISMATCH');
+    expect(migrations[0].currentValue).toBe(42);
+    expect(migrations[0].expectedType).toBe('string');
+  });
+
+  it('string→boolean: value "yes"', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { active: { type: 'boolean' } },
+    };
+    const examples = [
+      ex('e1', { active: 'yes' as unknown as JsonObject } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].currentValue).toBe('yes');
+    expect(migrations[0].expectedType).toBe('boolean');
+  });
+
+  it('object→string: value plain object', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { address: { type: 'string' } },
+    };
+    const examples = [
+      ex('e1', {
+        address: { city: 'NYC' } as unknown as JsonObject,
+      } as JsonObject) as unknown as DataExample,
+    ];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].issue).toBe('TYPE_MISMATCH');
+  });
+});
+
+// ===========================================================================
+// C. Rich-text inline ($ref) — BUG: false TYPE_MISMATCH on metadata-only changes
+// ===========================================================================
+
+describe('Rich-text inline: no migration on metadata-only changes', () => {
+  it('required→required with existing value → no migration', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { greeting: { $ref: RICH_TEXT_INLINE_SCHEMA_REF } },
+      required: ['greeting'],
+    };
+    const examples = [ex('e1', { greeting: inlineDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'inline required→required:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('optional→optional with existing value → no migration', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { greeting: { $ref: RICH_TEXT_INLINE_SCHEMA_REF } },
+      // not required
+    };
+    const examples = [ex('e1', { greeting: inlineDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'inline optional→optional:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('required→optional with existing value → no migration (BUG)', () => {
+    // Field was required, now optional. Value exists. No data change.
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { greeting: { $ref: RICH_TEXT_INLINE_SCHEMA_REF } },
+    };
+    const examples = [ex('e1', { greeting: inlineDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'inline required→optional:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('optional→required with value → no migration', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { greeting: { $ref: RICH_TEXT_INLINE_SCHEMA_REF } },
+      required: ['greeting'],
+    };
+    const examples = [ex('e1', { greeting: inlineDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'inline optional→required:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('required with no value → MISSING_REQUIRED (NOT type mismatch)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { greeting: { $ref: RICH_TEXT_INLINE_SCHEMA_REF } },
+      required: ['greeting'],
+    };
+    const examples = [ex('e1', {}) as JsonObject as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(compatible).toBe(false);
+    if (migrations.length > 0) {
+      expect(migrations[0].issue).toBe('MISSING_REQUIRED');
+      expect(migrations[0].issue).not.toBe('TYPE_MISMATCH');
+    }
+  });
+});
+
+// ===========================================================================
+// D. Rich-text block ($ref) — BUG: false TYPE_MISMATCH on metadata-only changes
+// ===========================================================================
+
+describe('Rich-text block: no migration on metadata-only changes', () => {
+  it('optional→optional with value → no migration', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { bio: { $ref: RICH_TEXT_BLOCK_SCHEMA_REF } },
+    };
+    const examples = [ex('e1', { bio: blockDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'block optional→optional:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('required→optional with existing value → no migration (BUG)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { bio: { $ref: RICH_TEXT_BLOCK_SCHEMA_REF } },
+    };
+    const examples = [ex('e1', { bio: blockDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'block required→optional:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// E. Rich-text → non-$ref (real type mismatches)
+// ===========================================================================
+
+describe('Rich-text→scalar: real type mismatches', () => {
+  it('richTextInline value → string schema', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { greeting: { type: 'string' } },
+    };
+    const examples = [ex('e1', { greeting: inlineDoc } as JsonObject) as unknown as DataExample];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    // expectedType should NOT be "undefined" — should be a meaningful label
+    expect(migrations[0].expectedType).not.toBe('undefined');
+    expect(migrations[0].expectedType).toBe('string');
+  });
+
+  it('richTextBlock value → integer schema', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { bio: { type: 'integer' } },
+    };
+    const examples = [ex('e1', { bio: blockDoc } as JsonObject) as unknown as DataExample];
+    const { migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].expectedType).toBe('integer');
+  });
+});
+
+// ===========================================================================
+// F. Rich-text → rich-text ($ref → different $ref)
+// ===========================================================================
+
+describe('Rich-text $ref changes (inline↔block)', () => {
+  it('inline doc → block schema: single-paragraph doc is valid for block too → no migration', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { content: { $ref: RICH_TEXT_BLOCK_SCHEMA_REF } },
+    };
+    const examples = [ex('e1', { content: inlineDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'inline-doc→block-schema:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    // A single-paragraph doc is valid under the block schema
+    expect(compatible).toBe(true);
+    expect(migrations).toHaveLength(0);
+  });
+
+  it('block doc with lists → inline schema: should detect issue', () => {
+    const listDoc = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Title' }] },
+        { type: 'bullet_list', content: [] },
+      ],
+    };
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { content: { $ref: RICH_TEXT_INLINE_SCHEMA_REF } },
+    };
+    const examples = [ex('e1', { content: listDoc } as JsonObject) as unknown as DataExample];
+    const { compatible, migrations } = detectMigrations(
+      schema as unknown as JsonSchema,
+      examples as unknown as DataExample[],
+    );
+    console.log(
+      'block-doc→inline-schema:',
+      compatible ? 'compatible' : `${migrations.length} migration(s)`,
+    );
+    for (const m of migrations) console.log('  ', dump(m));
+    // A block doc with lists doesn't match inline shape
+    expect(compatible).toBe(false);
+    if (migrations.length > 0) {
+      // migration should relate to shape incompatibility, not a false TYPE_MISMATCH
+      expect(migrations[0].expectedType).not.toBe('undefined');
+    }
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/utils/schemaMigration.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/schemaMigration.ts
@@ -5,6 +5,7 @@ import type {
   JsonSchemaProperty,
   JsonValue,
 } from '../types.js';
+import { findRefType } from '../ref-types.js';
 
 /**
  * Type of validation issue that can be auto-migrated.
@@ -87,13 +88,14 @@ function detectExampleMigrations(
     if (value === undefined) {
       // Missing field - check if required
       if (schema.required?.includes(propName)) {
+        const refType = findRefType(propSchema.$ref);
         migrations.push({
           exampleId,
           exampleName,
           path,
           issue: 'MISSING_REQUIRED',
           currentValue: undefined as unknown as JsonValue,
-          expectedType: propSchema.type as string,
+          expectedType: refType?.label ?? (propSchema.type as string),
           suggestedValue: null,
           autoMigratable: false,
         });
@@ -101,10 +103,27 @@ function detectExampleMigrations(
       continue;
     }
 
-    // Check type mismatch
-    const typeMigration = detectTypeMismatch(exampleId, exampleName, path, value, propSchema);
-    if (typeMigration) {
-      migrations.push(typeMigration);
+    // Check type mismatch — $ref-based properties use shape checking
+    const refType = findRefType(propSchema.$ref);
+    if (refType) {
+      const reason = refType.shallowShapeCheck(value);
+      if (reason !== null) {
+        migrations.push({
+          exampleId,
+          exampleName,
+          path,
+          issue: 'TYPE_MISMATCH',
+          currentValue: value,
+          expectedType: refType.label,
+          suggestedValue: null,
+          autoMigratable: false,
+        });
+      }
+    } else {
+      const typeMigration = detectTypeMismatch(exampleId, exampleName, path, value, propSchema);
+      if (typeMigration) {
+        migrations.push(typeMigration);
+      }
     }
 
     // Recursively check nested objects
@@ -130,8 +149,11 @@ function detectExampleMigrations(
         const item = value[i];
         const itemPath = `${path}[${i}]`;
 
+        const itemRefType = findRefType(propSchema.items.$ref);
+
         // For object items, recurse to check required fields and nested types
         if (
+          !itemRefType &&
           propSchema.items.type === 'object' &&
           propSchema.items.properties &&
           typeof item === 'object' &&
@@ -146,6 +168,20 @@ function detectExampleMigrations(
             itemPath,
           );
           migrations.push(...nested);
+        } else if (itemRefType) {
+          const reason = itemRefType.shallowShapeCheck(item);
+          if (reason !== null) {
+            migrations.push({
+              exampleId,
+              exampleName,
+              path: itemPath,
+              issue: 'TYPE_MISMATCH',
+              currentValue: item,
+              expectedType: itemRefType.label,
+              suggestedValue: null,
+              autoMigratable: false,
+            });
+          }
         } else {
           const itemMigration = detectTypeMismatch(
             exampleId,

--- a/modules/editor/src/main/typescript/editor.css
+++ b/modules/editor/src/main/typescript/editor.css
@@ -31,3 +31,4 @@
 @import './components/qrcode/qrcode.css';
 @import './components/stencil/stencil.css';
 @import './components/placeholder/placeholder.css';
+@import './components/richTextVariable/richtextvar.css';

--- a/modules/editor/src/main/typescript/ui/expression-dialog.ts
+++ b/modules/editor/src/main/typescript/ui/expression-dialog.ts
@@ -14,7 +14,7 @@
 
 import type { FieldPath } from '../engine/schema-paths.js';
 import {
-  formatBindingPreviewPlaceholder,
+  formatBindingPreview,
   formatFieldPathTypeLabel,
 } from '../data-contract/binding-compatibility.js';
 import {
@@ -837,8 +837,8 @@ function updatePreview(
         previewEl.textContent = validationError;
       } else {
         previewEl.className = 'expression-dialog-preview success';
-        const placeholder = formatBindingPreviewPlaceholder(result.value);
-        previewEl.textContent = `Preview: ${placeholder ?? formatForPreview(result.value)}`;
+        const richTextPreview = formatBindingPreview(result.value);
+        previewEl.textContent = `Preview: ${richTextPreview ?? formatForPreview(result.value)}`;
       }
     } else {
       previewEl.className = 'expression-dialog-preview error';


### PR DESCRIPTION
## Description

Rich text support improvements for the template editor:
- Fix `[object Object]` display in migration dialogs — rich-text docs now show "Rich text (inline)" / "Rich text (block)" instead of raw JSON
- Fix false TYPE_MISMATCH in migration detection for `$ref` fields (e.g. rich-text properties) where `propSchema.type` is `undefined`, causing metadata-only changes (required↔optional) to trigger spurious migrations
- Fix rich-text example inputs overflowing in the data contract editor
- Fix ProseMirror double border with parent element
- Fix label click not focusing ProseMirror editor in data examples (custom elements aren't labelable per HTML spec)
- Polish the Rich Text Block UI: title-case label, show bound variable name in canvas block header, style the empty state with design tokens
- Show actual preview of variable, instead of hardcoded `[rich text value]` string
- Fix overflowing text in rich text block via CSS

## Related Issue(s)

<!-- Link related issues using keywords: Closes #123, Fixes #456, Relates to #789 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

- `formatValue` in `MigrationAssistant` now uses `classifyValue` from the ref-type registry as the single source of truth for identifying rich-text doc shapes
- `detectMigrations` delegates to `shallowShapeCheck` for `$ref` properties, avoiding false TYPE_MISMATCH when `propSchema.type` is `undefined`
- Added comprehensive test coverage: `MigrationAssistant.test.ts` (32 tests, formatValue + DOM rendering) and `SchemaMigrationComprehensive.test.ts` (31 tests, migration detection edge cases)
- Empty state styling moved to a proper `richtextvar.css` file with `@layer components`, using design tokens