### PR TITLE
fix: clearer stencil version-pin upgrade and export-conflict UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- **[user]** fix(catalog): **Export-conflict dialog names the templates to fix.** When a catalog export is blocked because templates pin an outdated stencil version, the dialog (and the REST/exception message) now lists each published template that still pins an older version and tells you to upgrade and publish it, instead of an ambiguous version list that mixed already-correct templates in. The browse-view pin-drift hint is likewise rephrased.
+- **[user]** fix(stencils): **Stencil usage page no longer marks up-to-date templates as upgradable.** On a stencil's "Templates using this stencil" page, the **Upgradable** filter and count now exclude templates already pinned to the stencil's latest published version (they show a "already uses the latest stencil version" reason instead). The page also makes clear that upgrading creates a **draft you must publish yourself** — and that environment-deployed templates must be re-published to their environment.
+
 ## [1.0.0-RC1] - 2026-06-25
 
 Epistola Suite 1.0.0-RC1 is the first stable release: from this version onward the database is no longer reset between upgrades — your data persists across versions, with every schema change delivered as a forward migration. This release also fixes template creation failing for long slugs, and lands the 1.0.0-RC1 database consolidation — monthly-partitioned event log with retention, UUIDv7 ids, and a schema cleanup.

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
@@ -366,17 +366,20 @@ class CatalogHandler {
             val result = BrowseCatalog(tenantKey = tenantId.key, catalogKey = catalogKey).query()
             val usages = FindResourceUsages(tenantKey = tenantId.key, catalogKey = catalogKey).query()
             val usageCounts = usages.mapValues { it.value.size }
-            // Per-stencil version-conflict map (slug → "pinned v1, v2 (latest v3)").
-            // Empty when the catalog is exportable. Used by the browse view to flag
-            // stencils that block export — mirrors the precheck the export endpoint
-            // runs. The check also fires when templates pin a single stale version
-            // (not just multi-version usage), hence the explicit `latest` callout.
+            // Per-stencil version-conflict map (slug → "v1, v2 still pinned by N
+            // template(s) (latest v3)"). Empty when the catalog is exportable. Used by
+            // the browse view to flag stencils that block export — mirrors the precheck
+            // the export endpoint runs. The check also fires when templates pin a single
+            // stale version (not just multi-version usage), hence the explicit `latest`
+            // callout.
             val stencilVersionConflicts = FindStencilVersionExportConflicts(
                 tenantKey = tenantId.key,
                 catalogKey = catalogKey,
             ).query().associate { c ->
+                val staleVersions = c.pins.map { it.pinnedVersion }.distinct().sorted()
+                    .joinToString(", v", prefix = "v")
                 c.stencilKey.value to
-                    "pinned v${c.versions.joinToString(", v")} (latest v${c.latestPublishedVersion})"
+                    "$staleVersions still pinned by ${c.pins.size} template(s) (latest v${c.latestPublishedVersion})"
             }
 
             ServerResponse.ok().page("catalogs/browse") {
@@ -686,8 +689,13 @@ class CatalogHandler {
                 StencilConflictView(
                     name = s.stencilName,
                     slug = s.stencilKey.value,
-                    versionsDisplay = s.versions.joinToString(", ") { "v$it" },
                     latestPublishedVersion = "v${s.latestPublishedVersion}",
+                    pins = s.pins.map { p ->
+                        StencilConflictView.PinView(
+                            templateLabel = p.displayLabel,
+                            pinned = "v${p.pinnedVersion}",
+                        )
+                    },
                 )
             },
         )
@@ -727,9 +735,15 @@ class CatalogHandler {
     data class StencilConflictView(
         val name: String,
         val slug: String,
-        val versionsDisplay: String,
         val latestPublishedVersion: String,
-    )
+        /** The published template-variants that still pin an outdated version. */
+        val pins: List<PinView>,
+    ) {
+        data class PinView(
+            val templateLabel: String,
+            val pinned: String,
+        )
+    }
 
     /**
      * The shared model for **every** render of the catalog list — the full

--- a/apps/epistola/src/main/resources/templates/catalogs/list.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/list.html
@@ -386,26 +386,32 @@
                     <th:block th:replace="~{epistola-web/icon :: icon(name='alert-triangle', class='ep-icon ep-icon-lg')}" />
                     <div>
                         <div class="alert-title">
-                            Stencil version-pins in catalog '<span th:text="${catalogId}"></span>'
-                            are out of sync with the latest published version.
+                            Can't export '<span th:text="${catalogId}"></span>' yet — some templates
+                            pin an outdated stencil version.
                         </div>
                         <p style="margin: var(--ep-space-1) 0 0;">
-                            The export only ships the latest published version of each stencil. Templates
-                            that pin a different (or older) version would not resolve in the target.
-                            Republish the templates against the latest version of each stencil below
-                            before exporting.
+                            An export ships only each stencil's latest published version, so a template
+                            that pins an older version would break when this catalog is imported
+                            elsewhere. For each template variant below, open the template, upgrade the
+                            stencil <strong>to its latest version, and publish it</strong> — then export
+                            again.
                         </p>
                     </div>
                 </div>
 
                 <div class="form-group">
-                    <span class="ep-label">Affected stencils</span>
+                    <span class="ep-label">Templates to update</span>
                     <ul style="margin: var(--ep-space-1) 0 0; padding-left: var(--ep-space-5);">
-                        <li th:each="s : ${stencilVersionExportConflicts}">
+                        <li th:each="s : ${stencilVersionExportConflicts}" style="margin-bottom: var(--ep-space-2);">
                             <strong th:text="${s.name}"></strong>
                             (<span class="text-muted" th:text="${s.slug}"></span>)
-                            — pinned at <span th:text="${s.versionsDisplay}"></span>,
-                            latest published is <strong th:text="${s.latestPublishedVersion}"></strong>
+                            — latest published is <strong th:text="${s.latestPublishedVersion}"></strong>
+                            <ul style="margin: var(--ep-space-1) 0 0; padding-left: var(--ep-space-4);">
+                                <li th:each="p : ${s.pins}">
+                                    <span th:text="${p.templateLabel}"></span>
+                                    pins <strong th:text="${p.pinned}"></strong>
+                                </li>
+                            </ul>
                         </li>
                     </ul>
                 </div>

--- a/apps/epistola/src/main/resources/templates/stencils/detail.html
+++ b/apps/epistola/src/main/resources/templates/stencils/detail.html
@@ -131,9 +131,20 @@
                         <span id="upgrade-status" style="font-size: var(--ep-text-sm); color: var(--ep-muted-foreground);"></span>
                     </div>
 
-                    <p th:if="${auth.has('TEMPLATE_EDIT')}" class="text-muted" style="margin-bottom: var(--ep-space-3); font-size: var(--ep-text-sm);">
-                        Published templates are upgraded in a <strong>new draft</strong> — their live version stays unchanged until you publish that draft. Existing drafts are modified in place. Up to 100 templates can be upgraded at a time.
-                    </p>
+                    <div th:if="${auth.has('TEMPLATE_EDIT')}" class="alert alert-info" style="margin-bottom: var(--ep-space-3);">
+                        <th:block th:replace="~{epistola-web/icon :: icon(name='info', class='ep-icon ep-icon-lg')}" />
+                        <div>
+                            <div class="alert-title">Upgrading creates a draft — you must publish it yourself</div>
+                            <p style="margin: var(--ep-space-1) 0 0; font-size: var(--ep-text-sm);">
+                                Upgrading a published template lands the change in a <strong>new draft</strong>; its
+                                live version stays unchanged until <strong>you open that template and publish the
+                                draft</strong> (existing drafts are modified in place). The upgrade alone does
+                                <strong>not</strong> change what the template renders, and templates that are
+                                deployed to an environment also need to be <strong>published to that environment</strong>
+                                again. Up to 100 templates can be upgraded at a time.
+                            </p>
+                        </div>
+                    </div>
 
                     <!-- Filter (plain HTMX): the select re-requests the fragment on change,
                          carrying its value as ?filter=…. The hidden state element lets
@@ -193,7 +204,8 @@
                                           th:with="reasonText=${u.upgradeBlockReason == null ? 'This template cannot be upgraded.' :
                                               (u.upgradeBlockReason.name() == 'SUBSCRIBED' ? 'This stencil belongs to a subscribed catalog and is read-only.' :
                                               (u.upgradeBlockReason.name() == 'HAS_DRAFT' ? 'This variant already has an open draft. Upgrade it on the draft row instead.' :
-                                              'Only the latest version of a variant can be upgraded.'))}"
+                                              (u.upgradeBlockReason.name() == 'UP_TO_DATE' ? 'This template already uses the latest stencil version.' :
+                                              'Only the latest version of a variant can be upgraded.')))}"
                                           th:title="${reasonText}"
                                           th:aria-label="${reasonText}">
                                         <th:block th:replace="~{epistola-web/icon :: icon(name='info', class='ep-icon ep-icon-sm')}" />

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogListHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogListHandlerTest.kt
@@ -5,12 +5,31 @@ import app.epistola.suite.catalog.commands.CreateCatalog
 import app.epistola.suite.catalog.commands.ReleaseCatalogVersion
 import app.epistola.suite.common.ids.CatalogId
 import app.epistola.suite.common.ids.CatalogKey
+import app.epistola.suite.common.ids.StencilId
+import app.epistola.suite.common.ids.StencilKey
+import app.epistola.suite.common.ids.StencilVersionId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TemplateKey
 import app.epistola.suite.common.ids.TenantId
 import app.epistola.suite.common.ids.ThemeId
 import app.epistola.suite.common.ids.ThemeKey
+import app.epistola.suite.common.ids.VariantId
+import app.epistola.suite.common.ids.VariantKey
+import app.epistola.suite.common.ids.VersionId
+import app.epistola.suite.common.ids.VersionKey
 import app.epistola.suite.mediator.execute
+import app.epistola.suite.stencils.commands.CreateStencil
+import app.epistola.suite.stencils.commands.CreateStencilVersion
+import app.epistola.suite.stencils.commands.PublishStencilVersion
+import app.epistola.suite.templates.commands.CreateDocumentTemplate
+import app.epistola.suite.templates.commands.versions.PublishVersion
+import app.epistola.suite.templates.commands.versions.UpdateDraft
+import app.epistola.suite.templates.model.Node
+import app.epistola.suite.templates.model.Slot
+import app.epistola.suite.templates.model.TemplateDocument
 import app.epistola.suite.tenants.Tenant
 import app.epistola.suite.themes.commands.CreateTheme
+import app.epistola.template.model.ThemeRef
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -141,4 +160,98 @@ class CatalogListHandlerTest : BaseIntegrationTest() {
             assertThat(body.split("pending changes")).hasSize(2) // exactly one occurrence
         }
     }
+
+    @Test
+    fun `export-check dialog names the templates that pin an outdated stencil version`() = fixture {
+        lateinit var t: Tenant
+        given {
+            t = tenant("Export Conflict Dialog")
+            withMediator {
+                val catalogKey = CatalogKey.of("conflict-cat")
+                val catalogId = CatalogId(catalogKey, TenantId(t.id))
+                CreateCatalog(tenantKey = t.id, id = catalogKey, name = "Conflict Cat").execute()
+
+                // Stencil with two published versions (latest is v2).
+                val stencilKey = StencilKey.of("shared-stencil")
+                val stencilId = StencilId(stencilKey, catalogId)
+                CreateStencil(id = stencilId, name = "Shared Stencil", content = stencilContent()).execute()
+                PublishStencilVersion(versionId = StencilVersionId(VersionKey.of(1), stencilId)).execute()
+                CreateStencilVersion(stencilId = stencilId, content = stencilContent()).execute()
+                PublishStencilVersion(versionId = StencilVersionId(VersionKey.of(2), stencilId)).execute()
+
+                // "Letter A" pins the stale v1; "Letter B" is already on the latest v2.
+                publishTemplatePinningStencil(catalogId, "letter-a", "Letter A", stencilKey, 1)
+                publishTemplatePinningStencil(catalogId, "letter-b", "Letter B", stencilKey, 2)
+            }
+        }
+
+        whenever {
+            restTemplate.exchange(
+                "/tenants/${t.id}/catalogs/conflict-cat/export-check",
+                HttpMethod.GET,
+                HttpEntity<Void>(HttpHeaders().apply { add("HX-Request", "true") }),
+                String::class.java,
+            )
+        }
+
+        then {
+            val response = result<org.springframework.http.ResponseEntity<String>>()
+            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+            val body = response.body!!
+            // The dialog names the offending template + its stale pin, and the
+            // stencil's latest version. It must NOT list "Letter B" (already on v2).
+            assertThat(body).contains("Templates to update")
+            assertThat(body).contains("Letter A")
+            assertThat(body).contains("pins")
+            assertThat(body).contains("v1")
+            assertThat(body).contains("v2")
+            assertThat(body).doesNotContain("Letter B")
+            // And it tells the user to publish after upgrading.
+            assertThat(body).contains("publish")
+        }
+    }
+
+    private fun publishTemplatePinningStencil(
+        catalogId: CatalogId,
+        slug: String,
+        name: String,
+        stencilKey: StencilKey,
+        stencilVersion: Int,
+    ) {
+        val templateId = TemplateId(TemplateKey.of(slug), catalogId)
+        CreateDocumentTemplate(id = templateId, name = name).execute()
+        val variantId = VariantId(VariantKey.INITIAL, templateId)
+        UpdateDraft(
+            variantId = variantId,
+            templateModel = templateEmbeddingStencil(stencilKey, stencilVersion),
+        ).execute()
+        PublishVersion(versionId = VersionId(VersionKey.of(1), variantId)).execute()
+    }
+
+    private fun stencilContent(): TemplateDocument = TemplateDocument(
+        modelVersion = 1,
+        root = "root",
+        nodes = mapOf("root" to Node(id = "root", type = "root", slots = listOf("root-slot"))),
+        slots = mapOf("root-slot" to Slot(id = "root-slot", nodeId = "root", name = "children", children = emptyList())),
+        themeRef = ThemeRef.Inherit,
+    )
+
+    private fun templateEmbeddingStencil(stencilKey: StencilKey, version: Int): TemplateDocument = TemplateDocument(
+        modelVersion = 1,
+        root = "root",
+        nodes = mapOf(
+            "root" to Node(id = "root", type = "root", slots = listOf("root-slot")),
+            "stencil-instance" to Node(
+                id = "stencil-instance",
+                type = "stencil",
+                slots = listOf("stencil-children"),
+                props = mapOf("stencilId" to stencilKey.value, "version" to version),
+            ),
+        ),
+        slots = mapOf(
+            "root-slot" to Slot(id = "root-slot", nodeId = "root", name = "children", children = listOf("stencil-instance")),
+            "stencil-children" to Slot(id = "stencil-children", nodeId = "stencil-instance", name = "children", children = emptyList()),
+        ),
+        themeRef = ThemeRef.Inherit,
+    )
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/MultipleStencilVersionsInUseException.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/MultipleStencilVersionsInUseException.kt
@@ -22,16 +22,36 @@ class MultipleStencilVersionsInUseException(
     val catalogKey: CatalogKey,
     val stencils: List<StencilVersionConflict>,
 ) : RuntimeException(
-    "Cannot export catalog '${catalogKey.value}': stencil version-pins out of sync with latest published — ${
-        stencils.joinToString(", ") {
-            "'${it.stencilKey.value}' templates pin v${it.versions.joinToString(", v")}, latest published is v${it.latestPublishedVersion}"
-        }
-    }",
+    buildString {
+        append("Cannot export catalog '${catalogKey.value}': ")
+        append(
+            stencils.joinToString("; ") { s ->
+                "stencil '${s.stencilKey.value}' (latest published v${s.latestPublishedVersion}) is still pinned at " +
+                    "an older version by ${s.pins.joinToString(", ") { p -> "'${p.displayLabel}' v${p.pinnedVersion}" }}"
+            },
+        )
+        append(". Upgrade and publish those template variants, then export.")
+    },
 ) {
     data class StencilVersionConflict(
         val stencilKey: StencilKey,
         val stencilName: String,
-        val versions: List<Int>,
         val latestPublishedVersion: Int,
+        /** The published template-variants that pin an out-of-date version of this stencil. */
+        val pins: List<TemplatePin>,
     )
+
+    /**
+     * One published template-variant whose latest published version pins a
+     * version of the stencil other than the latest published one.
+     */
+    data class TemplatePin(
+        val templateName: String,
+        val variantKey: String,
+        val variantTitle: String?,
+        val pinnedVersion: Int,
+    ) {
+        /** Human label: the template name, plus the variant title when it has one. */
+        val displayLabel: String get() = variantTitle?.let { "$templateName · $it" } ?: templateName
+    }
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/queries/FindStencilVersionExportConflicts.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/queries/FindStencilVersionExportConflicts.kt
@@ -2,6 +2,7 @@ package app.epistola.suite.catalog.queries
 
 import app.epistola.suite.catalog.CatalogKey
 import app.epistola.suite.catalog.MultipleStencilVersionsInUseException.StencilVersionConflict
+import app.epistola.suite.catalog.MultipleStencilVersionsInUseException.TemplatePin
 import app.epistola.suite.common.ids.StencilKey
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.mediator.Query
@@ -42,8 +43,19 @@ class FindStencilVersionExportConflictsHandler(
     private val jdbi: Jdbi,
 ) : QueryHandler<FindStencilVersionExportConflicts, List<StencilVersionConflict>> {
 
+    /** One offending (stencil, template-variant) row before grouping by stencil. */
+    private data class ConflictRow(
+        val stencilKey: StencilKey,
+        val stencilName: String,
+        val latestPublishedVersion: Int,
+        val templateName: String,
+        val variantKey: String,
+        val variantTitle: String?,
+        val pinnedVersion: Int,
+    )
+
     override fun handle(query: FindStencilVersionExportConflicts): List<StencilVersionConflict> = jdbi.withHandle<List<StencilVersionConflict>, Exception> { handle ->
-        handle.createQuery(
+        val rows = handle.createQuery(
             """
                 WITH latest_stencil_version AS (
                     SELECT s.id, MAX(sv.id) AS latest_published_version
@@ -59,7 +71,7 @@ class FindStencilVersionExportConflictsHandler(
                 ),
                 latest_published_templates AS (
                     SELECT DISTINCT ON (tenant_key, catalog_key, template_key, variant_key)
-                        template_model
+                        template_key, variant_key, template_model
                     FROM template_versions
                     WHERE tenant_key = :tenantKey
                       AND catalog_key = :catalogKey
@@ -68,6 +80,8 @@ class FindStencilVersionExportConflictsHandler(
                 ),
                 stencil_refs AS (
                     SELECT
+                        lpv.template_key,
+                        lpv.variant_key,
                         node.value -> 'props' ->> 'stencilId' AS stencil_id,
                         COALESCE((node.value -> 'props' ->> 'version')::int, 0) AS stencil_version,
                         node.value -> 'props' ->> 'catalogKey' AS ref_catalog_key
@@ -75,32 +89,62 @@ class FindStencilVersionExportConflictsHandler(
                     CROSS JOIN LATERAL jsonb_each(lpv.template_model -> 'nodes') AS node(key, value)
                     WHERE node.value ->> 'type' = 'stencil'
                 )
-                SELECT sr.stencil_id, s.name, lsv.latest_published_version,
-                       ARRAY_AGG(DISTINCT sr.stencil_version ORDER BY sr.stencil_version) AS versions
+                SELECT DISTINCT
+                    sr.stencil_id, s.name AS stencil_name, lsv.latest_published_version,
+                    sr.template_key, dt.name AS template_name,
+                    sr.variant_key, tvar.title AS variant_title,
+                    sr.stencil_version AS pinned_version
                 FROM stencil_refs sr
                 JOIN stencils s ON s.tenant_key = :tenantKey
                                AND s.catalog_key = :catalogKey
                                AND s.id = sr.stencil_id
                 JOIN latest_stencil_version lsv ON lsv.id = s.id
+                JOIN document_templates dt ON dt.tenant_key = :tenantKey
+                                          AND dt.catalog_key = :catalogKey
+                                          AND dt.id = sr.template_key
+                LEFT JOIN template_variants tvar ON tvar.tenant_key = :tenantKey
+                                                AND tvar.catalog_key = :catalogKey
+                                                AND tvar.template_key = sr.template_key
+                                                AND tvar.id = sr.variant_key
                 WHERE sr.stencil_id IS NOT NULL
                   AND (sr.ref_catalog_key IS NULL OR sr.ref_catalog_key = :catalogKey)
-                GROUP BY sr.stencil_id, s.name, lsv.latest_published_version
-                HAVING bool_or(sr.stencil_version <> lsv.latest_published_version)
-                ORDER BY sr.stencil_id
+                  AND sr.stencil_version <> lsv.latest_published_version
+                ORDER BY stencil_name, template_name, sr.variant_key, pinned_version
                 """,
         )
             .bind("tenantKey", query.tenantKey)
             .bind("catalogKey", query.catalogKey)
             .map { rs, _ ->
-                @Suppress("UNCHECKED_CAST")
-                val versionsArr = rs.getArray("versions")?.array as Array<Any?>?
-                StencilVersionConflict(
+                ConflictRow(
                     stencilKey = StencilKey(rs.getString("stencil_id")),
-                    stencilName = rs.getString("name"),
-                    versions = versionsArr?.mapNotNull { (it as? Number)?.toInt() }?.sorted().orEmpty(),
+                    stencilName = rs.getString("stencil_name"),
                     latestPublishedVersion = rs.getInt("latest_published_version"),
+                    templateName = rs.getString("template_name"),
+                    variantKey = rs.getString("variant_key"),
+                    variantTitle = rs.getString("variant_title"),
+                    pinnedVersion = rs.getInt("pinned_version"),
                 )
             }
             .list()
+
+        // Group the flat (stencil, template-variant) rows into one conflict per
+        // stencil. groupBy preserves first-seen order, and the SQL already orders
+        // by stencil then template then variant.
+        rows.groupBy { it.stencilKey }
+            .map { (stencilKey, group) ->
+                StencilVersionConflict(
+                    stencilKey = stencilKey,
+                    stencilName = group.first().stencilName,
+                    latestPublishedVersion = group.first().latestPublishedVersion,
+                    pins = group.map {
+                        TemplatePin(
+                            templateName = it.templateName,
+                            variantKey = it.variantKey,
+                            variantTitle = it.variantTitle,
+                            pinnedVersion = it.pinnedVersion,
+                        )
+                    },
+                )
+            }
     }
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/model/StencilUsageDetail.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/model/StencilUsageDetail.kt
@@ -48,5 +48,8 @@ data class StencilUsageDetail(
 
         /** A newer version of the variant is the upgrade target (this one is superseded/archived). */
         SUPERSEDED,
+
+        /** This variant already pins the stencil's latest published version — nothing to upgrade to. */
+        UP_TO_DATE,
     }
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/queries/GetStencilUsagePage.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/queries/GetStencilUsagePage.kt
@@ -44,12 +44,23 @@ data class GetStencilUsagePage(
 }
 
 /**
- * Shared CTEs: `usage` (one row per template-version/stencil-version with an
- * instance count), `flagged` (adds the per-variant `upgradable` flag), and
- * `reasoned` (adds the block reason for non-upgradable rows).
+ * Shared CTEs: `latest_stencil` (the stencil's latest published version),
+ * `usage` (one row per template-version/stencil-version with an instance count),
+ * `flagged` (adds the per-variant candidate flag), and `reasoned` (adds the
+ * `upgradable` flag and the block reason for non-upgradable rows).
+ *
+ * A candidate row is only `upgradable` when it pins a version other than the
+ * stencil's latest published version — a row already on the latest version has
+ * nothing to upgrade to and is reported as `UP_TO_DATE`, not upgradable.
  */
 private val USAGE_CTES = """
-    WITH usage AS (
+    WITH latest_stencil AS (
+        SELECT COALESCE(MAX(id), 0) AS latest_published_version
+        FROM stencil_versions
+        WHERE tenant_key = :tenantId AND catalog_key = :catalogKey
+          AND stencil_key = :stencilId AND status = 'published'
+    ),
+    usage AS (
         SELECT tv.template_key, tv.catalog_key, c.type AS catalog_type, dt.name AS template_name,
                tv.variant_key, tv.id AS version_id, tv.status AS version_status,
                COALESCE((node.value -> 'props' ->> 'version')::int, 0) AS stencil_version,
@@ -79,14 +90,16 @@ private val USAGE_CTES = """
     ),
     reasoned AS (
         SELECT f.*,
-               (f.is_candidate AND f.rn = 1) AS upgradable,
+               (f.is_candidate AND f.rn = 1 AND f.stencil_version <> ls.latest_published_version) AS upgradable,
                CASE
-                   WHEN f.is_candidate AND f.rn = 1 THEN NULL
+                   WHEN f.is_candidate AND f.rn = 1 AND f.stencil_version <> ls.latest_published_version THEN NULL
                    WHEN f.catalog_type <> 'AUTHORED' THEN 'SUBSCRIBED'
+                   WHEN f.is_candidate AND f.rn = 1 THEN 'UP_TO_DATE'
                    WHEN f.variant_has_draft THEN 'HAS_DRAFT'
                    ELSE 'SUPERSEDED'
                END AS block_reason
         FROM flagged f
+        CROSS JOIN latest_stencil ls
     )
 """
 
@@ -105,6 +118,7 @@ class GetStencilUsagePageHandler(
             "$USAGE_CTES SELECT COUNT(*) AS total_all, COUNT(*) FILTER (WHERE upgradable) AS upgradable_count FROM reasoned",
         )
             .bind("tenantId", query.stencilId.tenantKey)
+            .bind("catalogKey", query.stencilId.catalogKey)
             .bind("stencilId", query.stencilId.key.value)
             .map { rs, _ -> rs.getInt("total_all") to rs.getInt("upgradable_count") }
             .one()
@@ -134,6 +148,7 @@ class GetStencilUsagePageHandler(
             """,
         )
             .bind("tenantId", query.stencilId.tenantKey)
+            .bind("catalogKey", query.stencilId.catalogKey)
             .bind("stencilId", query.stencilId.key.value)
             .bind("filter", filter)
             .bind("limit", USAGE_PAGE_SIZE)

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/ExportBlocksMultipleStencilVersionsTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/ExportBlocksMultipleStencilVersionsTest.kt
@@ -67,8 +67,11 @@ class ExportBlocksMultipleStencilVersionsTest : IntegrationTestBase() {
                     val conflict = e.stencils.single()
                     assertThat(conflict.stencilKey).isEqualTo(stencilKey)
                     assertThat(conflict.stencilName).isEqualTo("Shared Stencil")
-                    assertThat(conflict.versions).containsExactly(1, 2)
                     assertThat(conflict.latestPublishedVersion).isEqualTo(2)
+                    // Only the out-of-date template is named; template-b (already on
+                    // the latest v2) is not listed.
+                    assertThat(conflict.pins.map { it.templateName to it.pinnedVersion })
+                        .containsExactly("template-a" to 1)
                 })
         }
     }
@@ -106,7 +109,9 @@ class ExportBlocksMultipleStencilVersionsTest : IntegrationTestBase() {
                 .satisfies({ ex ->
                     val e = ex as MultipleStencilVersionsInUseException
                     val conflict = e.stencils.single()
-                    assertThat(conflict.versions).containsExactly(1)
+                    // Both templates pin the stale v1, so both are named.
+                    assertThat(conflict.pins.map { it.templateName to it.pinnedVersion })
+                        .containsExactlyInAnyOrder("template-a" to 1, "template-b" to 1)
                     assertThat(conflict.latestPublishedVersion).isEqualTo(2)
                 })
         }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/StencilIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/StencilIntegrationTest.kt
@@ -392,9 +392,10 @@ class StencilIntegrationTest : IntegrationTestBase() {
         // A new draft now exists pinned to stencil v2, while the published version
         // is left untouched on stencil v1.
         val pageAfter = GetStencilUsagePage(stencilId = stencilId).query()
-        // Counts come from SQL: 2 usage rows (published v1 + draft v2), 1 upgradable (the draft).
+        // Counts come from SQL: 2 usage rows (published v1 + draft v2). The draft now
+        // pins the latest stencil version (v2), so nothing is left to upgrade.
         assertThat(pageAfter.totalAll).isEqualTo(2)
-        assertThat(pageAfter.upgradableCount).isEqualTo(1)
+        assertThat(pageAfter.upgradableCount).isEqualTo(0)
         assertThat(pageAfter.page).isEqualTo(1)
         assertThat(pageAfter.totalPages).isEqualTo(1)
         val usageAfter = pageAfter.items
@@ -406,14 +407,46 @@ class StencilIntegrationTest : IntegrationTestBase() {
         assertThat(publishedRow).isNotNull
         assertThat(publishedRow!!.stencilVersion).isEqualTo(1)
 
-        // Now that the variant has a draft, only the draft is the upgrade target —
-        // the published row is no longer separately upgradable (issue #598 follow-up),
-        // and it carries the reason the UI explains on hover.
-        assertThat(draftRow.upgradable).isTrue()
-        assertThat(draftRow.upgradeBlockReason).isNull()
+        // The draft now pins the latest stencil version (v2), so it is up to date —
+        // no longer a pending upgrade target. The published row remains superseded by
+        // the draft. Each carries the reason the UI explains on hover.
+        assertThat(draftRow.upgradable).isFalse()
+        assertThat(draftRow.upgradeBlockReason)
+            .isEqualTo(StencilUsageDetail.UpgradeBlockReason.UP_TO_DATE)
         assertThat(publishedRow.upgradable).isFalse()
         assertThat(publishedRow.upgradeBlockReason)
             .isEqualTo(StencilUsageDetail.UpgradeBlockReason.HAS_DRAFT)
+    }
+
+    @Test
+    fun `a template already pinned to the latest stencil version is not upgradable`() = test {
+        val tenant = createTenant("Already Latest")
+        val tenantId = TenantId(tenant.id)
+        val stencilId = stencilId(tenantId)
+
+        // Stencil v1 and v2, both published.
+        CreateStencil(id = stencilId, name = "Header", content = createTestContent()).execute()
+        PublishStencilVersion(versionId = StencilVersionId(VersionKey.of(1), stencilId)).execute()
+        CreateStencilVersion(stencilId = stencilId, content = createTestContent()).execute()
+        PublishStencilVersion(versionId = StencilVersionId(VersionKey.of(2), stencilId)).execute()
+
+        // Template embedding the stencil, upgraded to v2 (the latest) and published —
+        // so its only (published) version already pins the latest stencil version.
+        val templateKey = TestIdHelpers.nextTemplateId()
+        val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
+        CreateDocumentTemplate(id = templateId, name = "Letter").execute()
+        val variantId = VariantId(VariantKey.INITIAL, templateId)
+        UpdateDraft(variantId = variantId, templateModel = templateEmbedding(stencilId.key.value)).execute()
+        UpdateStencilInTemplate(variantId = variantId, stencilId = stencilId, newVersion = 2).execute()
+        PublishVersion(versionId = VersionId(VersionKey.of(1), variantId)).execute()
+
+        val page = GetStencilUsagePage(stencilId = stencilId).query()
+        val row = page.items.single { it.templateId == templateKey }
+        assertThat(row.stencilVersion).isEqualTo(2)
+        assertThat(row.upgradable).isFalse()
+        assertThat(row.upgradeBlockReason)
+            .isEqualTo(StencilUsageDetail.UpgradeBlockReason.UP_TO_DATE)
+        assertThat(page.upgradableCount).isEqualTo(0)
     }
 
     /** A template body embedding [stencilKey] v1 once (with a children slot so the upgrade can rewrite it). */


### PR DESCRIPTION
## Why

A user repeatedly hit a catalog export block — *"Stencil version-pins … out of sync with the latest published version"* — even after running the stencils-overview bulk upgrade **and** manually publishing. Investigating the live tenant data showed the block was correct: three published templates still pinned outdated stencil versions. The confusion came from two UX gaps, both fixed here.

## What

### 1. Export-conflict dialog names the offending templates
The dialog showed an aggregate version list (e.g. *"pinned at v5, v6"*) that **mixed already-correct templates with the broken ones** and never said which templates to fix.

- `FindStencilVersionExportConflicts` now returns one entry per offending **template-variant** (template name + variant + stale pin), excluding pins already on the latest version.
- The dialog (`catalogs/list.html` → "Templates to update"), the browse-view pin-drift hint, and the exception/REST message now list the specific templates to **upgrade and publish**.

### 2. Stencil usage page no longer marks up-to-date templates as "Upgradable"
`GetStencilUsagePage` flagged every AUTHORED draft/published row as upgradable — including templates already pinned to the latest stencil version, so the **Upgradable** filter listed rows whose upgrade is a no-op.

- The query now compares each candidate's pin to the stencil's latest published version; already-current rows report a new `UP_TO_DATE` reason instead of being upgradable.

### 3. Clearer draft/publish messaging
The usage page now states plainly that upgrading creates a **draft you must publish yourself**, and that environment-deployed templates must be re-published to their environment.

## Follow-up
Opened #656 for **bulk publishing templates** (and bulk publish-to-environment) — the underlying friction that makes the "upgrade then publish every template one by one" flow tedious.

## Tests
- Updated the integration test that asserted the old (buggy) `upgradable=true` for an already-latest draft; added a focused "already-latest is not upgradable" test.
- Updated the export-conflict tests to the new per-template `pins` shape.
- Added a Thymeleaf **dialog rendering test** (`CatalogListHandlerTest`) that asserts the offending template is named and the up-to-date one is not.
- `unitTest`/`integrationTest` for the touched areas pass; `ktlintCheck` + `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)