### PR TITLE
feat(keycloak): auto-provision Group Membership mapper on client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Keycloak Group Membership mapper auto-provisioning.** When `epistola.keycloak.ensure-groups=true`, the app now ensures a correctly-configured Group Membership protocol mapper exists on its own Keycloak client at startup (claim name `groups`, `full.path=true`, included in ID/access/userinfo tokens). Self-heals only mappers it created itself (`name=epistola-groups`); warns and leaves alone any foreign mapper that already emits a `groups` claim, so operator-intentional config is preserved. Without this, a missing or misconfigured `full.path` setting silently drops group memberships from the JWT — meaning users in `/epistola/platform/tenant-manager` (and similar) failed to gain the corresponding platform role. Requires the realm-management role `manage-clients` on the service account; if absent the app logs a warning and the rest of startup continues. See [`docs/keycloak-setup.md`](docs/keycloak-setup.md).
+
+### Changed
+
+- **[`docs/keycloak-setup.md`](docs/keycloak-setup.md)** documents the new auto-provisioning behaviour, updates the list of required service-account roles to include `manage-clients`, and adds a new "Using a Non-Keycloak IDP (BYO IDP)" section describing the Keycloak-as-broker integration pattern and the token contract Epistola expects (full hierarchical group paths under `/epistola/...`).
+
 ## [0.21.0] - 2026-05-20
 
 ### Added

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/keycloak/KeycloakAdminClient.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/keycloak/KeycloakAdminClient.kt
@@ -123,6 +123,112 @@ class KeycloakAdminClient(
             .toBodilessEntity()
     }
 
+    /**
+     * Finds an OIDC client by its `clientId` attribute.
+     *
+     * @return the client representation map, or null if no client with that clientId exists
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun findClientByClientId(clientId: String): Map<String, Any>? {
+        val results = restClient.get()
+            .uri("/admin/realms/{realm}/clients?clientId={clientId}", properties.realm, clientId)
+            .headers { it.setBearerAuth(obtainAccessToken()) }
+            .retrieve()
+            .body(List::class.java) as? List<Map<String, Any>>
+            ?: return null
+
+        return results.firstOrNull()
+    }
+
+    /**
+     * Lists all protocol mappers configured directly on a client.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun listClientProtocolMappers(clientUuid: String): List<Map<String, Any>> {
+        val mappers = restClient.get()
+            .uri(
+                "/admin/realms/{realm}/clients/{clientUuid}/protocol-mappers/models",
+                properties.realm,
+                clientUuid,
+            )
+            .headers { it.setBearerAuth(obtainAccessToken()) }
+            .retrieve()
+            .body(List::class.java) as? List<Map<String, Any>>
+            ?: return emptyList()
+
+        return mappers
+    }
+
+    /**
+     * Ensures a Group Membership protocol mapper named [mapperName] exists on the given client,
+     * emitting full hierarchical group paths into the `groups` claim of all token types.
+     *
+     * Behaviour:
+     * - No mapper writing `claim.name=groups` exists → creates one with the canonical config.
+     * - A mapper named [mapperName] exists but its config differs from canonical → updates it (self-heal).
+     * - A mapper with a *different* name already writes `claim.name=groups` → leaves it alone and
+     *   logs a WARN, so operator-intentional config is not clobbered.
+     */
+    fun ensureGroupMembershipMapper(clientUuid: String, mapperName: String = DEFAULT_GROUPS_MAPPER_NAME) {
+        val existing = listClientProtocolMappers(clientUuid)
+        when (val action = decideMapperAction(existing, mapperName)) {
+            is MapperAction.Create -> {
+                log.info("Creating Group Membership mapper '{}' on client {}", mapperName, clientUuid)
+                createProtocolMapper(clientUuid, canonicalGroupsMapper(mapperName))
+            }
+            is MapperAction.Update -> {
+                log.info(
+                    "Updating Group Membership mapper '{}' on client {} (self-heal: config drifted from canonical)",
+                    mapperName,
+                    clientUuid,
+                )
+                updateProtocolMapper(clientUuid, action.mapperId, canonicalGroupsMapper(mapperName) + ("id" to action.mapperId))
+            }
+            is MapperAction.SkipForeign -> {
+                log.warn(
+                    "Found existing protocol mapper '{}' on client {} writing claim.name=groups. " +
+                        "Expected mapper name '{}'. Leaving foreign mapper alone — review manually if " +
+                        "the groups claim is not behaving as expected.",
+                    action.foreignName,
+                    clientUuid,
+                    mapperName,
+                )
+            }
+            is MapperAction.SkipUpToDate -> {
+                log.info("Group Membership mapper '{}' on client {} already matches canonical config", mapperName, clientUuid)
+            }
+        }
+    }
+
+    private fun createProtocolMapper(clientUuid: String, body: Map<String, Any>) {
+        restClient.post()
+            .uri(
+                "/admin/realms/{realm}/clients/{clientUuid}/protocol-mappers/models",
+                properties.realm,
+                clientUuid,
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(obtainAccessToken()) }
+            .body(body)
+            .retrieve()
+            .toBodilessEntity()
+    }
+
+    private fun updateProtocolMapper(clientUuid: String, mapperId: String, body: Map<String, Any>) {
+        restClient.put()
+            .uri(
+                "/admin/realms/{realm}/clients/{clientUuid}/protocol-mappers/models/{mapperId}",
+                properties.realm,
+                clientUuid,
+                mapperId,
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .headers { it.setBearerAuth(obtainAccessToken()) }
+            .body(body)
+            .retrieve()
+            .toBodilessEntity()
+    }
+
     private fun extractGroupIdFromLocation(response: org.springframework.http.ResponseEntity<Void>, name: String): UUID {
         val location = response.headers.location
             ?: throw KeycloakAdminException("No Location header in group creation response for: $name")
@@ -150,6 +256,60 @@ class KeycloakAdminClient(
 }
 
 class KeycloakAdminException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+internal const val DEFAULT_GROUPS_MAPPER_NAME: String = "epistola-groups"
+
+internal sealed interface MapperAction {
+    data object Create : MapperAction
+    data class Update(val mapperId: String) : MapperAction
+    data class SkipForeign(val foreignName: String) : MapperAction
+    data object SkipUpToDate : MapperAction
+}
+
+internal fun canonicalGroupsMapper(mapperName: String): Map<String, Any> = mapOf(
+    "name" to mapperName,
+    "protocol" to "openid-connect",
+    "protocolMapper" to "oidc-group-membership-mapper",
+    "consentRequired" to false,
+    "config" to canonicalGroupsMapperConfig(),
+)
+
+private fun canonicalGroupsMapperConfig(): Map<String, String> = mapOf(
+    "full.path" to "true",
+    "id.token.claim" to "true",
+    "access.token.claim" to "true",
+    "claim.name" to "groups",
+    "userinfo.token.claim" to "true",
+)
+
+internal fun decideMapperAction(existing: List<Map<String, Any>>, expectedName: String): MapperAction {
+    val groupsMappers = existing.filter { mapper ->
+        @Suppress("UNCHECKED_CAST")
+        val config = mapper["config"] as? Map<String, Any> ?: emptyMap()
+        mapper["protocolMapper"] == "oidc-group-membership-mapper" &&
+            config["claim.name"]?.toString() == "groups"
+    }
+
+    val ours = groupsMappers.firstOrNull { it["name"]?.toString() == expectedName }
+    if (ours != null) {
+        @Suppress("UNCHECKED_CAST")
+        val config = (ours["config"] as? Map<String, Any>).orEmpty()
+        val canonical = canonicalGroupsMapperConfig()
+        val matches = canonical.all { (k, v) -> config[k]?.toString() == v }
+        return if (matches) {
+            MapperAction.SkipUpToDate
+        } else {
+            MapperAction.Update(ours["id"].toString())
+        }
+    }
+
+    val foreign = groupsMappers.firstOrNull()
+    if (foreign != null) {
+        return MapperAction.SkipForeign(foreign["name"]?.toString() ?: "<unnamed>")
+    }
+
+    return MapperAction.Create
+}
 
 @Configuration
 @EnableConfigurationProperties(KeycloakAdminProperties::class)

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/keycloak/KeycloakClientMapperInitializer.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/keycloak/KeycloakClientMapperInitializer.kt
@@ -1,0 +1,60 @@
+package app.epistola.suite.keycloak
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
+
+/**
+ * Ensures the Group Membership protocol mapper exists on the configured Keycloak client
+ * so the JWT `groups` claim contains full hierarchical group paths.
+ *
+ * The mapper is required for [app.epistola.suite.security.GroupMembershipParser] to map
+ * Keycloak groups (e.g. `/epistola/platform/tenant-manager`) onto Epistola platform/tenant
+ * roles. Without it, group memberships are silently dropped from the token.
+ *
+ * Self-heals only mappers named [DEFAULT_GROUPS_MAPPER_NAME]; a foreign mapper that also writes
+ * a `groups` claim is logged and left untouched so operator-intentional config is preserved.
+ *
+ * Enabled via `epistola.keycloak.ensure-groups=true` (same flag as [KeycloakGroupInitializer]).
+ * Requires the service account to have the realm-management role `manage-clients`.
+ */
+@Component
+@ConditionalOnBean(KeycloakAdminClient::class)
+@ConditionalOnProperty(name = ["epistola.keycloak.ensure-groups"], havingValue = "true")
+class KeycloakClientMapperInitializer(
+    private val keycloakAdminClient: KeycloakAdminClient,
+    private val properties: KeycloakAdminProperties,
+) : ApplicationRunner {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun run(args: ApplicationArguments) {
+        val clientId = properties.clientId
+        try {
+            val client = keycloakAdminClient.findClientByClientId(clientId)
+            if (client == null) {
+                log.warn("Keycloak client '{}' not found in realm '{}' — skipping mapper provisioning", clientId, properties.realm)
+                return
+            }
+            val uuid = client["id"]?.toString()
+            if (uuid.isNullOrBlank()) {
+                log.warn("Keycloak client '{}' lookup returned no 'id' field — skipping mapper provisioning", clientId)
+                return
+            }
+            keycloakAdminClient.ensureGroupMembershipMapper(uuid)
+        } catch (e: HttpClientErrorException.Forbidden) {
+            log.warn(
+                "Cannot manage protocol mappers on client '{}': the service account is missing the " +
+                    "'manage-clients' realm-management role. Either grant it, or configure the Group " +
+                    "Membership mapper manually (see docs/keycloak-setup.md).",
+                clientId,
+            )
+        } catch (e: Exception) {
+            log.warn("Failed to ensure Group Membership mapper on client '{}': {}", clientId, e.message)
+        }
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/keycloak/KeycloakAdminClientMapperLogicTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/keycloak/KeycloakAdminClientMapperLogicTest.kt
@@ -1,0 +1,95 @@
+package app.epistola.suite.keycloak
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("unit")
+class KeycloakAdminClientMapperLogicTest {
+
+    @Test
+    fun `creates mapper when no existing groups-claim mapper is present`() {
+        val existing = listOf(
+            mapOf<String, Any>(
+                "id" to "abc",
+                "name" to "audience",
+                "protocolMapper" to "oidc-audience-mapper",
+                "config" to mapOf("included.client.audience" to "epistola-suite"),
+            ),
+        )
+
+        val action = decideMapperAction(existing, DEFAULT_GROUPS_MAPPER_NAME)
+
+        assertThat(action).isEqualTo(MapperAction.Create)
+    }
+
+    @Test
+    fun `updates our mapper when its config drifts from canonical`() {
+        val existing = listOf(
+            mapOf<String, Any>(
+                "id" to "mapper-uuid",
+                "name" to DEFAULT_GROUPS_MAPPER_NAME,
+                "protocolMapper" to "oidc-group-membership-mapper",
+                "config" to mapOf(
+                    "full.path" to "false",
+                    "claim.name" to "groups",
+                    "id.token.claim" to "true",
+                    "access.token.claim" to "true",
+                    "userinfo.token.claim" to "true",
+                ),
+            ),
+        )
+
+        val action = decideMapperAction(existing, DEFAULT_GROUPS_MAPPER_NAME)
+
+        assertThat(action).isEqualTo(MapperAction.Update("mapper-uuid"))
+    }
+
+    @Test
+    fun `skips when our mapper already matches canonical config`() {
+        val existing = listOf(
+            mapOf<String, Any>(
+                "id" to "mapper-uuid",
+                "name" to DEFAULT_GROUPS_MAPPER_NAME,
+                "protocolMapper" to "oidc-group-membership-mapper",
+                "config" to canonicalGroupsMapper(DEFAULT_GROUPS_MAPPER_NAME)["config"] as Map<*, *>,
+            ),
+        )
+
+        val action = decideMapperAction(existing, DEFAULT_GROUPS_MAPPER_NAME)
+
+        assertThat(action).isEqualTo(MapperAction.SkipUpToDate)
+    }
+
+    @Test
+    fun `warns and leaves alone when foreign mapper writes groups claim`() {
+        val existing = listOf(
+            mapOf<String, Any>(
+                "id" to "legacy-uuid",
+                "name" to "group-membership-mapper",
+                "protocolMapper" to "oidc-group-membership-mapper",
+                "config" to mapOf("full.path" to "true", "claim.name" to "groups"),
+            ),
+        )
+
+        val action = decideMapperAction(existing, DEFAULT_GROUPS_MAPPER_NAME)
+
+        assertThat(action).isEqualTo(MapperAction.SkipForeign("group-membership-mapper"))
+    }
+
+    @Test
+    fun `ignores group-membership mappers writing a different claim name`() {
+        val existing = listOf(
+            mapOf<String, Any>(
+                "id" to "other",
+                "name" to "groups-as-roles",
+                "protocolMapper" to "oidc-group-membership-mapper",
+                "config" to mapOf("full.path" to "true", "claim.name" to "roles"),
+            ),
+        )
+
+        val action = decideMapperAction(existing, DEFAULT_GROUPS_MAPPER_NAME)
+
+        assertThat(action).isEqualTo(MapperAction.Create)
+    }
+}

--- a/docs/keycloak-setup.md
+++ b/docs/keycloak-setup.md
@@ -121,15 +121,15 @@ managed-Keycloak setup.
 
 Add a protocol mapper to the `epistola-suite` client:
 
-| Setting             | Value                     |
-| ------------------- | ------------------------- |
-| Name                | `epistola-groups`         |
-| Mapper type         | `Group Membership`        |
-| Token claim name    | `groups`                  |
-| Full group path     | **ON**                    |
-| Add to ID token     | ON                        |
-| Add to access token | ON                        |
-| Add to userinfo     | ON                        |
+| Setting             | Value              |
+| ------------------- | ------------------ |
+| Name                | `epistola-groups`  |
+| Mapper type         | `Group Membership` |
+| Token claim name    | `groups`           |
+| Full group path     | **ON**             |
+| Add to ID token     | ON                 |
+| Add to access token | ON                 |
+| Add to userinfo     | ON                 |
 
 **Important:** `Full group path` must be ON so the JWT contains full paths like `/epistola/tenants/demo/reader`.
 
@@ -196,7 +196,7 @@ What it does:
   `epistola-groups` with `full.path=true`, included in ID/access/userinfo tokens.
 - If a mapper named `epistola-groups` already exists but its config has drifted → updates it
   back to the canonical config (self-heal).
-- If a mapper with a *different* name already writes `claim.name=groups` → logs a WARN and
+- If a mapper with a _different_ name already writes `claim.name=groups` → logs a WARN and
   leaves it alone, so deliberate operator config is not clobbered. Inspect the warning and
   reconcile manually if the `groups` claim isn't behaving as expected.
 
@@ -319,10 +319,10 @@ itself only ever sees Keycloak-issued tokens with the expected claim shape.
 
 For any IDP integration, the token Epistola Suite receives must contain:
 
-| Claim   | Type             | Example values                                                                  |
-| ------- | ---------------- | ------------------------------------------------------------------------------- |
-| `sub`   | string           | stable user identifier                                                          |
-| `email` | string           | user's email                                                                    |
+| Claim    | Type            | Example values                                                                                                                                                                                   |
+| -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sub`    | string          | stable user identifier                                                                                                                                                                           |
+| `email`  | string          | user's email                                                                                                                                                                                     |
 | `groups` | array of string | `["/epistola/tenants/acme-corp/reader", "/epistola/platform/tenant-manager"]` — paths must start with `/epistola/` and follow the conventions in [Group Path Convention](#group-path-convention) |
 
 Anything outside the `/epistola/` prefix is ignored by the parser. Short-name groups

--- a/docs/keycloak-setup.md
+++ b/docs/keycloak-setup.md
@@ -115,11 +115,15 @@ Create an OpenID Connect client named `epistola-suite`:
 
 ### 2. Group Membership Mapper
 
+This can be configured manually via the admin UI (steps below), or auto-provisioned by the
+app — see [Automatic Client Mapper Provisioning](#automatic-client-mapper-provisioning) for the
+managed-Keycloak setup.
+
 Add a protocol mapper to the `epistola-suite` client:
 
 | Setting             | Value                     |
 | ------------------- | ------------------------- |
-| Name                | `group-membership-mapper` |
+| Name                | `epistola-groups`         |
 | Mapper type         | `Group Membership`        |
 | Token claim name    | `groups`                  |
 | Full group path     | **ON**                    |
@@ -179,6 +183,27 @@ keycloakAdmin:
 
 This creates `/epistola/tenants`, `/epistola/global/*`, and `/epistola/platform/*` if they don't exist. The operation is idempotent.
 
+### Automatic Client Mapper Provisioning
+
+With `ensureGroups: true`, Epistola also ensures the Group Membership protocol mapper on its
+own client (`clientId`) is configured correctly on startup. This removes a manual setup step
+and prevents misconfigured deployments where the `groups` claim is missing or contains
+short-name groups (without `full.path=true`).
+
+What it does:
+
+- If no mapper writing `claim.name=groups` exists on the client → creates one named
+  `epistola-groups` with `full.path=true`, included in ID/access/userinfo tokens.
+- If a mapper named `epistola-groups` already exists but its config has drifted → updates it
+  back to the canonical config (self-heal).
+- If a mapper with a *different* name already writes `claim.name=groups` → logs a WARN and
+  leaves it alone, so deliberate operator config is not clobbered. Inspect the warning and
+  reconcile manually if the `groups` claim isn't behaving as expected.
+
+If the service account is missing the `manage-clients` realm-management role, the app logs a
+warning and the rest of startup continues. In that case, configure the mapper manually
+(Step 2 above) or grant the role.
+
 ### Configuration
 
 ```yaml
@@ -202,6 +227,8 @@ The `epistola-suite` client's service account needs `realm-management` client ro
 - `manage-users` — required for creating and deleting groups
 - `view-users` — required for listing groups
 - `query-users` — required for searching groups
+- `manage-clients` — required when `ensureGroups: true` so the app can manage its own
+  client's Group Membership protocol mapper (see [Automatic Client Mapper Provisioning](#automatic-client-mapper-provisioning))
 
 ## Local Development
 
@@ -250,3 +277,62 @@ After login, the JWT will contain:
   ]
 }
 ```
+
+## Using a Non-Keycloak IDP (BYO IDP)
+
+Epistola's `GroupMembershipParser` expects the `groups` claim to contain **full
+hierarchical paths** matching `/epistola/{tenants|global|platform}/...`. Most enterprise
+IdPs (Entra ID, Okta, ADFS, etc.) do not produce hierarchical group claims natively — they
+emit flat group names or object IDs.
+
+The supported integration pattern is therefore:
+
+```
+[ Customer IDP (Entra/Okta/ADFS) ]
+            │
+            │ OIDC / SAML identity brokering
+            ▼
+[ Keycloak ] ── issues tokens to ──► [ Epistola Suite ]
+   (broker)                                  ▲
+                                             │
+                                Token contains `/epistola/...`
+                                groups via Group Membership mapper
+```
+
+Keycloak acts as a broker: it federates authentication to the customer's IDP, then maps
+the brokered identity onto Epistola's group structure inside the realm. The application
+itself only ever sees Keycloak-issued tokens with the expected claim shape.
+
+### Setup outline
+
+1. In the Epistola Keycloak realm, configure the customer's IDP under **Identity Providers**
+   (OIDC v1 / SAML v2). Trust is established with the customer's IDP admins.
+2. Add identity-provider **claim mappers** that derive Epistola group memberships from
+   whatever the customer IDP emits — typically:
+   - Static group assignment, e.g. all brokered users land in `/epistola/global/reader`.
+   - Conditional / attribute-based assignment, e.g. users in the IDP's "Tenant Admins"
+     group are mapped into `/epistola/platform/tenant-manager`.
+3. Users authenticate via their corporate IDP. Keycloak provisions a local shadow user on
+   first login and issues a token that conforms to the contract documented above.
+
+### Token contract (read this first)
+
+For any IDP integration, the token Epistola Suite receives must contain:
+
+| Claim   | Type             | Example values                                                                  |
+| ------- | ---------------- | ------------------------------------------------------------------------------- |
+| `sub`   | string           | stable user identifier                                                          |
+| `email` | string           | user's email                                                                    |
+| `groups` | array of string | `["/epistola/tenants/acme-corp/reader", "/epistola/platform/tenant-manager"]` — paths must start with `/epistola/` and follow the conventions in [Group Path Convention](#group-path-convention) |
+
+Anything outside the `/epistola/` prefix is ignored by the parser. Short-name groups
+(e.g. `"tenant-manager"` without the path prefix) are also ignored — `full.path=true` on
+the Group Membership mapper is what produces the expected shape.
+
+### When to keep Keycloak in the loop vs. integrate directly
+
+Direct integration (no Keycloak broker) is technically possible if the customer's IDP can
+emit a `groups` claim with full Epistola-style paths. In practice this is rare — corporate
+IDP teams are reluctant to model another app's authorization hierarchy inside their
+identity store, and the result is brittle. The brokered pattern keeps Epistola's group
+model owned by the app deployment, while letting the customer's IDP own authentication.


### PR DESCRIPTION
## Summary

- When `epistola.keycloak.ensure-groups=true`, the app now ensures a correctly-configured Group Membership protocol mapper exists on its own Keycloak client at startup (claim `groups`, `full.path=true`, included in all token types).
- Self-heals only mappers it owns (`name=epistola-groups`); a foreign mapper that already writes `claim.name=groups` is logged and left alone so operator-intentional config is preserved.
- Decision logic (`decideMapperAction`) extracted as a pure function and covered by 5 unit tests.
- Docs (`docs/keycloak-setup.md`) updated: auto-provisioning behaviour, required service-account roles now include `manage-clients`, and a new section on Keycloak-as-broker for BYO-IDP customers (Entra/Okta/ADFS).

## Background

A user added to `/epistola/platform/tenant-manager` did not gain tenant-creation rights. Root cause: the existing protocol mapper on the `epistola-suite` client had `full.path=false`, so the JWT `groups` claim emitted bare role names (`tenant-manager`) instead of the full paths the parser expects (`/epistola/platform/tenant-manager`). The bug was patched manually in the test cluster's Keycloak admin UI; this change makes the fix reproducible for all deployments.

Companion PR: epistola-app/valtimo-epistola-plugin → fix `valtimo-realm.json` so fresh demo deploys come up correct (and the service account has `manage-clients` so this PR's auto-provisioning can do its job).

## Test plan

- [x] Unit tests pass (`./gradlew :apps:epistola:test --tests 'app.epistola.suite.keycloak.*'`)
- [x] ktlint clean (`./gradlew :apps:epistola:ktlintCheck`)
- [x] Main compiles (`./gradlew :apps:epistola:compileKotlin`)
- [ ] After release + Flux auto-deploy on test cluster, watch pod logs for `Ensured Group Membership mapper on client 'epistola-suite'`
- [ ] Verify token issued via `valtimo-console` direct grant for `uitest@epistola.app` contains `/epistola/platform/tenant-manager` in `groups` claim
- [ ] Have `uitest@epistola.app` log out / back in and confirm tenant creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)