### PR TITLE
Add support module auto-configuration switches

### DIFF
--- a/apps/epistola/src/test/kotlin/app/epistola/suite/SupportModulesDisabledApplicationTests.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/SupportModulesDisabledApplicationTests.kt
@@ -1,0 +1,43 @@
+package app.epistola.suite
+
+import app.epistola.suite.backups.BackupScheduler
+import app.epistola.suite.feedback.commands.CreateFeedbackHandler
+import app.epistola.suite.snapshots.TenantSnapshotSyncService
+import app.epistola.suite.support.SupportEntitlementService
+import app.epistola.suite.support.ui.SupportOverviewHandler
+import app.epistola.suite.testing.TestcontainersConfiguration
+import app.epistola.suite.upgrading.UpgradingSnapshotScheduler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+
+@Import(TestcontainersConfiguration::class)
+@SpringBootTest(
+    classes = [EpistolaSuiteApplication::class],
+    properties = [
+        "epistola.modules.support.enabled=false",
+        "epistola.modules.support-feedback.enabled=false",
+        "epistola.modules.support-backups.enabled=false",
+        "epistola.modules.support-snapshots.enabled=false",
+        "epistola.modules.support-upgrading.enabled=false",
+    ],
+)
+@ActiveProfiles("test")
+@Tag("integration")
+class SupportModulesDisabledApplicationTests(
+    private val context: ApplicationContext,
+) {
+    @Test
+    fun supportModulesCanBeDisabledAsWholeModules() {
+        assertThat(context.getBeanNamesForType(SupportEntitlementService::class.java)).isEmpty()
+        assertThat(context.getBeanNamesForType(SupportOverviewHandler::class.java)).isEmpty()
+        assertThat(context.getBeanNamesForType(CreateFeedbackHandler::class.java)).isEmpty()
+        assertThat(context.getBeanNamesForType(BackupScheduler::class.java)).isEmpty()
+        assertThat(context.getBeanNamesForType(TenantSnapshotSyncService::class.java)).isEmpty()
+        assertThat(context.getBeanNamesForType(UpgradingSnapshotScheduler::class.java)).isEmpty()
+    }
+}

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/backups/BackupScheduler.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/backups/BackupScheduler.kt
@@ -10,6 +10,7 @@ import app.epistola.suite.scheduling.SchedulerLock
 import app.epistola.suite.security.SecurityContext
 import app.epistola.suite.snapshots.TenantSnapshotSyncService
 import app.epistola.suite.snapshots.snapshotSystemPrincipal
+import app.epistola.suite.support.backups.ConditionalOnSupportBackupsModule
 import org.jdbi.v3.core.Jdbi
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 @EnableScheduling
+@ConditionalOnSupportBackupsModule
 @ConditionalOnProperty(
     name = ["epistola.support.backups.scheduled.enabled"],
     havingValue = "true",

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ConditionalOnSupportBackupsModule.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ConditionalOnSupportBackupsModule.kt
@@ -1,0 +1,13 @@
+package app.epistola.suite.support.backups
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "epistola.modules.support-backups",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+annotation class ConditionalOnSupportBackupsModule

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/SupportBackupsModuleAutoConfiguration.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/SupportBackupsModuleAutoConfiguration.kt
@@ -1,0 +1,18 @@
+package app.epistola.suite.support.backups
+
+import app.epistola.suite.backups.BackupScheduler
+import app.epistola.suite.support.backups.ui.BackupsHandler
+import app.epistola.suite.support.backups.ui.BackupsNavContributor
+import app.epistola.suite.support.backups.ui.BackupsRoutes
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.context.annotation.Import
+
+@AutoConfiguration
+@ConditionalOnSupportBackupsModule
+@Import(
+    BackupScheduler::class,
+    BackupsHandler::class,
+    BackupsRoutes::class,
+    BackupsNavContributor::class,
+)
+class SupportBackupsModuleAutoConfiguration

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
@@ -10,6 +10,7 @@ import app.epistola.suite.security.requirePermission
 import app.epistola.suite.snapshots.RemoteSnapshot
 import app.epistola.suite.snapshots.SnapshotSyncOutcome
 import app.epistola.suite.snapshots.TenantSnapshotSyncService
+import app.epistola.suite.support.backups.ConditionalOnSupportBackupsModule
 import app.epistola.suite.support.hubFeatureCall
 import app.epistola.suite.support.logTo
 import app.epistola.suite.tenants.queries.GetTenant
@@ -27,6 +28,7 @@ import java.time.format.DateTimeFormatter
  * (no service contract) render an informational state rather than an error.
  */
 @Component
+@ConditionalOnSupportBackupsModule
 class BackupsHandler(
     private val snapshotSync: TenantSnapshotSyncService,
 ) {

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsNavContributor.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsNavContributor.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.htmx.UiRequestContext
 import app.epistola.suite.htmx.nav.NavContributor
 import app.epistola.suite.htmx.nav.NavItem
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.backups.ConditionalOnSupportBackupsModule
 import org.springframework.stereotype.Component
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component
  * the local toggle is on **and** the installation is entitled to it (hub-gated).
  */
 @Component
+@ConditionalOnSupportBackupsModule
 class BackupsNavContributor : NavContributor {
     override fun items(context: UiRequestContext): List<NavItem> {
         val available = ResolveAvailableFeatures(context.tenantKey).query()

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsRoutes.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsRoutes.kt
@@ -1,5 +1,6 @@
 package app.epistola.suite.support.backups.ui
 
+import app.epistola.suite.support.backups.ConditionalOnSupportBackupsModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.function.RouterFunction
@@ -7,6 +8,7 @@ import org.springframework.web.servlet.function.ServerResponse
 import org.springframework.web.servlet.function.router
 
 @Configuration
+@ConditionalOnSupportBackupsModule
 class BackupsRoutes(
     private val handler: BackupsHandler,
 ) {

--- a/modules/epistola-support-backups/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/epistola-support-backups/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+app.epistola.suite.support.backups.SupportBackupsModuleAutoConfiguration

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/AddFeedbackAsset.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/AddFeedbackAsset.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -81,6 +82,7 @@ data class AddFeedbackAsset(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class AddFeedbackAssetHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<AddFeedbackAsset, FeedbackAsset> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/AddFeedbackComment.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/AddFeedbackComment.kt
@@ -7,6 +7,7 @@ import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -27,6 +28,7 @@ data class AddFeedbackComment(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class AddFeedbackCommentHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<AddFeedbackComment, FeedbackComment> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/CreateFeedback.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/CreateFeedback.kt
@@ -12,6 +12,7 @@ import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -38,6 +39,7 @@ data class CreateFeedback(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class CreateFeedbackHandler(
     private val jdbi: Jdbi,
     private val feedbackSyncPort: FeedbackSyncPort,

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/SyncFeedbackComment.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/SyncFeedbackComment.kt
@@ -8,6 +8,7 @@ import app.epistola.suite.feedback.FeedbackComment
 import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.SystemInternal
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -23,6 +24,7 @@ data class SyncFeedbackComment(
     SystemInternal
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class SyncFeedbackCommentHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<SyncFeedbackComment, FeedbackComment?> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/SyncFeedbackStatus.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/SyncFeedbackStatus.kt
@@ -5,6 +5,7 @@ import app.epistola.suite.feedback.FeedbackStatus
 import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.SystemInternal
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -24,6 +25,7 @@ data class SyncFeedbackStatus(
     SystemInternal
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class SyncFeedbackStatusHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<SyncFeedbackStatus, Boolean> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackCommentExternalRef.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackCommentExternalRef.kt
@@ -4,6 +4,7 @@ import app.epistola.suite.common.ids.FeedbackCommentId
 import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.SystemInternal
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -15,6 +16,7 @@ data class UpdateFeedbackCommentExternalRef(
     SystemInternal
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class UpdateFeedbackCommentExternalRefHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<UpdateFeedbackCommentExternalRef, Boolean> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackStatus.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackStatus.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -20,6 +21,7 @@ data class UpdateFeedbackStatus(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class UpdateFeedbackStatusHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<UpdateFeedbackStatus, Boolean> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackSyncRef.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackSyncRef.kt
@@ -5,6 +5,7 @@ import app.epistola.suite.feedback.SyncStatus
 import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.SystemInternal
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -17,6 +18,7 @@ data class UpdateFeedbackSyncRef(
     SystemInternal
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class UpdateFeedbackSyncRefHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<UpdateFeedbackSyncRef, Boolean> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackSyncStatus.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/commands/UpdateFeedbackSyncStatus.kt
@@ -5,6 +5,7 @@ import app.epistola.suite.feedback.SyncStatus
 import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.SystemInternal
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -17,6 +18,7 @@ data class UpdateFeedbackSyncStatus(
     SystemInternal
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class UpdateFeedbackSyncStatusHandler(
     private val jdbi: Jdbi,
 ) : CommandHandler<UpdateFeedbackSyncStatus, Boolean> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedback.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedback.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -19,6 +20,7 @@ data class GetFeedback(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class GetFeedbackHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<GetFeedback, Feedback?> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedbackAssetContent.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedbackAssetContent.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -19,6 +20,7 @@ data class GetFeedbackAssetContent(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class GetFeedbackAssetContentHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<GetFeedbackAssetContent, FeedbackAssetContent?> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedbackByExternalRef.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedbackByExternalRef.kt
@@ -8,6 +8,7 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -21,6 +22,7 @@ data class GetFeedbackByExternalRef(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class GetFeedbackByExternalRefHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<GetFeedbackByExternalRef, FeedbackId?> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedbackComments.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/GetFeedbackComments.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -19,6 +20,7 @@ data class GetFeedbackComments(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class GetFeedbackCommentsHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<GetFeedbackComments, List<FeedbackComment>> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListFeedback.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListFeedback.kt
@@ -8,6 +8,7 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -23,6 +24,7 @@ data class ListFeedback(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class ListFeedbackHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<ListFeedback, List<FeedbackSummary>> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListFeedbackAssets.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListFeedbackAssets.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -19,6 +20,7 @@ data class ListFeedbackAssets(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class ListFeedbackAssetsHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<ListFeedbackAssets, List<FeedbackAsset>> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListPendingSyncFeedback.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListPendingSyncFeedback.kt
@@ -5,6 +5,7 @@ import app.epistola.suite.feedback.SyncStatus
 import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.SystemInternal
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -20,6 +21,7 @@ data class ListPendingSyncFeedback(
 }
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class ListPendingSyncFeedbackHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<ListPendingSyncFeedback, List<Feedback>> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListUnsyncedComments.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/queries/ListUnsyncedComments.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.feedback.SyncStatus
 import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.SystemInternal
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
@@ -22,6 +23,7 @@ data class ListUnsyncedComments(
     SystemInternal
 
 @Component
+@ConditionalOnSupportFeedbackModule
 class ListUnsyncedCommentsHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<ListUnsyncedComments, List<FeedbackComment>> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/FeedbackPollScheduler.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/FeedbackPollScheduler.kt
@@ -12,6 +12,7 @@ import app.epistola.suite.metadata.AppMetadataService
 import app.epistola.suite.metadata.getAs
 import app.epistola.suite.scheduling.SchedulerLock
 import app.epistola.suite.security.SecurityContext
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 @EnableScheduling
+@ConditionalOnSupportFeedbackModule
 @ConditionalOnProperty(
     name = ["epistola.feedback.sync.polling.enabled"],
     havingValue = "true",

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/FeedbackSyncFallbackConfiguration.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/FeedbackSyncFallbackConfiguration.kt
@@ -1,5 +1,6 @@
 package app.epistola.suite.feedback.sync
 
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.Configuration
  */
 @Configuration
 @EnableConfigurationProperties(FeedbackSyncProperties::class)
+@ConditionalOnSupportFeedbackModule
 class FeedbackSyncFallbackConfiguration {
 
     @Bean

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/FeedbackSyncScheduler.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/FeedbackSyncScheduler.kt
@@ -21,6 +21,7 @@ import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
 import app.epistola.suite.scheduling.SchedulerLock
 import app.epistola.suite.security.SecurityContext
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
@@ -40,6 +41,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 @EnableScheduling
+@ConditionalOnSupportFeedbackModule
 @ConditionalOnProperty(
     name = ["epistola.feedback.sync.enabled"],
     havingValue = "true",

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/OnFeedbackCommentAdded.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/OnFeedbackCommentAdded.kt
@@ -11,6 +11,7 @@ import app.epistola.suite.mediator.EventHandler
 import app.epistola.suite.mediator.EventPhase
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component
  * so the inbound poll scheduler can dedup and skip it.
  */
 @Component
+@ConditionalOnSupportFeedbackModule
 class OnFeedbackCommentAdded(
     private val feedbackSyncPort: FeedbackSyncPort,
 ) : EventHandler<AddFeedbackComment> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/OnFeedbackCreated.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/OnFeedbackCreated.kt
@@ -13,6 +13,7 @@ import app.epistola.suite.mediator.EventHandler
 import app.epistola.suite.mediator.EventPhase
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component
  * If sync fails, the feedback remains with sync_status=PENDING for the retry scheduler.
  */
 @Component
+@ConditionalOnSupportFeedbackModule
 class OnFeedbackCreated(
     private val feedbackSyncPort: FeedbackSyncPort,
 ) : EventHandler<CreateFeedback> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/OnFeedbackStatusChanged.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/feedback/sync/OnFeedbackStatusChanged.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.feedback.queries.GetFeedback
 import app.epistola.suite.mediator.EventHandler
 import app.epistola.suite.mediator.EventPhase
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component
  * for a later status change to reconcile (the hub keeps the operator-authoritative value).
  */
 @Component
+@ConditionalOnSupportFeedbackModule
 class OnFeedbackStatusChanged(
     private val feedbackSyncPort: FeedbackSyncPort,
 ) : EventHandler<UpdateFeedbackStatus> {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ConditionalOnSupportFeedbackModule.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ConditionalOnSupportFeedbackModule.kt
@@ -1,0 +1,13 @@
+package app.epistola.suite.support.feedback
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "epistola.modules.support-feedback",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+annotation class ConditionalOnSupportFeedbackModule

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/SupportFeedbackConfiguration.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/SupportFeedbackConfiguration.kt
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Configuration
  * the support tier is enabled.
  */
 @Configuration
+@ConditionalOnSupportFeedbackModule
 @ConditionalOnProperty(
     prefix = "epistola.support",
     name = ["enabled"],

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/SupportFeedbackModuleAutoConfiguration.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/SupportFeedbackModuleAutoConfiguration.kt
@@ -1,0 +1,68 @@
+package app.epistola.suite.support.feedback
+
+import app.epistola.suite.feedback.commands.AddFeedbackAssetHandler
+import app.epistola.suite.feedback.commands.AddFeedbackCommentHandler
+import app.epistola.suite.feedback.commands.CreateFeedbackHandler
+import app.epistola.suite.feedback.commands.SyncFeedbackCommentHandler
+import app.epistola.suite.feedback.commands.SyncFeedbackStatusHandler
+import app.epistola.suite.feedback.commands.UpdateFeedbackCommentExternalRefHandler
+import app.epistola.suite.feedback.commands.UpdateFeedbackStatusHandler
+import app.epistola.suite.feedback.commands.UpdateFeedbackSyncRefHandler
+import app.epistola.suite.feedback.commands.UpdateFeedbackSyncStatusHandler
+import app.epistola.suite.feedback.queries.GetFeedbackAssetContentHandler
+import app.epistola.suite.feedback.queries.GetFeedbackByExternalRefHandler
+import app.epistola.suite.feedback.queries.GetFeedbackCommentsHandler
+import app.epistola.suite.feedback.queries.GetFeedbackHandler
+import app.epistola.suite.feedback.queries.ListFeedbackAssetsHandler
+import app.epistola.suite.feedback.queries.ListFeedbackHandler
+import app.epistola.suite.feedback.queries.ListPendingSyncFeedbackHandler
+import app.epistola.suite.feedback.queries.ListUnsyncedCommentsHandler
+import app.epistola.suite.feedback.sync.FeedbackPollScheduler
+import app.epistola.suite.feedback.sync.FeedbackSyncFallbackConfiguration
+import app.epistola.suite.feedback.sync.FeedbackSyncProperties
+import app.epistola.suite.feedback.sync.FeedbackSyncScheduler
+import app.epistola.suite.feedback.sync.OnFeedbackCommentAdded
+import app.epistola.suite.feedback.sync.OnFeedbackCreated
+import app.epistola.suite.feedback.sync.OnFeedbackStatusChanged
+import app.epistola.suite.support.feedback.ui.FeedbackFooterContributor
+import app.epistola.suite.support.feedback.ui.FeedbackHandler
+import app.epistola.suite.support.feedback.ui.FeedbackNavContributor
+import app.epistola.suite.support.feedback.ui.FeedbackRoutes
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Import
+
+@AutoConfiguration
+@ConditionalOnSupportFeedbackModule
+@EnableConfigurationProperties(FeedbackSyncProperties::class)
+@Import(
+    SupportFeedbackConfiguration::class,
+    FeedbackSyncFallbackConfiguration::class,
+    CreateFeedbackHandler::class,
+    AddFeedbackAssetHandler::class,
+    AddFeedbackCommentHandler::class,
+    UpdateFeedbackStatusHandler::class,
+    UpdateFeedbackSyncRefHandler::class,
+    UpdateFeedbackSyncStatusHandler::class,
+    UpdateFeedbackCommentExternalRefHandler::class,
+    SyncFeedbackCommentHandler::class,
+    SyncFeedbackStatusHandler::class,
+    GetFeedbackHandler::class,
+    GetFeedbackAssetContentHandler::class,
+    GetFeedbackByExternalRefHandler::class,
+    GetFeedbackCommentsHandler::class,
+    ListFeedbackHandler::class,
+    ListFeedbackAssetsHandler::class,
+    ListPendingSyncFeedbackHandler::class,
+    ListUnsyncedCommentsHandler::class,
+    FeedbackSyncScheduler::class,
+    FeedbackPollScheduler::class,
+    OnFeedbackCreated::class,
+    OnFeedbackCommentAdded::class,
+    OnFeedbackStatusChanged::class,
+    FeedbackHandler::class,
+    FeedbackRoutes::class,
+    FeedbackNavContributor::class,
+    FeedbackFooterContributor::class,
+)
+class SupportFeedbackModuleAutoConfiguration

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackFooterContributor.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackFooterContributor.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.htmx.UiRequestContext
 import app.epistola.suite.htmx.footer.FooterContributor
 import app.epistola.suite.htmx.footer.FooterFragment
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.springframework.stereotype.Component
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component
  * the local toggle is on **and** the installation is entitled to it (hub-gated).
  */
 @Component
+@ConditionalOnSupportFeedbackModule
 class FeedbackFooterContributor : FooterContributor {
     override fun fragments(context: UiRequestContext): List<FooterFragment> {
         val available = ResolveAvailableFeatures(context.tenantKey).query()

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackHandler.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackHandler.kt
@@ -28,6 +28,7 @@ import app.epistola.suite.htmx.tenantId
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
 import app.epistola.suite.security.SecurityContext
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import app.epistola.suite.tenants.queries.GetTenant
 import org.slf4j.LoggerFactory
 import org.springframework.boot.info.BuildProperties
@@ -46,6 +47,7 @@ import java.util.concurrent.TimeUnit
  * `layout/shell` chrome. Gated for visibility only by the `support-feedback` feature toggle.
  */
 @Component
+@ConditionalOnSupportFeedbackModule
 class FeedbackHandler(
     private val buildProperties: BuildProperties?,
 ) {

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackNavContributor.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackNavContributor.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.htmx.UiRequestContext
 import app.epistola.suite.htmx.nav.NavContributor
 import app.epistola.suite.htmx.nav.NavItem
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.springframework.stereotype.Component
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component
  * the local toggle is on **and** the installation is entitled to it (hub-gated).
  */
 @Component
+@ConditionalOnSupportFeedbackModule
 class FeedbackNavContributor : NavContributor {
     override fun items(context: UiRequestContext): List<NavItem> {
         val available = ResolveAvailableFeatures(context.tenantKey).query()

--- a/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackRoutes.kt
+++ b/modules/epistola-support-feedback/src/main/kotlin/app/epistola/suite/support/feedback/ui/FeedbackRoutes.kt
@@ -1,5 +1,6 @@
 package app.epistola.suite.support.feedback.ui
 
+import app.epistola.suite.support.feedback.ConditionalOnSupportFeedbackModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.function.RouterFunction
@@ -7,6 +8,7 @@ import org.springframework.web.servlet.function.ServerResponse
 import org.springframework.web.servlet.function.router
 
 @Configuration
+@ConditionalOnSupportFeedbackModule
 class FeedbackRoutes(private val handler: FeedbackHandler) {
     @Bean
     fun feedbackRouterFunction(): RouterFunction<ServerResponse> = router {

--- a/modules/epistola-support-feedback/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/epistola-support-feedback/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+app.epistola.suite.support.feedback.SupportFeedbackModuleAutoConfiguration

--- a/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/snapshots/SnapshotSyncPort.kt
+++ b/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/snapshots/SnapshotSyncPort.kt
@@ -2,6 +2,7 @@ package app.epistola.suite.snapshots
 
 import app.epistola.suite.catalog.snapshot.TenantSnapshot
 import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.support.snapshots.ConditionalOnSupportSnapshotsModule
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -83,6 +84,7 @@ class NoOpSnapshotSyncAdapter : SnapshotSyncPort {
  * still wins.
  */
 @Configuration
+@ConditionalOnSupportSnapshotsModule
 class SnapshotSyncFallbackConfiguration {
     @Bean
     @ConditionalOnMissingBean(SnapshotSyncPort::class)

--- a/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/snapshots/TenantSnapshotSyncService.kt
+++ b/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/snapshots/TenantSnapshotSyncService.kt
@@ -7,6 +7,7 @@ import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.metadata.AppMetadataService
 import app.epistola.suite.metadata.getAs
+import app.epistola.suite.support.snapshots.ConditionalOnSupportSnapshotsModule
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.time.Instant
@@ -24,6 +25,7 @@ import java.time.Instant
  * permission-gated commands) — see [snapshotSystemPrincipal].
  */
 @Component
+@ConditionalOnSupportSnapshotsModule
 class TenantSnapshotSyncService(
     private val port: SnapshotSyncPort,
     private val appMetadata: AppMetadataService,

--- a/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/support/snapshots/ConditionalOnSupportSnapshotsModule.kt
+++ b/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/support/snapshots/ConditionalOnSupportSnapshotsModule.kt
@@ -1,0 +1,13 @@
+package app.epistola.suite.support.snapshots
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "epistola.modules.support-snapshots",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+annotation class ConditionalOnSupportSnapshotsModule

--- a/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/support/snapshots/SupportSnapshotsConfiguration.kt
+++ b/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/support/snapshots/SupportSnapshotsConfiguration.kt
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Configuration
  * so snapshots sync to the hub only when the support tier is enabled.
  */
 @Configuration
+@ConditionalOnSupportSnapshotsModule
 @ConditionalOnProperty(
     prefix = "epistola.support",
     name = ["enabled"],

--- a/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/support/snapshots/SupportSnapshotsModuleAutoConfiguration.kt
+++ b/modules/epistola-support-snapshots/src/main/kotlin/app/epistola/suite/support/snapshots/SupportSnapshotsModuleAutoConfiguration.kt
@@ -1,0 +1,15 @@
+package app.epistola.suite.support.snapshots
+
+import app.epistola.suite.snapshots.SnapshotSyncFallbackConfiguration
+import app.epistola.suite.snapshots.TenantSnapshotSyncService
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.context.annotation.Import
+
+@AutoConfiguration
+@ConditionalOnSupportSnapshotsModule
+@Import(
+    SupportSnapshotsConfiguration::class,
+    SnapshotSyncFallbackConfiguration::class,
+    TenantSnapshotSyncService::class,
+)
+class SupportSnapshotsModuleAutoConfiguration

--- a/modules/epistola-support-snapshots/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/epistola-support-snapshots/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+app.epistola.suite.support.snapshots.SupportSnapshotsModuleAutoConfiguration

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ConditionalOnSupportUpgradingModule.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ConditionalOnSupportUpgradingModule.kt
@@ -1,0 +1,13 @@
+package app.epistola.suite.support.upgrading
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "epistola.modules.support-upgrading",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+annotation class ConditionalOnSupportUpgradingModule

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/HubCompatibilitySyncAdapter.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/HubCompatibilitySyncAdapter.kt
@@ -60,6 +60,7 @@ class HubCompatibilitySyncAdapter(
  * registering it overrides the no-op fallback.
  */
 @Configuration
+@ConditionalOnSupportUpgradingModule
 @ConditionalOnProperty(prefix = "epistola.support", name = ["enabled"], havingValue = "true")
 class SupportUpgradingConfiguration {
     @Bean

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/SupportUpgradingModuleAutoConfiguration.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/SupportUpgradingModuleAutoConfiguration.kt
@@ -1,0 +1,24 @@
+package app.epistola.suite.support.upgrading
+
+import app.epistola.suite.support.upgrading.ui.UpgradingHandler
+import app.epistola.suite.support.upgrading.ui.UpgradingNavContributor
+import app.epistola.suite.support.upgrading.ui.UpgradingRoutes
+import app.epistola.suite.upgrading.CompatibilitySyncFallbackConfiguration
+import app.epistola.suite.upgrading.UpgradingSnapshotProperties
+import app.epistola.suite.upgrading.UpgradingSnapshotScheduler
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Import
+
+@AutoConfiguration
+@ConditionalOnSupportUpgradingModule
+@EnableConfigurationProperties(UpgradingSnapshotProperties::class)
+@Import(
+    SupportUpgradingConfiguration::class,
+    CompatibilitySyncFallbackConfiguration::class,
+    UpgradingSnapshotScheduler::class,
+    UpgradingHandler::class,
+    UpgradingRoutes::class,
+    UpgradingNavContributor::class,
+)
+class SupportUpgradingModuleAutoConfiguration

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ui/UpgradingHandler.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ui/UpgradingHandler.kt
@@ -7,6 +7,7 @@ import app.epistola.suite.security.Permission
 import app.epistola.suite.security.requirePermission
 import app.epistola.suite.support.hubFeatureCall
 import app.epistola.suite.support.logTo
+import app.epistola.suite.support.upgrading.ConditionalOnSupportUpgradingModule
 import app.epistola.suite.tenants.queries.GetTenant
 import app.epistola.suite.upgrading.CompatibilityCheckResult
 import app.epistola.suite.upgrading.CompatibilitySyncPort
@@ -23,6 +24,7 @@ import java.time.format.DateTimeFormatter
  * Epistola version that was tested.
  */
 @Component
+@ConditionalOnSupportUpgradingModule
 class UpgradingHandler(
     private val compatibility: CompatibilitySyncPort,
 ) {

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ui/UpgradingNavContributor.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ui/UpgradingNavContributor.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.htmx.UiRequestContext
 import app.epistola.suite.htmx.nav.NavContributor
 import app.epistola.suite.htmx.nav.NavItem
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.upgrading.ConditionalOnSupportUpgradingModule
 import org.springframework.stereotype.Component
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component
  * — the local toggle is on **and** the installation is entitled to it (hub-gated).
  */
 @Component
+@ConditionalOnSupportUpgradingModule
 class UpgradingNavContributor : NavContributor {
     override fun items(context: UiRequestContext): List<NavItem> {
         val available = ResolveAvailableFeatures(context.tenantKey).query()

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ui/UpgradingRoutes.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/support/upgrading/ui/UpgradingRoutes.kt
@@ -1,5 +1,6 @@
 package app.epistola.suite.support.upgrading.ui
 
+import app.epistola.suite.support.upgrading.ConditionalOnSupportUpgradingModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.function.RouterFunction
@@ -7,6 +8,7 @@ import org.springframework.web.servlet.function.ServerResponse
 import org.springframework.web.servlet.function.router
 
 @Configuration
+@ConditionalOnSupportUpgradingModule
 class UpgradingRoutes(
     private val handler: UpgradingHandler,
 ) {

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/upgrading/CompatibilitySyncPort.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/upgrading/CompatibilitySyncPort.kt
@@ -1,6 +1,7 @@
 package app.epistola.suite.upgrading
 
 import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.support.upgrading.ConditionalOnSupportUpgradingModule
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -51,6 +52,7 @@ class NoOpCompatibilitySyncAdapter : CompatibilitySyncPort {
  * is kept so an explicit/test override still wins.
  */
 @Configuration
+@ConditionalOnSupportUpgradingModule
 class CompatibilitySyncFallbackConfiguration {
     @Bean
     @ConditionalOnMissingBean(CompatibilitySyncPort::class)

--- a/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/upgrading/UpgradingSnapshotScheduler.kt
+++ b/modules/epistola-support-upgrading/src/main/kotlin/app/epistola/suite/upgrading/UpgradingSnapshotScheduler.kt
@@ -10,6 +10,7 @@ import app.epistola.suite.scheduling.SchedulerLock
 import app.epistola.suite.security.SecurityContext
 import app.epistola.suite.snapshots.TenantSnapshotSyncService
 import app.epistola.suite.snapshots.snapshotSystemPrincipal
+import app.epistola.suite.support.upgrading.ConditionalOnSupportUpgradingModule
 import org.jdbi.v3.core.Jdbi
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -34,6 +35,7 @@ import java.time.Instant
 @Component
 @EnableScheduling
 @EnableConfigurationProperties(UpgradingSnapshotProperties::class)
+@ConditionalOnSupportUpgradingModule
 @ConditionalOnProperty(
     name = ["epistola.support.upgrading.snapshot.scheduled.enabled"],
     havingValue = "true",

--- a/modules/epistola-support-upgrading/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/epistola-support-upgrading/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+app.epistola.suite.support.upgrading.SupportUpgradingModuleAutoConfiguration

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ConditionalOnSupportModule.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ConditionalOnSupportModule.kt
@@ -1,0 +1,13 @@
+package app.epistola.suite.support
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ConditionalOnProperty(
+    prefix = "epistola.modules.support",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+annotation class ConditionalOnSupportModule

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/EntitlementRefreshScheduler.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/EntitlementRefreshScheduler.kt
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 @EnableScheduling
+@ConditionalOnSupportModule
 @ConditionalOnProperty(prefix = "epistola.support", name = ["enabled"], havingValue = "true")
 class EntitlementRefreshScheduler(
     private val entitlementSync: EntitlementSyncService,

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/EntitlementRevisionTrigger.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/EntitlementRevisionTrigger.kt
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Only constructed when the support tier is enabled.
  */
 @Component
+@ConditionalOnSupportModule
 @ConditionalOnProperty(prefix = "epistola.support", name = ["enabled"], havingValue = "true")
 class EntitlementRevisionTrigger(
     private val store: EntitlementStore,

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/EntitlementSyncService.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/EntitlementSyncService.kt
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service
  * `BuildTenantSnapshot` command.
  */
 @Service
+@ConditionalOnSupportModule
 @ConditionalOnProperty(prefix = "epistola.support", name = ["enabled"], havingValue = "true")
 class EntitlementSyncService(
     private val mediator: Mediator,

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/HubConnectivityService.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/HubConnectivityService.kt
@@ -15,6 +15,7 @@ import java.time.Instant
  * is a list so the UI is ready for multiple nodes once cross-node aggregation lands.
  */
 @Component
+@ConditionalOnSupportModule
 class HubConnectivityService(
     private val clientProvider: ObjectProvider<EpistolaHubClient>,
     private val nodeIdentity: NodeIdentity,

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/HubHealthCheckScheduler.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/HubHealthCheckScheduler.kt
@@ -18,6 +18,7 @@ import java.time.Instant
 @Component
 @EnableScheduling
 @EnableConfigurationProperties(HubHealthCheckProperties::class)
+@ConditionalOnSupportModule
 @ConditionalOnProperty(
     prefix = "epistola.support",
     name = ["enabled"],

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/RefreshEntitlements.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/RefreshEntitlements.kt
@@ -28,6 +28,7 @@ class RefreshEntitlements :
     SystemInternal
 
 @Component
+@ConditionalOnSupportModule
 @ConditionalOnProperty(prefix = "epistola.support", name = ["enabled"], havingValue = "true")
 class RefreshEntitlementsHandler(
     private val client: EpistolaHubClient,

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/SupportConfiguration.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/SupportConfiguration.kt
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.DependsOn
  */
 @Configuration
 @EnableConfigurationProperties(SupportProperties::class)
+@ConditionalOnSupportModule
 @ConditionalOnProperty(
     prefix = "epistola.support",
     name = ["enabled"],

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/SupportEntitlementService.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/SupportEntitlementService.kt
@@ -30,6 +30,7 @@ enum class EntitlementDecision {
  * core treats every feature as ungated.
  */
 @Service
+@ConditionalOnSupportModule
 @ConditionalOnProperty(prefix = "epistola.support", name = ["enabled"], havingValue = "true")
 class SupportEntitlementService(
     private val store: EntitlementStore,

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/SupportModuleAutoConfiguration.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/SupportModuleAutoConfiguration.kt
@@ -1,0 +1,26 @@
+package app.epistola.suite.support
+
+import app.epistola.suite.support.ui.SupportNavContributor
+import app.epistola.suite.support.ui.SupportOverviewHandler
+import app.epistola.suite.support.ui.SupportOverviewRoutes
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Import
+
+@AutoConfiguration
+@ConditionalOnSupportModule
+@EnableConfigurationProperties(SupportProperties::class, HubHealthCheckProperties::class)
+@Import(
+    SupportConfiguration::class,
+    HubConnectivityService::class,
+    HubHealthCheckScheduler::class,
+    EntitlementSyncService::class,
+    EntitlementRefreshScheduler::class,
+    EntitlementRevisionTrigger::class,
+    SupportEntitlementService::class,
+    RefreshEntitlementsHandler::class,
+    SupportNavContributor::class,
+    SupportOverviewHandler::class,
+    SupportOverviewRoutes::class,
+)
+class SupportModuleAutoConfiguration

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ui/SupportNavContributor.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ui/SupportNavContributor.kt
@@ -7,6 +7,7 @@ import app.epistola.suite.htmx.nav.NavContributor
 import app.epistola.suite.htmx.nav.NavGroup
 import app.epistola.suite.htmx.nav.NavItem
 import app.epistola.suite.mediator.query
+import app.epistola.suite.support.ConditionalOnSupportModule
 import org.springframework.stereotype.Component
 
 /**
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component
  * enabled for the tenant, matching the previous "Support hidden unless ≥1 toggle on" behavior.
  */
 @Component
+@ConditionalOnSupportModule
 class SupportNavContributor : NavContributor {
 
     override fun groups(context: UiRequestContext): List<NavGroup> = listOf(

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ui/SupportOverviewHandler.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ui/SupportOverviewHandler.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.htmx.tenantId
 import app.epistola.suite.mediator.query
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.requirePermission
+import app.epistola.suite.support.ConditionalOnSupportModule
 import app.epistola.suite.support.EntitlementEffect
 import app.epistola.suite.support.EntitlementSyncService
 import app.epistola.suite.support.HubConnectivityService
@@ -27,6 +28,7 @@ import java.time.format.DateTimeFormatter
  * will also host subscription/contract details in the future.
  */
 @Component
+@ConditionalOnSupportModule
 class SupportOverviewHandler(
     private val connectivity: HubConnectivityService,
     private val entitlements: ObjectProvider<SupportEntitlementService>,

--- a/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ui/SupportOverviewRoutes.kt
+++ b/modules/epistola-support/src/main/kotlin/app/epistola/suite/support/ui/SupportOverviewRoutes.kt
@@ -1,5 +1,6 @@
 package app.epistola.suite.support.ui
 
+import app.epistola.suite.support.ConditionalOnSupportModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.function.RouterFunction
@@ -7,6 +8,7 @@ import org.springframework.web.servlet.function.ServerResponse
 import org.springframework.web.servlet.function.router
 
 @Configuration
+@ConditionalOnSupportModule
 class SupportOverviewRoutes(
     private val handler: SupportOverviewHandler,
 ) {

--- a/modules/epistola-support/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/epistola-support/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+app.epistola.suite.support.SupportModuleAutoConfiguration


### PR DESCRIPTION
## Summary
- add Spring Boot auto-configuration registrations for support modules
- gate support, feedback, backups, snapshots, and upgrading as whole modules via `epistola.modules.*.enabled`
- add a context regression test proving disabled support modules do not register representative beans

## Verification
- `./gradlew :modules:epistola-support:compileKotlin :modules:epistola-support-feedback:compileKotlin :modules:epistola-support-backups:compileKotlin :modules:epistola-support-upgrading:compileKotlin :modules:epistola-support-snapshots:compileKotlin`
- `./gradlew :apps:epistola:test --tests app.epistola.suite.EpistolaSuiteApplicationTests`
- `./gradlew :apps:epistola:test --tests app.epistola.suite.SupportModulesDisabledApplicationTests`
- `./gradlew :apps:epistola:ktlintCheck :modules:epistola-support:ktlintCheck :modules:epistola-support-feedback:ktlintCheck :modules:epistola-support-backups:ktlintCheck :modules:epistola-support-upgrading:ktlintCheck :modules:epistola-support-snapshots:ktlintCheck`