### PR TITLE
test: gaps in api key management

### DIFF
--- a/apps/epistola/src/test/kotlin/app/epistola/suite/config/ApiKeyAuthenticationFilterAsyncTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/config/ApiKeyAuthenticationFilterAsyncTest.kt
@@ -46,6 +46,48 @@ class ApiKeyAuthenticationFilterAsyncTest {
     }
 
     @Test
+    fun `reads from custom header name when configured`() {
+        val customFilter = ApiKeyAuthenticationFilter(service, meterRegistry, headerName = "X-Custom-Api-Key")
+        val plaintext = "epk_unit_test_key_value"
+        val key = sampleApiKey()
+        fakeMediator.lookupResponse = key
+
+        val request = MockHttpServletRequest("POST", "/api/mcp").apply {
+            addHeader("X-Custom-Api-Key", plaintext)
+        }
+        val response = MockHttpServletResponse()
+
+        MediatorContext.runWithMediator(fakeMediator) {
+            customFilter.doFilter(request, response, FilterChain { _, _ -> })
+        }
+
+        assertThat(fakeMediator.lookupQueries).isEqualTo(1)
+        assertThat(SecurityContextHolder.getContext().authentication)
+            .isInstanceOf(ApiKeyAuthenticationToken::class.java)
+    }
+
+    @Test
+    fun `ignores default X-API-Key header when custom header is configured`() {
+        val customFilter = ApiKeyAuthenticationFilter(service, meterRegistry, headerName = "X-Custom-Api-Key")
+        val key = sampleApiKey()
+        fakeMediator.lookupResponse = key
+
+        val request = MockHttpServletRequest("POST", "/api/mcp").apply {
+            // The default header is present but the custom one is not
+            addHeader("X-API-Key", "epk_some_key")
+        }
+        val response = MockHttpServletResponse()
+
+        MediatorContext.runWithMediator(fakeMediator) {
+            customFilter.doFilter(request, response, FilterChain { _, _ -> })
+        }
+
+        // Should pass through without validating because the custom header is missing
+        assertThat(fakeMediator.lookupQueries).isEqualTo(0)
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+    }
+
+    @Test
     fun `validates on REQUEST and restores from cache on ASYNC dispatch without re-querying`() {
         val plaintext = "epk_unit_test_key_value"
         val key = sampleApiKey()

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -284,6 +284,75 @@ data class EpistolaPrincipal(
 )
 ```
 
+## API Key Authentication
+
+API key authentication allows machine-to-machine access to the REST API without a browser login. Each key is scoped to a single tenant and carries the full set of tenant roles.
+
+### Managing API Keys
+
+API keys are managed per-tenant via the web UI at `/tenants/{tenantId}/api-keys`:
+
+- **Create:** Name the key and optionally set an expiration date. The plaintext key is shown **exactly once** — store it immediately.
+- **List:** View all active keys with name, prefix, creation date, last used, and expiration.
+- **Revoke:** Delete a key to immediately invalidate it.
+
+Keys are created as **non-personal accounts (NPAs)** — the key itself becomes the actor identity for audit trails.
+
+### Using an API Key
+
+Include the key in every REST API request via the `X-API-Key` header:
+
+```bash
+curl -H "X-API-Key: epk_abc123..." https://epistola.example.com/api/v1/...
+```
+
+The header name is configurable via `epistola.auth.api-key.header-name` (defaults to `X-API-Key`).
+
+### Key Format
+
+- Prefix: `epk_`
+- Total length: ~47 characters
+- Stored as SHA-256 hash (plaintext never persisted)
+- Display prefix in UI: `epk_ABC12345...` (first 8 chars after prefix)
+
+### Expiration & Revocation
+
+- **Expiration:** Optionally set at creation. Expired keys return 401.
+- **Revocation:** Deleting a key immediately invalidates it. Disabled keys also return 401.
+- **Last-used tracking:** Updated asynchronously on each authentication.
+
+### How It Works
+
+```
+Client                    ApiKeyAuthenticationFilter            Database
+  │                              │                                │
+  │  X-API-Key: epk_...          │                                │
+  │ ─────────────────────────►   │                                │
+  │                              │  SHA-256(key)                  │
+  │                              │  LookupApiKeyByHash(hash)      │
+  │                              │ ───────────────────────────►   │
+  │                              │  ◄───────────────────────────  │
+  │                              │                                │
+  │                              │  ├─ Not found    → 401         │
+  │                              │  ├─ Expired      → 401         │
+  │                              │  ├─ Disabled     → 401         │
+  │                              │  └─ Valid        → proceed     │
+  │                              │                                │
+  │  ◄─────────────────────────  │                                │
+```
+
+The filter is registered in the `/api/**` security chain. Unlike session-based auth, API key requests are **stateless** — every request is validated independently.
+
+### When to Use
+
+API key auth is intended for:
+
+- External system integrations (CI/CD, ETL pipelines, etc.)
+- MCP (Model Context Protocol) clients
+- Any application that needs to call the REST API without a user session
+
+For interactive browser usage, use form login or OAuth2/OIDC instead.
+
 ## Testing
 
 ### Integration Tests
@@ -348,3 +417,11 @@ This error means code is trying to access `SecurityContext.current()` outside of
 - In HTTP requests: Ensure `SecurityFilter` is running
 - In background tasks: Use `SecurityContext.runWithPrincipal()` to set context
 - In tests: Use `withTestUser { }` helper
+
+### API Key Requests Return 401
+
+1. Verify the key is correctly included in the `X-API-Key` header (not `Authorization: Bearer`)
+2. Check that the key has not expired
+3. Confirm the key was not revoked (check the API keys list in the UI)
+4. If using a custom header name, verify `epistola.auth.api-key.header-name` matches
+5. Ensure the request path starts with `/api` — API key auth only applies to the API security chain


### PR DESCRIPTION
## Description

Adds missing test coverage for the `ApiKeyAuthenticationFilter` custom header name configuration, and completes the API key authentication documentation for end users.

**Test changes:**
- Two new test cases in `ApiKeyAuthenticationFilterAsyncTest` covering the configurable `headerName` parameter:
  - Validates keys from a custom header name (`X-Custom-Api-Key`)
  - Ignores the default `X-API-Key` header when a custom one is configured

**Documentation changes:**
- New "API Key Authentication" section in `docs/auth.md` covering key management, usage, format, expiration/revocation, filter flow, and troubleshooting
- New troubleshooting entry for "API Key Requests Return 401"

## Related Issue(s)

- Relates to #414 (umbrella issue)
- Covers acceptance criteria gaps and Closes #55
## Type of Change

- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Documentation
- [ ] Frontend (Editor/TypeScript)
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

## Additional Notes