### PR TITLE
fix(generation): keep result sequence monotonic across a DB reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- **[dev]** fix(generation): **Result sequence survives a destructive DB reset.** The collect feed is a Kafka-style log: each generation result gets a globally monotonic `sequence` and every external consumer (e.g. the Valtimo plugin) persists a high-water cursor **in its own database**, polling `WHERE sequence > cursor`. A destructive reset of the suite DB — a Flyway `clean` (embedded-mode self-heal on a checksum mismatch) — restarted the `BIGSERIAL` at 1 while the consumer's cursor survived, so every freshly emitted result fell at or below the stale cursor and was **silently never delivered** (observed in tst: cursor pinned at 4 while the reset sequence sat at 2, so Valtimo intermediate catch events never completed). A new migration seeds `generation_results_sequence_seq` from wall-clock **epoch-milliseconds** at (re)initialisation; since it re-runs on every schema rebuild and wall-clock only moves forward, any post-reset sequence strictly exceeds every previously issued one, so a stale cursor is always below new results and consumption self-heals with no client change. Milliseconds keep values under JS's 2^53 limit for ~285k years; `sequence` is an opaque internal token, so the large magnitude has no storage/index/comparison cost (`bigint` is a fixed 8 bytes). Deploying this also unblocks an already-stuck consumer on the next boot.
+
 ## [0.24.0] - 2026-06-16
 
 This release encrypts stored catalog, code-list, and hub credentials at rest with AES-256-GCM and no-downtime key rotation, and forwards application logs and metrics to epistola-hub over OTLP-over-gRPC. Enabling the support tier now turns the hub-only backups and upgrading features on by default, and integration-test CI shuts down its shared Postgres cleanly.

--- a/modules/epistola-core/src/main/resources/db/migration/core/V20260616204832__core_generation_results_seq_timeseed.sql
+++ b/modules/epistola-core/src/main/resources/db/migration/core/V20260616204832__core_generation_results_seq_timeseed.sql
@@ -1,0 +1,43 @@
+-- Keep `generation_results.sequence` MONOTONIC ACROSS A DESTRUCTIVE DB RESET.
+--
+-- The collect protocol is a Kafka-style log: every emitted result gets a globally
+-- monotonic `sequence` (the BIGSERIAL `generation_results_sequence_seq`), and each
+-- external consumer (e.g. the Valtimo plugin) persists a high-water cursor IN ITS
+-- OWN DATABASE and polls `WHERE sequence > cursor`. The protocol's one correctness
+-- assumption is that the sequence only ever moves forward.
+--
+-- A destructive reset of THIS database breaks that assumption asymmetrically: a
+-- Flyway `clean` (the embedded-mode self-heal on a migration checksum mismatch)
+-- drops the schema and restarts the BIGSERIAL at 1, but the consumer's cursor
+-- survives in its own database. The consumer then asks for `sequence > <old
+-- high-water>` and every freshly emitted result (sequence 1, 2, ...) falls at or
+-- below it and is NEVER delivered — silently. (Observed in tst: consumer cursor
+-- pinned at 4 while the reset sequence sat at 2; Valtimo intermediate catch
+-- events never completed because the document-generated results never arrived.)
+--
+-- Fix: seed the sequence from wall-clock epoch-MILLISECONDS at (re)initialisation.
+-- This versioned migration re-runs whenever the schema is rebuilt (fresh install
+-- OR after a `clean`), so the floor is always the reinit time. Because wall-clock
+-- only moves forward, any post-reset sequence strictly exceeds every sequence the
+-- previous incarnation issued (we would have to emit >1000 results/SECOND on
+-- average between resets for the +1 increments to catch up to elapsed time) — so a
+-- stale consumer cursor is always below the new results and consumption self-heals
+-- with no client change.
+--
+-- Milliseconds, not microseconds: keeps values under JS's 2^53 safe-integer limit
+-- for ~285k years and at `Date.now()` magnitude. `sequence` is an internal cursor
+-- token (opaque to clients; documents/jobs are UUID-keyed), so the large magnitude
+-- has no storage, index, or comparison cost — a bigint is a fixed 8 bytes
+-- regardless of value, and bigint headroom is ~9.2e18 (overflow ~year 292,000,000).
+--
+-- GREATEST(last_value, now) only ever RAISES the floor, never lowers it: a normal
+-- restart never re-runs this migration, and on the off chance the sequence is
+-- already ahead it is left untouched.
+SELECT setval(
+    'generation_results_sequence_seq',
+    GREATEST(
+        (SELECT last_value FROM generation_results_sequence_seq),
+        (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint
+    ),
+    true
+);

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/generation/collect/GenerationResultSequenceTimeSeedIT.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/generation/collect/GenerationResultSequenceTimeSeedIT.kt
@@ -1,0 +1,44 @@
+package app.epistola.suite.generation.collect
+
+import app.epistola.suite.testing.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.jdbi.v3.core.Jdbi
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+/**
+ * The global result sequence is seeded from wall-clock epoch-MILLISECONDS at
+ * (re)initialisation so it stays monotonic across a destructive DB reset — see
+ * `V20260616204832__core_generation_results_seq_timeseed.sql`. This guards the
+ * invariant that an external consumer's surviving high-water cursor is always
+ * below newly emitted results after a reset (a fresh BIGSERIAL would restart at 1
+ * and the consumer would silently stop receiving results).
+ *
+ * The test relies on Flyway having applied the seed migration to the test
+ * database, exactly as it would on a real fresh install or post-`clean` rebuild.
+ */
+class GenerationResultSequenceTimeSeedIT : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var jdbi: Jdbi
+
+    @Test
+    fun `result sequence is seeded to epoch-millis magnitude, not restarted at 1`() {
+        val lastValue = jdbi.withHandle<Long, Exception> { handle ->
+            handle.createQuery("SELECT last_value FROM generation_results_sequence_seq")
+                .mapTo(Long::class.java)
+                .one()
+        }
+
+        // Floor: 2024-01-01T00:00:00Z in epoch-millis. Any real test run is well
+        // after this, so a sequence that restarted at 1 (the bug) fails here.
+        val floorMillis = 1_704_067_200_000L
+        // Ceiling: ~year 2286 in epoch-millis. Catches an accidental microsecond
+        // seed (~1.7e15), which would blow past JS's 2^53 safe-integer limit.
+        val ceilingMillis = 10_000_000_000_000L
+
+        assertThat(lastValue)
+            .`as`("generation result sequence seeded to epoch-millis magnitude (monotonic across reset)")
+            .isBetween(floorMillis, ceilingMillis)
+    }
+}


### PR DESCRIPTION
## Problem

The collect feed is a Kafka-style log: each generation result gets a globally monotonic `sequence`, and every external consumer (e.g. the Valtimo plugin) persists a high-water cursor **in its own database**, polling `WHERE sequence > cursor`. The protocol's one correctness assumption is that the sequence only ever moves forward.

A destructive reset of the suite DB — a Flyway `clean` (the embedded-mode self-heal on a migration checksum mismatch) — breaks that asymmetrically: it restarts the `BIGSERIAL` at 1, but the consumer's cursor survives in *its* database. The consumer then asks for `sequence > <old high-water>`, and every freshly emitted result (seq 1, 2, …) falls at or below it and is **silently never delivered**.

Observed in **tst** (epistola-infra demo): the consumer cursor was pinned at `4` while the reset sequence sat at `2`, so the `EpistolaResultCollectorRunner` polled `count=0, idle=false` indefinitely and Valtimo's BPMN **intermediate catch events never completed** — with no error logged on either side.

## Fix

Seed `generation_results_sequence_seq` from wall-clock **epoch-milliseconds** at (re)initialisation, via a versioned migration. It re-runs on every schema rebuild (fresh install **or** post-`clean`), and because wall-clock only moves forward, any post-reset sequence strictly exceeds every sequence the previous incarnation issued — so a stale consumer cursor is always below the new results and consumption **self-heals with no client change**.

- **Milliseconds (not microseconds):** keeps values under JS's 2⁵³ safe-integer limit for ~285k years and at `Date.now()` magnitude. `sequence` is an opaque internal cursor token (documents/jobs are UUID-keyed), so the large magnitude has **no storage/index/comparison cost** — `bigint` is a fixed 8 bytes regardless of value; headroom is ~9.2×10¹⁸.
- `GREATEST(last_value, now)` only ever raises the floor, never lowers it.

## Changes
- `V20260616204832__core_generation_results_seq_timeseed.sql` — the seed migration (with a full root-cause comment).
- `GenerationResultSequenceTimeSeedIT` — asserts the sequence is seeded to epoch-millis magnitude (floor catches a restarted-at-1 regression; ceiling catches an accidental microsecond seed).
- CHANGELOG `[Unreleased]` entry.

## Notes
- **Also unblocks the currently-stuck environments**: on next deploy the migration runs once on existing DBs and lifts the live sequence above any stale cursor, so generations flow again. (Already-orphaned rows below the cursor stay orphaned — recoverable with a one-time cursor reset if needed.)
- Internal correctness invariant, not a user-facing capability — no REST/MCP/web-UI surface or demo-catalog changes required.

## Testing
- New test + `FetchGenerationResultsHandlerIT` + `EmitGenerationResultHandlerIT` green (every collect IT boots Flyway with the new migration, proving it applies cleanly).
- `ktlintCheck`, `pnpm format:check`, gitleaks all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)