### PR TITLE
fix(catalog): align CatalogIntegrationTest with demo catalog v5.12.0

### DIFF
--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -40,7 +40,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("5.11.0")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("5.12.0")
         }
     }
 


### PR DESCRIPTION
## Description

Main branch CI was red: the **Unit & Integration Tests** job failed on `CatalogIntegrationTest > register catalog from classpath creates catalog entity()`.

Commit `d18ce344` ("fix(catalog): bump demo company-header stencil to v2…") bumped the demo catalog's `release.version` from `5.11.0` → `5.12.0` in `catalog.json`, but left the test assertion at `CatalogIntegrationTest.kt:43` hardcoding the old `5.11.0`. This one-line change realigns the test with the bundled catalog version.

Verified locally: `./gradlew :modules:epistola-core:test --tests "...CatalogIntegrationTest"` → **BUILD SUCCESSFUL** (the previously-failing test now passes).

## Related Issue(s)

<!-- none -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [ ] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

This is the failure mode the catalog-versioning rule warns about: bumping a bundled catalog without updating the assertions pinning its version. `BundledCatalogFingerprintTest` guards the *fingerprint*, but nothing guards this version string, so the drift slipped past CI on the bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)