### PR TITLE
fix(templates): add inline template name editing in settings tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   - **Batch 2** — `create-form-submit` on the submit button in `.create-form-card` for themes, templates, fonts, environments, attributes, and API keys.
   - **Batch 3** — `template-tab` (+ `data-tab-name`) on the template detail tab strip; `template-row` (+ `data-template-slug`) on template list rows; `delete-action` on danger-zone delete buttons (theme detail, template settings); `theme-default-badge` on the themes list; `variant-create-open` / `variant-create-submit` on the variant create dialog; `catalog-create-open` / `catalog-create-submit` on the catalog create dialog; `feature-toggle` (+ `data-feature-key`) / `feature-toggle-switch` on feature toggle items; `api-key-row` (+ `data-api-key-name`) / `api-key-delete` on API key list rows; `api-key-name` on the created key details page; `alert-success` on success alert banners (login, catalogs, features). Purely additive markup; no behaviour change.
 
+### Fixed
+
+- **Template name cannot be changed after creation.** The backend `UpdateDocumentTemplate` command already accepted a `name` parameter, but the settings tab had no UI to edit it — the template name was only settable in the create form. Added an inline-editable name input to the template settings tab that saves on blur/Enter via the existing `PATCH` endpoint, reverts on Escape or failure, and updates the page heading on success. Disabled for templates in read-only (subscribed) catalogs. Closes #333.
+
 ## [0.22.1] - 2026-05-21
 
 ### Fixed

--- a/apps/epistola/src/main/resources/templates/templates/detail/settings.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail/settings.html
@@ -7,6 +7,15 @@
             <div class="detail-section-header"><h3>Details</h3></div>
             <div class="detail-section-body">
                 <dl class="description-list">
+                    <dt>Name</dt>
+                    <dd>
+                        <input type="text" id="template-name-input" class="ep-input"
+                               th:value="${template.name}" th:disabled="${!editable}"
+                               th:attr="data-original-name=${template.name}"
+                               style="max-width: 300px;"
+                               onblur="updateTemplateName(this)"
+                               onkeydown="if(event.key==='Enter')this.blur();if(event.key==='Escape'){this.value=this.dataset.originalName;this.blur();}">
+                    </dd>
                     <dt>ID</dt>
                     <dd><code th:text="${template.id}"></code></dd>
                     <dt>Created</dt>
@@ -90,6 +99,29 @@
                     headers: { 'Content-Type': 'application/json', 'X-XSRF-TOKEN': csrfToken },
                     body: JSON.stringify({ pdfaEnabled: enabled })
                 }).then(r => { if (!r.ok) document.getElementById('pdfa-toggle').checked = !enabled; });
+            }
+
+            function updateTemplateName(input) {
+                const newName = input.value.trim();
+                if (!newName || newName === input.dataset.originalName) {
+                    input.value = input.dataset.originalName;
+                    return;
+                }
+                const url = `/tenants/${TENANT_ID}/templates/${CATALOG_ID}/${TEMPLATE_ID}`;
+                const csrfToken = typeof window.getCsrfToken === 'function' ? window.getCsrfToken() : '';
+                fetch(url, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json', 'X-XSRF-TOKEN': csrfToken },
+                    body: JSON.stringify({ name: newName })
+                }).then(r => {
+                    if (r.ok) {
+                        input.dataset.originalName = newName;
+                        const h1 = document.querySelector('.page-header h1');
+                        if (h1) h1.textContent = newName;
+                    } else {
+                        input.value = input.dataset.originalName;
+                    }
+                });
             }
 
             function updateTheme(select) {


### PR DESCRIPTION
## Description

Templates created via the UI could not be renamed after creation — the name field only appeared in the create form and was read-only everywhere else. The backend `UpdateDocumentTemplate` command already supported a `name` parameter, so this was a UI-only gap.

Added an inline-editable name field to the template settings tab. The input auto-saves on blur or Enter via `PATCH` to the existing update endpoint, reverts on Escape or failure, and updates the page `<h1>` title on success. Disabled for read-only (subscribed catalog) templates.

## Related Issue(s)

Closes #333

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Thymeleaf/HTMX)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

No backend changes — the `UpdateDocumentTemplate` command and the `PATCH /tenants/{tenantId}/templates/{catalogId}/{id}` handler already accepted a `name` field. The input uses the same `fetch()` / CSRF pattern as the existing PDF/A toggle and theme selector on the same page.

Error and success feedback are deliberately omitted — this page has no notification pattern, and adding one here would be inconsistent with the silent patterns used by the PDF/A toggle and theme selector on the same tab. UX feedback improvements are tracked separately.
