### PR TITLE
refactor(chart)!: chart-hygiene pass (secrets-only, remove cnpgExisting.username, schema, grafana fixes)

### DIFF
--- a/charts/epistola/CHANGELOG.md
+++ b/charts/epistola/CHANGELOG.md
@@ -12,9 +12,15 @@
 - **`serviceAccount.automount` now defaults to `false`.** The app makes no Kubernetes API calls, so its pods no longer auto-mount a ServiceAccount token. Set `true` if you add something that needs API access.
 - **`database.type=external` now fails the render when `database.external.host` is empty** (mirroring the existing password guard), instead of emitting a broken `jdbc:postgresql://:5432/…` URL that only failed at pod startup.
 
+### Fixed
+
+- **Grafana alerts now reconcile into the intended folder.** `GrafanaAlertRuleGroup.folderRef` was fed the folder *title* (`observability.grafana.folder`), but `folderRef` must name a `GrafanaFolder` CR. Added a `GrafanaFolder` template (gated by `observability.grafana.enabled`); the alert group now references it by name, co-located with the dashboards.
+- Removed a dead `datasource` template variable from all five dashboards — panels reference the datasource uid directly, so the picker did nothing.
+
 ### Internal
 
 - DB/migration credential helpers de-duplicated: a shared `epistola.database.externalUrl` helper, `epistola.database.effectiveType` now centralizes supported-type validation, and the dead `cnpgExisting` branch left by the `cnpgExisting.username` removal is gone. No behavior change.
+- Documented the grafana-operator CRD prerequisite for `observability.grafana.enabled`.
 
 ## [0.8.0] - 2026-07-04
 

--- a/charts/epistola/CHANGELOG.md
+++ b/charts/epistola/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING: `database.cnpgExisting.username` (+ its `existingSecret` / `passwordKey`) removed.** The knob was meant to run the app as a restricted role on a CNPG cluster (two-role setup), but it was silently broken: `cnpgExisting` builds the datasource URL from CNPG's `-app` secret `jdbc-uri`, which **embeds the owner's `user=`/`password=`**, and pgjdbc lets URL credentials override the explicit `SPRING_DATASOURCE_USERNAME` — so the app connected as the **owner** (full DDL) regardless, defeating the split. **For a two-role setup on CNPG, use `database.type=external`** pointed at the cluster's `-rw` service: `external` builds a credentials-free URL, so the restricted app role actually takes effect (this is the validated path). `cnpgExisting` is now single-role only (app = owner). Setting `migration.credentials` together with `cnpgExisting` now **fails the render** with a pointer to `external` (that combination had the same `jdbc-uri` flaw and no valid use — a single-role app is already the owner). See the rewritten two-role recipe in [`docs/deployment.md`](../../docs/deployment.md).
+
 ## [0.8.0] - 2026-07-04
 
 ### Added

--- a/charts/epistola/CHANGELOG.md
+++ b/charts/epistola/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed (breaking)
 
-- **BREAKING: renamed two value keys for consistency** (one name for "existing Secret" / "key within it" across the `database` and `migration` blocks): `database.cnpgExisting.secretName` → `database.cnpgExisting.existingSecret`, and `migration.credentials.passwordKey` → `migration.credentials.secretKey`. Update your values accordingly.
+- **BREAKING: renamed value keys for consistency.** `database.cnpgExisting.secretName` → `database.cnpgExisting.existingSecret`; `migration.credentials.passwordKey` → `migration.credentials.secretKey` (one name for "existing Secret" / "key within it" across the `database` and `migration` blocks); `observability.grafana.datasourceName` → `observability.grafana.datasourceUid` (it is the datasource *uid*, not a display name). Update your values accordingly.
 
 ### Removed
 
@@ -20,9 +20,11 @@
 - **`serviceAccount.automount` now defaults to `false`.** The app makes no Kubernetes API calls, so its pods no longer auto-mount a ServiceAccount token. Set `true` if you add something that needs API access.
 - **`database.type=external` now fails the render when `database.external.host` is empty** (mirroring the existing password guard), instead of emitting a broken `jdbc:postgresql://:5432/…` URL that only failed at pod startup.
 - Moved the `datasource.hikari` pool-tuning block adjacent to `database` in `values.yaml` so all database config is contiguous (no key change).
+- **`observability.prometheus.port` now derives from `config.profiles`** (default blank): the scrape target follows the actuator — `4040` under the `prod` profile, `4000` without — so the two can no longer silently disagree. Set an explicit port to override.
 
 ### Fixed
 
+- **The migration Job's pod now carries the full label set + `podLabels`/`podAnnotations`** (previously only selector labels). This is the pod that opens the database connection, so it needs the same service-mesh / NetworkPolicy / egress hooks the app pods get — otherwise a policy keyed on `podLabels` would silently exclude it and the pre-upgrade migration could fail to reach the DB.
 - **Grafana alerts now reconcile into the intended folder.** `GrafanaAlertRuleGroup.folderRef` was fed the folder *title* (`observability.grafana.folder`), but `folderRef` must name a `GrafanaFolder` CR. Added a `GrafanaFolder` template (gated by `observability.grafana.enabled`); the alert group now references it by name, co-located with the dashboards.
 - Removed a dead `datasource` template variable from all five dashboards — panels reference the datasource uid directly, so the picker did nothing.
 

--- a/charts/epistola/CHANGELOG.md
+++ b/charts/epistola/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 ### Removed
 
+- **BREAKING: inline secret values removed — secrets must come from a Kubernetes Secret.** `oidc.clientSecret`, `keycloakAdmin.clientSecret`, and `encryption.keys[].material` are gone; use `oidc.existingSecret`, `keycloakAdmin.existingSecret`, and `encryption.keys[].existingSecret` (all now `required` when the feature is enabled). Previously an inline value rendered as a **plaintext env var** in the Deployment (and was stored in the Helm release Secret) — the chart now never places secret material in the pod spec, values.yaml, or the release. CA certs (`extraCaCerts.certs`) are unaffected — they are public, not secret. (App-level `epistola.encryption.keys[].material` still exists for local/dev config; only the chart drops the inline path.)
 - **BREAKING: `database.cnpgExisting.username` (+ its `existingSecret` / `passwordKey`) removed.** The knob was meant to run the app as a restricted role on a CNPG cluster (two-role setup), but it was silently broken: `cnpgExisting` builds the datasource URL from CNPG's `-app` secret `jdbc-uri`, which **embeds the owner's `user=`/`password=`**, and pgjdbc lets URL credentials override the explicit `SPRING_DATASOURCE_USERNAME` — so the app connected as the **owner** (full DDL) regardless, defeating the split. **For a two-role setup on CNPG, use `database.type=external`** pointed at the cluster's `-rw` service: `external` builds a credentials-free URL, so the restricted app role actually takes effect (this is the validated path). `cnpgExisting` is now single-role only (app = owner). Setting `migration.credentials` together with `cnpgExisting` now **fails the render** with a pointer to `external` (that combination had the same `jdbc-uri` flaw and no valid use — a single-role app is already the owner). See the rewritten two-role recipe in [`docs/deployment.md`](../../docs/deployment.md).
+
+### Changed
+
+- **`serviceAccount.automount` now defaults to `false`.** The app makes no Kubernetes API calls, so its pods no longer auto-mount a ServiceAccount token. Set `true` if you add something that needs API access.
+- **`database.type=external` now fails the render when `database.external.host` is empty** (mirroring the existing password guard), instead of emitting a broken `jdbc:postgresql://:5432/…` URL that only failed at pod startup.
+
+### Internal
+
+- DB/migration credential helpers de-duplicated: a shared `epistola.database.externalUrl` helper, `epistola.database.effectiveType` now centralizes supported-type validation, and the dead `cnpgExisting` branch left by the `cnpgExisting.username` removal is gone. No behavior change.
 
 ## [0.8.0] - 2026-07-04
 

--- a/charts/epistola/CHANGELOG.md
+++ b/charts/epistola/CHANGELOG.md
@@ -7,10 +7,15 @@
 - **BREAKING: inline secret values removed — secrets must come from a Kubernetes Secret.** `oidc.clientSecret`, `keycloakAdmin.clientSecret`, and `encryption.keys[].material` are gone; use `oidc.existingSecret`, `keycloakAdmin.existingSecret`, and `encryption.keys[].existingSecret` (all now `required` when the feature is enabled). Previously an inline value rendered as a **plaintext env var** in the Deployment (and was stored in the Helm release Secret) — the chart now never places secret material in the pod spec, values.yaml, or the release. CA certs (`extraCaCerts.certs`) are unaffected — they are public, not secret. (App-level `epistola.encryption.keys[].material` still exists for local/dev config; only the chart drops the inline path.)
 - **BREAKING: `database.cnpgExisting.username` (+ its `existingSecret` / `passwordKey`) removed.** The knob was meant to run the app as a restricted role on a CNPG cluster (two-role setup), but it was silently broken: `cnpgExisting` builds the datasource URL from CNPG's `-app` secret `jdbc-uri`, which **embeds the owner's `user=`/`password=`**, and pgjdbc lets URL credentials override the explicit `SPRING_DATASOURCE_USERNAME` — so the app connected as the **owner** (full DDL) regardless, defeating the split. **For a two-role setup on CNPG, use `database.type=external`** pointed at the cluster's `-rw` service: `external` builds a credentials-free URL, so the restricted app role actually takes effect (this is the validated path). `cnpgExisting` is now single-role only (app = owner). Setting `migration.credentials` together with `cnpgExisting` now **fails the render** with a pointer to `external` (that combination had the same `jdbc-uri` flaw and no valid use — a single-role app is already the owner). See the rewritten two-role recipe in [`docs/deployment.md`](../../docs/deployment.md).
 
+### Added
+
+- **`values.schema.json`** — validates the datasource/migration wiring at render time: `database.type` (`none`/`external`/`cnpgExisting`) and `migration.mode` (`job`/`initContainer`/`embedded`) enums, and requires `database.external.host` + `existingSecret` when `database.type=external`. Catches typos (e.g. the removed `cnpg` type) with a clear message before templating.
+
 ### Changed
 
 - **`serviceAccount.automount` now defaults to `false`.** The app makes no Kubernetes API calls, so its pods no longer auto-mount a ServiceAccount token. Set `true` if you add something that needs API access.
 - **`database.type=external` now fails the render when `database.external.host` is empty** (mirroring the existing password guard), instead of emitting a broken `jdbc:postgresql://:5432/…` URL that only failed at pod startup.
+- Moved the `datasource.hikari` pool-tuning block adjacent to `database` in `values.yaml` so all database config is contiguous (no key change).
 
 ### Fixed
 

--- a/charts/epistola/CHANGELOG.md
+++ b/charts/epistola/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed (breaking)
+
+- **BREAKING: renamed two value keys for consistency** (one name for "existing Secret" / "key within it" across the `database` and `migration` blocks): `database.cnpgExisting.secretName` → `database.cnpgExisting.existingSecret`, and `migration.credentials.passwordKey` → `migration.credentials.secretKey`. Update your values accordingly.
+
 ### Removed
 
 - **BREAKING: inline secret values removed — secrets must come from a Kubernetes Secret.** `oidc.clientSecret`, `keycloakAdmin.clientSecret`, and `encryption.keys[].material` are gone; use `oidc.existingSecret`, `keycloakAdmin.existingSecret`, and `encryption.keys[].existingSecret` (all now `required` when the feature is enabled). Previously an inline value rendered as a **plaintext env var** in the Deployment (and was stored in the Helm release Secret) — the chart now never places secret material in the pod spec, values.yaml, or the release. CA certs (`extraCaCerts.certs`) are unaffected — they are public, not secret. (App-level `epistola.encryption.keys[].material` still exists for local/dev config; only the chart drops the inline path.)

--- a/charts/epistola/templates/_helpers.tpl
+++ b/charts/epistola/templates/_helpers.tpl
@@ -84,8 +84,8 @@ Get the CNPG secret name for an existing cluster's app credentials
 the cluster (and any roles) separately — see docs/deployment.md.
 */}}
 {{- define "epistola.cnpg.secretName" -}}
-{{- if .Values.database.cnpgExisting.secretName }}
-{{- .Values.database.cnpgExisting.secretName }}
+{{- if .Values.database.cnpgExisting.existingSecret }}
+{{- .Values.database.cnpgExisting.existingSecret }}
 {{- else }}
 {{- printf "%s-app" .Values.database.cnpgExisting.clusterName }}
 {{- end }}
@@ -185,7 +185,7 @@ wires the migration container to the right one.
   valueFrom:
     secretKeyRef:
       name: {{ required "migration.credentials.existingSecret is required when migration.credentials.username is set" $mig.existingSecret }}
-      key: {{ $mig.passwordKey | default "password" }}
+      key: {{ $mig.secretKey | default "password" }}
 {{- else }}
 {{- /* Single-role: migration reuses the app credentials. For cnpgExisting that
        is the cluster owner (-app secret); a two-role CNPG setup uses

--- a/charts/epistola/templates/_helpers.tpl
+++ b/charts/epistola/templates/_helpers.tpl
@@ -107,26 +107,16 @@ config.env to provide the datasource.
 {{- define "epistola.databaseEnv" -}}
 {{- $dbType := include "epistola.database.effectiveType" . -}}
 {{- if eq $dbType "cnpgExisting" }}
+{{- /* cnpgExisting is single-role: the app connects as the CNPG cluster owner
+       via the `-app` secret. A two-role setup (restricted app role) on CNPG is
+       done with database.type=external pointed at the cluster's -rw service —
+       NOT here — because CNPG's jdbc-uri embeds the owner credentials, which
+       pgjdbc lets override an explicit username. See docs/deployment.md. */}}
 - name: SPRING_DATASOURCE_URL
   valueFrom:
     secretKeyRef:
       name: {{ include "epistola.cnpg.secretName" . }}
       key: jdbc-uri
-{{- if .Values.database.cnpgExisting.username }}
-{{- /* App connects as a specific role (e.g. a DDL-less runtime role) instead of
-       the cluster owner — the secure two-role setup where the owner runs
-       migrations and the app only does DML/EXECUTE (see docs/deployment.md).
-       URL/host stay from the cluster's -app secret; only the credentials differ.
-       CNPG mints a plain username/password Secret for managed roles, so the
-       password comes from that Secret. */}}
-- name: SPRING_DATASOURCE_USERNAME
-  value: {{ .Values.database.cnpgExisting.username | quote }}
-- name: SPRING_DATASOURCE_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ required "database.cnpgExisting.existingSecret is required when database.cnpgExisting.username is set" .Values.database.cnpgExisting.existingSecret }}
-      key: {{ .Values.database.cnpgExisting.passwordKey | default "password" }}
-{{- else }}
 - name: SPRING_DATASOURCE_USERNAME
   valueFrom:
     secretKeyRef:
@@ -137,7 +127,6 @@ config.env to provide the datasource.
     secretKeyRef:
       name: {{ include "epistola.cnpg.secretName" . }}
       key: password
-{{- end }}
 {{- else if eq $dbType "external" }}
 - name: SPRING_DATASOURCE_URL
   value: "jdbc:postgresql://{{ .Values.database.external.host }}:{{ .Values.database.external.port }}/{{ .Values.database.external.database }}"
@@ -155,29 +144,25 @@ config.env to provide the datasource.
 Datasource env for the MIGRATION container (SPRING_DATASOURCE_*).
 
 The migration step needs the DDL-holding role. Resolution order:
-  1. `migration.credentials.username` set → connect as that explicit role
-     (any database type; URL shared, only username/password differ).
+  1. `migration.credentials.username` set (external only) → connect as that
+     explicit role — the two-role setup where the app runs as a restricted role
+     and migrations run as the DDL-holding role. Not supported with
+     `cnpgExisting` (single-role: the app is already the owner); use `external`
+     for a two-role CNPG setup.
   2. Otherwise, for `cnpgExisting` → connect as the CNPG cluster OWNER (the
-     `-app` secret), NOT whatever `database.cnpgExisting.username` set for the
-     app. This is the secure two-role default: the owner runs migrations, the
-     app connects as a restricted role. Single-role setups (no app override)
-     also land here as the same owner, unchanged.
+     `-app` secret) — same as the app (single-role).
   3. Otherwise (external/none) → reuse the app credentials from
      `epistola.databaseEnv` (single-role, unless overridden via case 1).
 
-The operator provisions any extra roles and their Secrets out of band (for CNPG,
-via `managed.roles`); this only wires the migration container to the right one.
+The operator provisions any extra roles and their Secrets out of band; this only
+wires the migration container to the right one.
 */}}
 {{- define "epistola.migrationDatabaseEnv" -}}
 {{- $mig := .Values.migration.credentials | default dict -}}
 {{- $dbType := include "epistola.database.effectiveType" . -}}
 {{- if $mig.username }}
 {{- if eq $dbType "cnpgExisting" }}
-- name: SPRING_DATASOURCE_URL
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "epistola.cnpg.secretName" . }}
-      key: jdbc-uri
+{{- fail "migration.credentials is not supported with database.type=cnpgExisting: the app already connects as the CNPG cluster owner, which holds DDL, so no separate migration role is needed. For a two-role setup on CNPG, use database.type=external pointed at the cluster's -rw service (see docs/deployment.md)." }}
 {{- else if eq $dbType "external" }}
 - name: SPRING_DATASOURCE_URL
   value: "jdbc:postgresql://{{ .Values.database.external.host }}:{{ .Values.database.external.port }}/{{ .Values.database.external.database }}"

--- a/charts/epistola/templates/_helpers.tpl
+++ b/charts/epistola/templates/_helpers.tpl
@@ -92,10 +92,24 @@ the cluster (and any roles) separately — see docs/deployment.md.
 {{- end }}
 
 {{/*
-Determine effective database type
+Resolve and validate database.type. Every datasource helper funnels through
+here, so an unsupported type fails the render once, with a clear message,
+regardless of which template is rendered first.
 */}}
 {{- define "epistola.database.effectiveType" -}}
-{{- .Values.database.type }}
+{{- $t := .Values.database.type -}}
+{{- if not (has $t (list "none" "external" "cnpgExisting")) -}}
+{{- fail (printf "database.type=%q is not supported. Use 'external', 'cnpgExisting', or 'none'. The chart no longer provisions a CloudNativePG cluster (a database must not share the app release's lifecycle); manage the CNPG Cluster yourself (see charts/epistola/examples/cnpg-cluster.yaml) and use database.type=cnpgExisting." $t) -}}
+{{- end -}}
+{{- $t -}}
+{{- end }}
+
+{{/*
+Credentials-free JDBC URL for database.type=external, shared by the app and the
+migration container so the URL (and its required-host guard) live in one place.
+*/}}
+{{- define "epistola.database.externalUrl" -}}
+jdbc:postgresql://{{ required "database.external.host is required when database.type is 'external'" .Values.database.external.host }}:{{ .Values.database.external.port }}/{{ .Values.database.external.database }}
 {{- end }}
 
 {{/*
@@ -129,7 +143,7 @@ config.env to provide the datasource.
       key: password
 {{- else if eq $dbType "external" }}
 - name: SPRING_DATASOURCE_URL
-  value: "jdbc:postgresql://{{ .Values.database.external.host }}:{{ .Values.database.external.port }}/{{ .Values.database.external.database }}"
+  value: {{ include "epistola.database.externalUrl" . | quote }}
 - name: SPRING_DATASOURCE_USERNAME
   value: {{ .Values.database.external.username | quote }}
 - name: SPRING_DATASOURCE_PASSWORD
@@ -146,13 +160,11 @@ Datasource env for the MIGRATION container (SPRING_DATASOURCE_*).
 The migration step needs the DDL-holding role. Resolution order:
   1. `migration.credentials.username` set (external only) → connect as that
      explicit role — the two-role setup where the app runs as a restricted role
-     and migrations run as the DDL-holding role. Not supported with
+     and migrations run as the DDL-holding role. Fails the render with
      `cnpgExisting` (single-role: the app is already the owner); use `external`
      for a two-role CNPG setup.
-  2. Otherwise, for `cnpgExisting` → connect as the CNPG cluster OWNER (the
-     `-app` secret) — same as the app (single-role).
-  3. Otherwise (external/none) → reuse the app credentials from
-     `epistola.databaseEnv` (single-role, unless overridden via case 1).
+  2. Otherwise → reuse the app credentials from `epistola.databaseEnv`
+     (single-role: `external`/`none` as configured, `cnpgExisting` as the owner).
 
 The operator provisions any extra roles and their Secrets out of band; this only
 wires the migration container to the right one.
@@ -165,7 +177,7 @@ wires the migration container to the right one.
 {{- fail "migration.credentials is not supported with database.type=cnpgExisting: the app already connects as the CNPG cluster owner, which holds DDL, so no separate migration role is needed. For a two-role setup on CNPG, use database.type=external pointed at the cluster's -rw service (see docs/deployment.md)." }}
 {{- else if eq $dbType "external" }}
 - name: SPRING_DATASOURCE_URL
-  value: "jdbc:postgresql://{{ .Values.database.external.host }}:{{ .Values.database.external.port }}/{{ .Values.database.external.database }}"
+  value: {{ include "epistola.database.externalUrl" . | quote }}
 {{- end }}
 - name: SPRING_DATASOURCE_USERNAME
   value: {{ $mig.username | quote }}
@@ -174,25 +186,10 @@ wires the migration container to the right one.
     secretKeyRef:
       name: {{ required "migration.credentials.existingSecret is required when migration.credentials.username is set" $mig.existingSecret }}
       key: {{ $mig.passwordKey | default "password" }}
-{{- else if eq $dbType "cnpgExisting" }}
-{{- /* Migration always uses the cluster owner (-app secret), independent of any
-       app-role override on database.cnpgExisting. */}}
-- name: SPRING_DATASOURCE_URL
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "epistola.cnpg.secretName" . }}
-      key: jdbc-uri
-- name: SPRING_DATASOURCE_USERNAME
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "epistola.cnpg.secretName" . }}
-      key: username
-- name: SPRING_DATASOURCE_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "epistola.cnpg.secretName" . }}
-      key: password
 {{- else }}
+{{- /* Single-role: migration reuses the app credentials. For cnpgExisting that
+       is the cluster owner (-app secret); a two-role CNPG setup uses
+       database.type=external (see the fail branch above and docs/deployment.md). */}}
 {{- include "epistola.databaseEnv" . }}
 {{- end }}
 {{- end }}
@@ -276,7 +273,7 @@ Handles CNPG's asynchronous provisioning. Rendered as a container list item.
 {{- end }}
 
 {{/*
-Migration container — same app image, EPISTOLA_RUN_MODE=migrate. Used by the
+Migration container — same app image, EPISTOLA_MIGRATION_MODE=migrate. Used by the
 hook Job (job mode) and the app pod init container (initContainer mode).
 Rendered as a container list item.
 */}}

--- a/charts/epistola/templates/_helpers.tpl
+++ b/charts/epistola/templates/_helpers.tpl
@@ -197,8 +197,9 @@ wires the migration container to the right one.
 {{/*
 Credential encryption-at-rest env (EPISTOLA_ENCRYPTION_*). Only the app
 Deployment needs this — the migration Job/init container never touch ciphertext.
-Each key's material is sourced from a Kubernetes Secret (existingSecret/secretKey)
-in production; an inline `material` is supported for dev convenience only.
+Each key's material is sourced from a Kubernetes Secret (existingSecret/secretKey);
+inline key material is intentionally not supported — the chart never places secret
+material in the pod spec or the Helm release.
 */}}
 {{- define "epistola.encryptionEnv" -}}
 {{- if .Values.encryption.enabled }}
@@ -210,14 +211,10 @@ in production; an inline `material` is supported for dev convenience only.
 - name: EPISTOLA_ENCRYPTION_KEYS_{{ $i }}_ID
   value: {{ required "each encryption.keys entry requires an id" $key.id | quote }}
 - name: EPISTOLA_ENCRYPTION_KEYS_{{ $i }}_MATERIAL
-  {{- if $key.existingSecret }}
   valueFrom:
     secretKeyRef:
-      name: {{ $key.existingSecret }}
+      name: {{ required "each encryption.keys entry requires existingSecret (inline key material is not supported)" $key.existingSecret }}
       key: {{ $key.secretKey | default $key.id }}
-  {{- else }}
-  value: {{ required "each encryption.keys entry requires existingSecret or inline material" $key.material | quote }}
-  {{- end }}
 {{- end }}
 {{- else }}
 - name: EPISTOLA_ENCRYPTION_ENABLED

--- a/charts/epistola/templates/deployment.yaml
+++ b/charts/epistola/templates/deployment.yaml
@@ -125,14 +125,10 @@ spec:
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTID
               value: {{ .Values.oidc.clientId | quote }}
             - name: SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET
-              {{- if .Values.oidc.existingSecret }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "oidc.existingSecret is required when oidc.enabled is true and oidc.clientSecret is empty" .Values.oidc.existingSecret }}
+                  name: {{ required "oidc.existingSecret is required when oidc.enabled is true" .Values.oidc.existingSecret }}
                   key: {{ .Values.oidc.secretKey }}
-              {{- else }}
-              value: {{ required "oidc.clientSecret is required when oidc.enabled is true and oidc.existingSecret is empty" .Values.oidc.clientSecret | quote }}
-              {{- end }}
             - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI
               value: {{ required "oidc.issuerUri is required when oidc.enabled is true" .Values.oidc.issuerUri | quote }}
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
@@ -156,14 +152,10 @@ spec:
             - name: EPISTOLA_KEYCLOAK_CLIENTID
               value: {{ .Values.keycloakAdmin.clientId | quote }}
             - name: EPISTOLA_KEYCLOAK_CLIENTSECRET
-              {{- if .Values.keycloakAdmin.existingSecret }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "keycloakAdmin.existingSecret is required when keycloakAdmin.enabled is true and keycloakAdmin.clientSecret is empty" .Values.keycloakAdmin.existingSecret }}
+                  name: {{ required "keycloakAdmin.existingSecret is required when keycloakAdmin.enabled is true" .Values.keycloakAdmin.existingSecret }}
                   key: {{ .Values.keycloakAdmin.secretKey }}
-              {{- else }}
-              value: {{ required "keycloakAdmin.clientSecret is required when keycloakAdmin.enabled is true and keycloakAdmin.existingSecret is empty" .Values.keycloakAdmin.clientSecret | quote }}
-              {{- end }}
             {{- if .Values.keycloakAdmin.ensureGroups }}
             - name: EPISTOLA_KEYCLOAK_ENSUREGROUPS
               value: "true"

--- a/charts/epistola/templates/deployment.yaml
+++ b/charts/epistola/templates/deployment.yaml
@@ -1,6 +1,3 @@
-{{- if not (has .Values.database.type (list "none" "external" "cnpgExisting")) }}
-{{- fail (printf "database.type=%q is not supported. Use 'external', 'cnpgExisting', or 'none'. The chart no longer provisions a CloudNativePG cluster (a database must not share the app release's lifecycle); manage the CNPG Cluster yourself (see charts/epistola/examples/cnpg-cluster.yaml) and use database.type=cnpgExisting." .Values.database.type) }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/epistola/templates/deployment.yaml
+++ b/charts/epistola/templates/deployment.yaml
@@ -17,7 +17,10 @@ spec:
       annotations:
         {{- if .Values.observability.prometheus.enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .Values.observability.prometheus.port | quote }}
+        {{- /* Actuator serves on the management port 4040 under the prod profile,
+               else on the main port 4000. Derive it from config.profiles so the
+               scrape target follows the actuator; an explicit port overrides. */}}
+        prometheus.io/port: {{ .Values.observability.prometheus.port | default (ternary "4040" "4000" (contains "prod" (.Values.config.profiles | default ""))) | quote }}
         prometheus.io/path: {{ .Values.observability.prometheus.path | quote }}
         {{- end }}
         {{- with .Values.podAnnotations }}

--- a/charts/epistola/templates/grafana-alerts.yaml
+++ b/charts/epistola/templates/grafana-alerts.yaml
@@ -32,7 +32,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "epistola_generation_queue_depth"
             instant: true
@@ -41,7 +41,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "rate(epistola_jobs_completed_total[5m]) == 0"
             instant: true
@@ -74,7 +74,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "rate(epistola_jobs_failed_total[5m])"
             instant: true
@@ -83,7 +83,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "rate(epistola_jobs_completed_total[5m]) + rate(epistola_jobs_failed_total[5m])"
             instant: true
@@ -116,7 +116,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "hikaricp_connections_active / hikaricp_connections_max"
             instant: true
@@ -151,7 +151,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "epistola_generation_queue_depth"
             instant: true
@@ -183,7 +183,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "histogram_quantile(0.95, rate(epistola_generation_document_duration_seconds_bucket[5m]))"
             instant: true
@@ -215,7 +215,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "sum(rate(epistola_mediator_command_duration_seconds_count{outcome=\"failure\"}[5m]))"
             instant: true
@@ -224,7 +224,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "sum(rate(epistola_mediator_command_duration_seconds_count[5m]))"
             instant: true
@@ -256,7 +256,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "rate(epistola_eventlog_persist_failures_total[5m])"
             instant: true
@@ -288,7 +288,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "rate(epistola_api_auth_attempts_total{result=\"invalid_key\"}[5m]) + rate(epistola_api_auth_attempts_total{result=\"invalid_format\"}[5m])"
             instant: true
@@ -320,7 +320,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "sum(jvm_memory_used_bytes{area=\"heap\"}) / sum(jvm_memory_max_bytes{area=\"heap\"})"
             instant: true
@@ -355,7 +355,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: "{{ .Values.observability.grafana.datasourceName }}"
+          datasourceUid: "{{ .Values.observability.grafana.datasourceUid }}"
           model:
             expr: "histogram_quantile(0.95, sum by (operation, backend, le) (rate(epistola_storage_operation_duration_seconds_bucket[5m])))"
             instant: true

--- a/charts/epistola/templates/grafana-alerts.yaml
+++ b/charts/epistola/templates/grafana-alerts.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   instanceSelector:
     {{- toYaml .Values.observability.grafana.instanceSelector | nindent 4 }}
-  folderRef: {{ .Values.observability.grafana.folder | quote }}
+  folderRef: {{ printf "%s-folder" (include "epistola.fullname" .) | quote }}
   interval: 60s
   rules:
     # -------------------------------------------------------------------------

--- a/charts/epistola/templates/grafana-dashboard-api-security.yaml
+++ b/charts/epistola/templates/grafana-dashboard-api-security.yaml
@@ -25,7 +25,7 @@ spec:
           "title": "API Request Rate",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 0, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum by (method, uri) (rate(http_server_requests_seconds_count{uri=~\"/api/.*\"}[5m]))",
@@ -49,7 +49,7 @@ spec:
           "title": "API Error Rate (4xx / 5xx)",
           "type": "gauge",
           "gridPos": { "x": 12, "y": 0, "w": 6, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/.*\", status=~\"[45]..\"}[5m])) / sum(rate(http_server_requests_seconds_count{uri=~\"/api/.*\"}[5m])) * 100",
@@ -84,7 +84,7 @@ spec:
           "title": "API Latency by Endpoint (p95)",
           "type": "timeseries",
           "gridPos": { "x": 18, "y": 0, "w": 6, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "histogram_quantile(0.95, sum by (uri, le) (rate(http_server_requests_seconds_bucket{uri=~\"/api/.*\"}[5m])))",
@@ -108,7 +108,7 @@ spec:
           "title": "Auth Attempts by Result",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 6, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum by (result) (rate(epistola_api_auth_attempts_total[5m]))",
@@ -134,7 +134,7 @@ spec:
           "title": "Auth Failures (invalid_key + invalid_format)",
           "type": "timeseries",
           "gridPos": { "x": 12, "y": 6, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(epistola_api_auth_attempts_total{result=\"invalid_key\"}[5m])",
@@ -173,7 +173,7 @@ spec:
           "title": "Requests by Status Code",
           "type": "piechart",
           "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum by (status) (increase(http_server_requests_seconds_count{uri=~\"/api/.*\"}[6h]))",

--- a/charts/epistola/templates/grafana-dashboard-api-security.yaml
+++ b/charts/epistola/templates/grafana-dashboard-api-security.yaml
@@ -19,18 +19,6 @@ spec:
       "version": 1,
       "time": { "from": "now-6h", "to": "now" },
       "refresh": "30s",
-      "templating": {
-        "list": [
-          {
-            "name": "datasource",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "label": "Datasource",
-            "current": { "text": "{{ .Values.observability.grafana.datasourceName }}", "value": "{{ .Values.observability.grafana.datasourceName }}" },
-            "hide": 0
-          }
-        ]
-      },
       "panels": [
         {
           "id": 1,

--- a/charts/epistola/templates/grafana-dashboard-generation.yaml
+++ b/charts/epistola/templates/grafana-dashboard-generation.yaml
@@ -25,7 +25,7 @@ spec:
           "title": "Generation Rate",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 0, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(epistola_jobs_completed_total[5m])",
@@ -49,7 +49,7 @@ spec:
           "title": "Generation Duration Heatmap",
           "type": "heatmap",
           "gridPos": { "x": 12, "y": 0, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(epistola_generation_document_duration_seconds_bucket[5m])",
@@ -69,7 +69,7 @@ spec:
           "title": "Duration by Template (p95)",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 6, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "histogram_quantile(0.95, sum by (template, le) (rate(epistola_generation_document_duration_seconds_bucket[5m])))",
@@ -93,7 +93,7 @@ spec:
           "title": "Queue Depth vs Generation Rate",
           "type": "timeseries",
           "gridPos": { "x": 12, "y": 6, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "epistola_generation_queue_depth",
@@ -128,7 +128,7 @@ spec:
           "title": "Adaptive Batch Size",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 12, "w": 8, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "epistola_jobs_batch_size",
@@ -152,7 +152,7 @@ spec:
           "title": "Document Size Distribution",
           "type": "timeseries",
           "gridPos": { "x": 8, "y": 12, "w": 8, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "histogram_quantile(0.50, rate(epistola_generation_document_size_bytes_bucket[5m]))",
@@ -186,7 +186,7 @@ spec:
           "title": "Failed Jobs",
           "type": "timeseries",
           "gridPos": { "x": 16, "y": 12, "w": 8, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(epistola_jobs_failed_total[5m])",
@@ -210,7 +210,7 @@ spec:
           "title": "Active vs Max Concurrent Jobs",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 18, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "epistola_jobs_active",
@@ -248,7 +248,7 @@ spec:
           "title": "Snapshot vs Legacy Path",
           "type": "barchart",
           "gridPos": { "x": 12, "y": 18, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum by (path) (increase(epistola_generation_document_duration_seconds_count[5m]))",

--- a/charts/epistola/templates/grafana-dashboard-generation.yaml
+++ b/charts/epistola/templates/grafana-dashboard-generation.yaml
@@ -19,18 +19,6 @@ spec:
       "version": 1,
       "time": { "from": "now-6h", "to": "now" },
       "refresh": "30s",
-      "templating": {
-        "list": [
-          {
-            "name": "datasource",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "label": "Datasource",
-            "current": { "text": "{{ .Values.observability.grafana.datasourceName }}", "value": "{{ .Values.observability.grafana.datasourceName }}" },
-            "hide": 0
-          }
-        ]
-      },
       "panels": [
         {
           "id": 1,

--- a/charts/epistola/templates/grafana-dashboard-infrastructure.yaml
+++ b/charts/epistola/templates/grafana-dashboard-infrastructure.yaml
@@ -25,7 +25,7 @@ spec:
           "title": "JVM Heap Usage",
           "type": "gauge",
           "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum(jvm_memory_used_bytes{area=\"heap\"}) / sum(jvm_memory_max_bytes{area=\"heap\"}) * 100",
@@ -60,7 +60,7 @@ spec:
           "title": "JVM Heap Over Time",
           "type": "timeseries",
           "gridPos": { "x": 4, "y": 0, "w": 14, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
@@ -103,7 +103,7 @@ spec:
           "title": "GC Pause Duration (avg)",
           "type": "timeseries",
           "gridPos": { "x": 18, "y": 0, "w": 6, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(jvm_gc_pause_seconds_sum[5m]) / rate(jvm_gc_pause_seconds_count[5m])",
@@ -127,7 +127,7 @@ spec:
           "title": "Thread Count",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 6, "w": 8, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "jvm_threads_live_threads",
@@ -161,7 +161,7 @@ spec:
           "title": "HikariCP Active vs Max Pool Size",
           "type": "timeseries",
           "gridPos": { "x": 8, "y": 6, "w": 8, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "hikaricp_connections_active",
@@ -204,7 +204,7 @@ spec:
           "title": "HikariCP Pending Connections",
           "type": "timeseries",
           "gridPos": { "x": 16, "y": 6, "w": 4, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "hikaricp_connections_pending",
@@ -228,7 +228,7 @@ spec:
           "title": "HikariCP Connection Timeouts",
           "type": "timeseries",
           "gridPos": { "x": 20, "y": 6, "w": 4, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(hikaricp_connections_timeout_total[5m])",
@@ -252,7 +252,7 @@ spec:
           "title": "CPU Usage",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 12, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "process_cpu_usage",
@@ -283,7 +283,7 @@ spec:
           "title": "Storage Latency p95 (by operation & backend)",
           "type": "timeseries",
           "gridPos": { "x": 12, "y": 12, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "histogram_quantile(0.95, sum by (operation, backend, le) (rate(epistola_storage_operation_duration_seconds_bucket[5m])))",
@@ -307,7 +307,7 @@ spec:
           "title": "Slowest HTTP Endpoints (p95)",
           "type": "table",
           "gridPos": { "x": 0, "y": 18, "w": 24, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "topk(15, histogram_quantile(0.95, sum by (uri, method, le) (rate(http_server_requests_seconds_bucket[5m]))))",

--- a/charts/epistola/templates/grafana-dashboard-infrastructure.yaml
+++ b/charts/epistola/templates/grafana-dashboard-infrastructure.yaml
@@ -19,18 +19,6 @@ spec:
       "version": 1,
       "time": { "from": "now-6h", "to": "now" },
       "refresh": "30s",
-      "templating": {
-        "list": [
-          {
-            "name": "datasource",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "label": "Datasource",
-            "current": { "text": "{{ .Values.observability.grafana.datasourceName }}", "value": "{{ .Values.observability.grafana.datasourceName }}" },
-            "hide": 0
-          }
-        ]
-      },
       "panels": [
         {
           "id": 1,

--- a/charts/epistola/templates/grafana-dashboard-mediator.yaml
+++ b/charts/epistola/templates/grafana-dashboard-mediator.yaml
@@ -19,18 +19,6 @@ spec:
       "version": 1,
       "time": { "from": "now-6h", "to": "now" },
       "refresh": "30s",
-      "templating": {
-        "list": [
-          {
-            "name": "datasource",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "label": "Datasource",
-            "current": { "text": "{{ .Values.observability.grafana.datasourceName }}", "value": "{{ .Values.observability.grafana.datasourceName }}" },
-            "hide": 0
-          }
-        ]
-      },
       "panels": [
         {
           "id": 1,

--- a/charts/epistola/templates/grafana-dashboard-mediator.yaml
+++ b/charts/epistola/templates/grafana-dashboard-mediator.yaml
@@ -25,7 +25,7 @@ spec:
           "title": "Top 10 Commands by Rate",
           "type": "barchart",
           "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "topk(10, sum by (command) (rate(epistola_mediator_command_duration_seconds_count[5m])))",
@@ -51,7 +51,7 @@ spec:
           "title": "Top 10 Queries by Rate",
           "type": "barchart",
           "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "topk(10, sum by (query) (rate(epistola_mediator_query_duration_seconds_count[5m])))",
@@ -77,7 +77,7 @@ spec:
           "title": "Slowest Commands (p95)",
           "type": "table",
           "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "topk(10, histogram_quantile(0.95, sum by (command, le) (rate(epistola_mediator_command_duration_seconds_bucket[5m]))))",
@@ -112,7 +112,7 @@ spec:
           "title": "Slowest Queries (p95)",
           "type": "table",
           "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "topk(10, histogram_quantile(0.95, sum by (query, le) (rate(epistola_mediator_query_duration_seconds_bucket[5m]))))",
@@ -147,7 +147,7 @@ spec:
           "title": "Command Failures by Type",
           "type": "timeseries",
           "gridPos": { "x": 0, "y": 16, "w": 12, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum by (command) (rate(epistola_mediator_command_duration_seconds_count{outcome=\"failure\"}[5m]))",
@@ -171,7 +171,7 @@ spec:
           "title": "Event Log Write Duration (p95)",
           "type": "timeseries",
           "gridPos": { "x": 12, "y": 16, "w": 6, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "histogram_quantile(0.95, rate(epistola_eventlog_persist_duration_seconds_bucket[5m]))",
@@ -203,7 +203,7 @@ spec:
           "title": "Event Log Persistence Failures",
           "type": "timeseries",
           "gridPos": { "x": 18, "y": 16, "w": 6, "h": 6 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(epistola_eventlog_persist_failures_total[5m])",

--- a/charts/epistola/templates/grafana-dashboard-overview.yaml
+++ b/charts/epistola/templates/grafana-dashboard-overview.yaml
@@ -25,7 +25,7 @@ spec:
           "title": "Documents Generated (24h)",
           "type": "stat",
           "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "increase(epistola_jobs_completed_total[24h])",
@@ -52,7 +52,7 @@ spec:
           "title": "Generation Success Rate",
           "type": "gauge",
           "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(epistola_jobs_completed_total[5m]) / (rate(epistola_jobs_completed_total[5m]) + rate(epistola_jobs_failed_total[5m])) * 100",
@@ -87,7 +87,7 @@ spec:
           "title": "Queue Depth",
           "type": "timeseries",
           "gridPos": { "x": 8, "y": 0, "w": 8, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "epistola_generation_queue_depth",
@@ -111,7 +111,7 @@ spec:
           "title": "Active Jobs",
           "type": "stat",
           "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "epistola_jobs_active",
@@ -138,7 +138,7 @@ spec:
           "title": "p95 Generation Time",
           "type": "stat",
           "gridPos": { "x": 20, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "histogram_quantile(0.95, rate(epistola_generation_document_duration_seconds_bucket[5m]))",
@@ -172,7 +172,7 @@ spec:
           "title": "Command Error Rate",
           "type": "gauge",
           "gridPos": { "x": 0, "y": 4, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "sum(rate(epistola_mediator_command_duration_seconds_count{outcome=\"failure\"}[5m])) / sum(rate(epistola_mediator_command_duration_seconds_count[5m])) * 100",
@@ -207,7 +207,7 @@ spec:
           "title": "HTTP 5xx Rate",
           "type": "gauge",
           "gridPos": { "x": 4, "y": 4, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "rate(http_server_requests_seconds_count{status=~\"5..\"}[5m]) / rate(http_server_requests_seconds_count[5m]) * 100",
@@ -242,7 +242,7 @@ spec:
           "title": "Uptime",
           "type": "stat",
           "gridPos": { "x": 8, "y": 4, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceName }}" },
+          "datasource": { "type": "prometheus", "uid": "{{ .Values.observability.grafana.datasourceUid }}" },
           "targets": [
             {
               "expr": "process_uptime_seconds",

--- a/charts/epistola/templates/grafana-dashboard-overview.yaml
+++ b/charts/epistola/templates/grafana-dashboard-overview.yaml
@@ -19,18 +19,6 @@ spec:
       "version": 1,
       "time": { "from": "now-6h", "to": "now" },
       "refresh": "30s",
-      "templating": {
-        "list": [
-          {
-            "name": "datasource",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "label": "Datasource",
-            "current": { "text": "{{ .Values.observability.grafana.datasourceName }}", "value": "{{ .Values.observability.grafana.datasourceName }}" },
-            "hide": 0
-          }
-        ]
-      },
       "panels": [
         {
           "id": 1,

--- a/charts/epistola/templates/grafana-folder.yaml
+++ b/charts/epistola/templates/grafana-folder.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.observability.grafana.enabled }}
+{{- /* A managed Grafana folder so the alert group's folderRef points at a real
+       GrafanaFolder CR (folderRef references a CR by metadata.name, not a title).
+       The dashboards place themselves in the same folder by title. */}}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: {{ include "epistola.fullname" . }}-folder
+  labels:
+    {{- include "epistola.labels" . | nindent 4 }}
+spec:
+  instanceSelector:
+    {{- toYaml .Values.observability.grafana.instanceSelector | nindent 4 }}
+  title: {{ .Values.observability.grafana.folder | quote }}
+{{- end }}

--- a/charts/epistola/templates/migration-job.yaml
+++ b/charts/epistola/templates/migration-job.yaml
@@ -33,8 +33,15 @@ spec:
   {{- end }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        {{- include "epistola.selectorLabels" . | nindent 8 }}
+        {{- include "epistola.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: Never
       {{- with .Values.imagePullSecrets }}

--- a/charts/epistola/values.schema.json
+++ b/charts/epistola/values.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Epistola Suite Helm values",
+  "description": "Partial schema: constrains the datasource/migration wiring that has hard render-time requirements. Other values are validated by the templates.",
+  "type": "object",
+  "properties": {
+    "database": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Which database the chart connects to. The chart never provisions one.",
+          "enum": ["none", "external", "cnpgExisting"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["type"],
+            "properties": { "type": { "const": "external" } }
+          },
+          "then": {
+            "required": ["external"],
+            "properties": {
+              "external": {
+                "type": "object",
+                "required": ["host", "existingSecret"],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Required for database.type=external."
+                  },
+                  "existingSecret": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Name of the Secret holding the password; required for database.type=external."
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "migration": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "description": "How schema migrations run.",
+          "enum": ["job", "initContainer", "embedded"]
+        }
+      }
+    }
+  }
+}

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -178,13 +178,13 @@ observability:
     deploymentEnvironment: ""
     # Extra OTEL resource attributes as key/value pairs (merged in).
     resourceAttributes: {}
-  # Prometheus scrape annotations on pods. Port must match the management port:
-  # in production (prod profile) the actuator endpoints serve on the separate
-  # management port 4040; set this to 4000 only if you run without the prod
-  # profile (actuator on the main port).
+  # Prometheus scrape annotations on pods.
   prometheus:
     enabled: false
-    port: 4040
+    # Scrape port. Blank → derived from config.profiles: the actuator serves on
+    # the management port 4040 under the `prod` profile, else on the main port
+    # 4000. Set explicitly to override (e.g. a non-standard management port).
+    port: ""
     path: /actuator/prometheus
   # Grafana dashboards + alerts, shipped as grafana-operator custom resources
   # (GrafanaDashboard / GrafanaAlertRuleGroup / GrafanaFolder,
@@ -198,9 +198,8 @@ observability:
     instanceSelector:
       matchLabels:
         dashboards: "grafana"
-    # UID of the Prometheus datasource the dashboard panels query (despite the
-    # name, this is the datasource *uid*, not its display name).
-    datasourceName: "Prometheus"
+    # UID of the Prometheus datasource the dashboard panels + alerts query.
+    datasourceUid: "Prometheus"
     # Title of the Grafana folder that holds the dashboards and alerts.
     folder: "Epistola"
 

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -382,7 +382,7 @@ migration:
     # Required when `username` is set.
     existingSecret: ""
     # Key within `existingSecret` that holds the password.
-    passwordKey: password
+    secretKey: password
   # Helm hook Job tuning (job mode only).
   job:
     backoffLimit: 3
@@ -448,5 +448,6 @@ database:
   cnpgExisting:
     # Name of the existing CNPG cluster
     clusterName: ""
-    # Secret name (defaults to <clusterName>-app)
-    secretName: ""
+    # Name of the credentials Secret (defaults to <clusterName>-app, which CNPG
+    # generates for the cluster owner).
+    existingSecret: ""

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -17,8 +17,10 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: true
+  # Automatically mount a ServiceAccount's API credentials? Off by default — the
+  # app does not call the Kubernetes API, so it needs no token. Set true only if
+  # you add something that does.
+  automount: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -222,8 +224,11 @@ oidc:
   # Client ID used for browser login and resource-server validation.
   clientId: epistola-suite
   # Client secret used for the OIDC client.
+  # DEV ONLY: an inline value is rendered as a plaintext env var in the
+  # Deployment (and stored in the Helm release Secret). In production set
+  # `existingSecret` instead so the secret is referenced via secretKeyRef.
   clientSecret: ""
-  # Reference a pre-existing secret containing the OIDC client secret.
+  # Reference a pre-existing secret containing the OIDC client secret (preferred).
   existingSecret: ""
   # Key within the existing secret that holds the client secret.
   secretKey: client-secret
@@ -250,8 +255,11 @@ keycloakAdmin:
   # Client ID used for client-credentials authentication.
   clientId: epistola-suite
   # Client secret used for client-credentials authentication.
+  # DEV ONLY: an inline value is rendered as a plaintext env var in the
+  # Deployment (and stored in the Helm release Secret). In production set
+  # `existingSecret` instead so the secret is referenced via secretKeyRef.
   clientSecret: ""
-  # Reference a pre-existing secret containing the admin client secret.
+  # Reference a pre-existing secret containing the admin client secret (preferred).
   existingSecret: ""
   # Key within the existing secret that holds the client secret.
   secretKey: client-secret
@@ -366,16 +374,23 @@ migration:
   waitImage: busybox:1.38
   # Resources for the migrate container.
   resources: {}
-  # Optional: run the migration container as a SEPARATE database role from the
-  # app pods. Set this to the role that holds DDL, so the app's own role
-  # (database.*) can run with NO DDL privileges — the app performs partition
-  # maintenance only via SECURITY DEFINER functions (see #438 and
-  # docs/deployment.md "Running with a DDL-less runtime role"). The database URL
-  # is shared (same host/db); only the username/password differ.
+  # Optional (database.type=external only): run the migration container as a
+  # SEPARATE database role from the app pods. Set this to the role that holds DDL,
+  # so the app's own role (database.*) can run with NO DDL privileges — the app
+  # performs partition maintenance only via SECURITY DEFINER functions (see #438
+  # and docs/deployment.md "Running with a DDL-less runtime role"). The database
+  # URL is shared (same host/db); only the username/password differ.
+  #
+  # Not supported with database.type=cnpgExisting (that path is single-role: the
+  # app already connects as the cluster owner, which holds DDL) — setting this
+  # with cnpgExisting FAILS the render. For a two-role setup on CNPG, use
+  # database.type=external pointed at the cluster's -rw service; the migration
+  # role is then the CNPG cluster OWNER, whose password is in CNPG's own
+  # <clusterName>-app Secret. See docs/deployment.md.
   #
   # Leave `username` empty to reuse the app credentials (single-role, default —
-  # unchanged behaviour). The operator provisions this role and its password
-  # Secret out of band (for CNPG, e.g. via `managed.roles`).
+  # unchanged behaviour). You provision this role and its password Secret out of
+  # band.
   credentials:
     # Migration-role username. When empty, the migration container reuses the
     # app credentials from `database.*`.

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -425,22 +425,12 @@ database:
     # Key in the secret containing the password
     secretKey: password
 
-  # Existing CNPG Cluster configuration (type: cnpgExisting)
+  # Existing CNPG Cluster configuration (type: cnpgExisting). Single-role: the app
+  # connects as the cluster OWNER via the CNPG `-app` secret. For a two-role setup
+  # on CNPG (a restricted, DDL-less app role) use `database.type=external` pointed
+  # at the cluster's `-rw` service — see the two-role recipe in docs/deployment.md.
   cnpgExisting:
     # Name of the existing CNPG cluster
     clusterName: ""
     # Secret name (defaults to <clusterName>-app)
     secretName: ""
-    # Optional: connect the APP as a specific role instead of the cluster owner.
-    # Use this for the secure two-role setup — the cluster owner runs migrations
-    # (holds DDL) and the app uses a restricted DML-only role. Provision the role
-    # on the cluster (spec.managed.roles) with the required grants; see the CNPG
-    # two-role recipe in docs/deployment.md. The database host/URL are taken from
-    # the cluster's -app secret; only the credentials differ. Leave empty to use
-    # the owner (single-role, unchanged). The migration step keeps using the owner
-    # unless overridden via migration.credentials.
-    username: ""
-    # Secret holding the app role's password; required when `username` is set.
-    existingSecret: ""
-    # Key within `existingSecret` that holds the password.
-    passwordKey: password

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -186,13 +186,22 @@ observability:
     enabled: false
     port: 4040
     path: /actuator/prometheus
-  # Grafana Operator CRDs (dashboards + alerts)
+  # Grafana dashboards + alerts, shipped as grafana-operator custom resources
+  # (GrafanaDashboard / GrafanaAlertRuleGroup / GrafanaFolder,
+  # grafana.integreatly.org/v1beta1).
+  # PREREQUISITE: the grafana-operator and its CRDs must already be installed in
+  # the cluster — otherwise `enabled: true` fails to render ("no matches for kind
+  # GrafanaDashboard"). Leave false if you do not run grafana-operator.
   grafana:
     enabled: false
+    # Selects which Grafana instance(s) the CRs apply to (grafana-operator).
     instanceSelector:
       matchLabels:
         dashboards: "grafana"
+    # UID of the Prometheus datasource the dashboard panels query (despite the
+    # name, this is the datasource *uid*, not its display name).
     datasourceName: "Prometheus"
+    # Title of the Grafana folder that holds the dashboards and alerts.
     folder: "Epistola"
 
 # Credential encryption at rest (catalog/code-list auth, hub credentials).

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -333,24 +333,6 @@ logging:
   # turning the whole root logger (and all libraries) verbose.
   appLevel: ""
 
-# Connection pool (HikariCP) tuning. The base liveness/recovery settings
-# (socketTimeout, keepalive, leak detection, …) live in the app's
-# application.yaml and apply by default; these values let operators size the
-# pool and tune the app-side socket timeout per deployment without re-templating.
-datasource:
-  hikari:
-    # Per-replica pool size (fixed: minimum-idle is pinned to this). Each replica
-    # owns its own pool, so the cluster total is replicas * maximumPoolSize. Ensure
-    # Postgres max_connections comfortably exceeds
-    # (maxReplicas * maximumPoolSize) + migration job + reserve. Raise your
-    # database's max_connections (or front PG with PgBouncer) when scaling
-    # replicaCount / autoscaling.
-    maximumPoolSize: 20
-    # APP per-socket read timeout (SECONDS). Breaks a wedged active read (post
-    # DB-failover / network blip) so the pool self-heals without a restart. Keep
-    # it >= your slowest normal query. Migrations use migration.socketTimeoutSeconds.
-    socketTimeoutSeconds: 30
-
 # Database migration strategy. Migrations can run as a separate, explicit step
 # (recommended for multi-replica / production) or embedded at app startup.
 #   job           — a Helm pre-install/pre-upgrade hook Job runs migrations once
@@ -418,6 +400,24 @@ migration:
     #     argocd.argoproj.io/hook: PreSync
     #     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     annotations: {}
+
+# Connection pool (HikariCP) tuning. The base liveness/recovery settings
+# (socketTimeout, keepalive, leak detection, …) live in the app's
+# application.yaml and apply by default; these values let operators size the
+# pool and tune the app-side socket timeout per deployment without re-templating.
+datasource:
+  hikari:
+    # Per-replica pool size (fixed: minimum-idle is pinned to this). Each replica
+    # owns its own pool, so the cluster total is replicas * maximumPoolSize. Ensure
+    # Postgres max_connections comfortably exceeds
+    # (maxReplicas * maximumPoolSize) + migration job + reserve. Raise your
+    # database's max_connections (or front PG with PgBouncer) when scaling
+    # replicaCount / autoscaling.
+    maximumPoolSize: 20
+    # APP per-socket read timeout (SECONDS). Breaks a wedged active read (post
+    # DB-failover / network blip) so the pool self-heals without a restart. Keep
+    # it >= your slowest normal query. Migrations use migration.socketTimeoutSeconds.
+    socketTimeoutSeconds: 30
 
 # Database configuration. The chart CONSUMES a database; it does not provision
 # one — the database has its own lifecycle and must never be tied to (and deleted

--- a/charts/epistola/values.yaml
+++ b/charts/epistola/values.yaml
@@ -203,19 +203,19 @@ observability:
 #   openssl rand -base64 32
 # and store it in a Kubernetes Secret, then reference it below.
 encryption:
+  # Enabled by default (fail-closed). Opt out with `enabled: false`.
   enabled: true
   # Key id used for all NEW encryptions. Must match one of the `keys[].id` below.
   primaryKeyId: ""
   # The keyset. All listed keys are available for decryption (this is how
   # rotation works: add a new key, point primaryKeyId at it, re-encrypt, then
-  # remove the old key). Each entry sources its 32-byte base64 material from a
-  # Secret (recommended) or inline (dev only):
+  # remove the old key). Each entry's 32-byte base64 material is sourced ONLY
+  # from a Kubernetes Secret — inline material is not supported, so key material
+  # never lands in values.yaml, the pod spec, or the Helm release:
   #   keys:
   #     - id: k1
-  #       existingSecret: epistola-encryption   # Secret name
+  #       existingSecret: epistola-encryption   # Secret name (required)
   #       secretKey: k1                          # key within the Secret (defaults to id)
-  #     - id: k2
-  #       material: "<base64-32-bytes>"          # inline — DEV ONLY, avoid in prod
   keys: []
 
 # OIDC login configuration (optional, requires config.profiles to include "keycloak")
@@ -223,12 +223,8 @@ oidc:
   enabled: false
   # Client ID used for browser login and resource-server validation.
   clientId: epistola-suite
-  # Client secret used for the OIDC client.
-  # DEV ONLY: an inline value is rendered as a plaintext env var in the
-  # Deployment (and stored in the Helm release Secret). In production set
-  # `existingSecret` instead so the secret is referenced via secretKeyRef.
-  clientSecret: ""
-  # Reference a pre-existing secret containing the OIDC client secret (preferred).
+  # Name of an existing Kubernetes Secret holding the OIDC client secret.
+  # Required when oidc.enabled is true — the chart never takes an inline secret.
   existingSecret: ""
   # Key within the existing secret that holds the client secret.
   secretKey: client-secret
@@ -254,12 +250,8 @@ keycloakAdmin:
   realm: epistola
   # Client ID used for client-credentials authentication.
   clientId: epistola-suite
-  # Client secret used for client-credentials authentication.
-  # DEV ONLY: an inline value is rendered as a plaintext env var in the
-  # Deployment (and stored in the Helm release Secret). In production set
-  # `existingSecret` instead so the secret is referenced via secretKeyRef.
-  clientSecret: ""
-  # Reference a pre-existing secret containing the admin client secret (preferred).
+  # Name of an existing Kubernetes Secret holding the admin client secret.
+  # Required when keycloakAdmin.enabled is true — no inline secret is accepted.
   existingSecret: ""
   # Key within the existing secret that holds the client secret.
   secretKey: client-secret

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -289,7 +289,7 @@ migration:
   credentials:
     username: epistola # owner role — from CNPG's -app secret
     existingSecret: epistola-db-app
-    passwordKey: password
+    secretKey: password
 ```
 
 The `ALTER DEFAULT PRIVILEGES` grants only apply on a **fresh** initdb (they set

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,9 +97,12 @@ helm upgrade --install epistola oci://ghcr.io/epistola-app/charts/epistola \
 ```
 
 CNPG generates the app-credentials Secret `<clusterName>-app`, which the chart
-reads. `examples/cnpg-cluster.yaml` is a minimal starting point; extend it (roles,
-grants, storage, resources) as your environment needs. This is also how you set
-up the [DDL-less two-role](#running-with-a-ddl-less-runtime-role) database.
+reads. This wires the app as the cluster **owner** (single-role).
+`examples/cnpg-cluster.yaml` is a minimal starting point; extend it (roles,
+grants, storage, resources) as your environment needs. For a
+[DDL-less two-role](#running-with-a-ddl-less-runtime-role) setup on CNPG, own the
+cluster the same way but wire the chart with `database.type=external` (not
+`cnpgExisting`) — see that section for why.
 
 ### Run the migration step standalone (outside Helm / CI / one-off)
 
@@ -225,27 +228,45 @@ migration:
     existingSecret: epistola-owner-db
 ```
 
-**CNPG (`cnpgExisting`).** The CNPG cluster **owner** is the migration role (it
-gets CNPG's rich `-app` secret, which the migration step uses by default). Add
-the restricted app role via `spec.managed.roles`, grant it in `postInitApplicationSQL`
-(which runs _as the owner_, so `ALTER DEFAULT PRIVILEGES` covers the objects the
-owner/Flyway creates — no role-membership gymnastics), and point the app at it
-with `database.cnpgExisting.username`:
+**CNPG — use `database.type=external`, not `cnpgExisting`.** For two roles on a
+CloudNativePG cluster, wire the chart with `external` pointed at the cluster's
+`-rw` service. `cnpgExisting` is single-role only (the app connects as the owner
+via CNPG's `-app` secret): its URL comes from CNPG's `jdbc-uri`, which **embeds
+the owner's credentials**, and pgjdbc lets URL credentials override an explicit
+username — so an app-role override there would silently connect as the owner and
+defeat the split. `external` builds a credentials-free URL, so the app role
+actually takes effect. (Setting `migration.credentials` with `cnpgExisting` fails
+the render with this guidance.)
+
+Provision the restricted role on the CNPG cluster. Two subtleties:
+
+- `CREATE ROLE` needs superuser, so create it in **`postInitSQL`** (runs as the
+  superuser in the `postgres` database); do the grants in **`postInitApplicationSQL`**
+  (runs in the app database).
+- CNPG runs `postInitApplicationSQL` **as the superuser, not the owner** — so
+  `ALTER DEFAULT PRIVILEGES` must be qualified **`FOR ROLE <owner>`**, or the
+  defaults apply to the superuser's objects and the app gets no grants on the
+  migration-created tables (you'll see `permission denied for table
+flyway_schema_history` at boot).
 
 ```yaml
 # in your CNPG Cluster manifest
 spec:
   bootstrap:
     initdb:
+      database: epistola
       owner: epistola # the migration role — owns objects, runs Flyway
+      postInitSQL:
+        - CREATE ROLE epistola_app LOGIN # created here (needs superuser)
       postInitApplicationSQL:
-        - CREATE ROLE epistola_app LOGIN
+        - GRANT CONNECT ON DATABASE epistola TO epistola_app
         - GRANT USAGE ON SCHEMA public TO epistola_app
-        - ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO epistola_app
-        - ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO epistola_app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE epistola IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO epistola_app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE epistola IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO epistola_app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE epistola IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO epistola_app
   managed:
     roles:
-      - name: epistola_app
+      - name: epistola_app # password managed from the Secret below
         ensure: present
         login: true
         passwordSecret:
@@ -255,23 +276,29 @@ spec:
 ```yaml
 # in the HelmRelease values
 database:
-  type: cnpgExisting
-  cnpgExisting:
-    clusterName: epistola-db
-    username: epistola_app # app connects as the restricted role…
+  type: external
+  external:
+    host: epistola-db-rw.<namespace> # the CNPG read-write service
+    port: 5432
+    database: epistola
+    username: epistola_app # app connects as the restricted role
     existingSecret: epistola-app-db
-# migration.credentials is NOT needed — the migration step uses the cluster
-# owner (the -app secret) by default.
+    secretKey: password
+migration:
+  mode: job # a DDL-less app role cannot migrate; the Job runs as the owner
+  credentials:
+    username: epistola # owner role — from CNPG's -app secret
+    existingSecret: epistola-db-app
+    passwordKey: password
 ```
 
-With `database.cnpgExisting.username` set, only the **app pods** drop to the
-restricted role (URL/host still from the cluster's `-app` secret); the migration
-Job/init container keeps using the owner. Leave it empty for single-role
-(app = owner, unchanged).
+The `ALTER DEFAULT PRIVILEGES` grants only apply on a **fresh** initdb (they set
+defaults for objects created afterwards). If you change them, CNPG re-runs
+`postInit*SQL` only on a new cluster — recreate it (data permitting) or apply the
+equivalent grants by hand as the owner.
 
-> Validate the `ALTER DEFAULT PRIVILEGES` / role setup against your CNPG and
-> Postgres versions — public-schema ownership and default-privilege semantics are
-> version-sensitive.
+> Validate the role/grant setup against your CNPG and Postgres versions —
+> public-schema ownership and default-privilege semantics are version-sensitive.
 
 ## Trusting a client root CA: `extraCaCerts`
 

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -89,7 +89,10 @@ self-test encrypt/decrypt under the primary key.
 ## Helm
 
 The chart wires the keyset as indexed environment variables sourced from a
-Kubernetes Secret (`charts/epistola`):
+Kubernetes Secret (`charts/epistola`). Key material must come from a Secret via
+`existingSecret` — the chart does **not** accept inline `material` (the inline
+form above is for app-level/local config only), so key material never lands in
+values.yaml, the pod spec, or the Helm release:
 
 ```yaml
 encryption:


### PR DESCRIPTION
A hygiene pass on `charts/epistola` driven by a multi-dimension audit (DB/migration helpers, values, templates, observability, security, docs). Six focused commits; three carry breaking changes (pre-GA, deliberate).

## Commits
1. `fix(chart)!` **Remove `database.cnpgExisting.username`** — it silently connected the app as the CNPG *owner* (CNPG's `jdbc-uri` embeds owner creds, and pgjdbc lets URL creds override the explicit username — verified). Two-role on CNPG is done with `database.type=external`; `migration.credentials` + `cnpgExisting` now fails the render.
2. `refactor(chart)` **Batch-A helper hygiene** — delete the dead `cnpgExisting` branch in `migrationDatabaseEnv`; shared `epistola.database.externalUrl` helper with a **required-host guard** (external + empty host now fails render instead of a broken `jdbc://:5432/` URL); fold supported-type validation into `effectiveType`; `serviceAccount.automount: false` (the app makes no k8s API calls); stale-comment fixes.
3. `feat(chart)!` **Secrets only via `existingSecret`** — remove inline `oidc.clientSecret`, `keycloakAdmin.clientSecret`, `encryption.keys[].material`; the chart never places secret material in the pod spec, values, or the release. Encryption stays enabled-by-default (opt out with `enabled: false`).
4. `fix(chart)` **Grafana** — `GrafanaAlertRuleGroup.folderRef` was a folder *title*, not a `GrafanaFolder` CR name (alerts never reconciled into the folder); added a `GrafanaFolder` template and referenced it by name. Dropped a dead `datasource` picker variable from all 5 dashboards. Documented the grafana-operator CRD prerequisite.
5. `feat(chart)` **`values.schema.json`** — enums for `database.type` / `migration.mode`, required `external.host`/`existingSecret` for `external`; catches typos (incl. the removed `cnpg` type) before render. Also grouped `datasource.hikari` next to `database`.
6. `refactor(chart)!` **Renames for consistency** — `database.cnpgExisting.secretName` → `existingSecret`, `migration.credentials.passwordKey` → `secretKey`.

## Breaking changes
- `database.cnpgExisting.username` (+ its `existingSecret`/`passwordKey`) removed — use `database.type=external` for two-role CNPG.
- Inline `oidc.clientSecret` / `keycloakAdmin.clientSecret` / `encryption.keys[].material` removed — use `existingSecret`.
- `database.cnpgExisting.secretName` → `existingSecret`; `migration.credentials.passwordKey` → `secretKey`.

**Companion infra PR** (epistola-infra `chart-align-migration-secretkey`) carries the matching `secretKey` rename. It's order-independent — the value is `password`, which is also the chart default, so neither chart version breaks. The live epistola-demo already complies with every breaking change (secrets via `existingSecret`, encryption on, `external` two-role).

## Validation
`helm lint` clean; every path render-tested (external two-role, cnpgExisting single-role, `none`); schema rejects bad `database.type`/`migration.mode` and missing external host; no plaintext secret env renders; grafana dashboards parse as valid JSON.

## Deferred (separate PR)
The bigger **observability extraction** — moving the ~60 KB of grafana CRDs to a subchart or `configmap-from-files`. Not urgent now that the bugs are fixed and the prereq is documented.