### PR TITLE
chore(chart): re-open next -SNAPSHOT for both charts

### DIFF
--- a/charts/epistola-grafana/Chart.yaml
+++ b/charts/epistola-grafana/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # -SNAPSHOT; a release strips it, tags epistola-grafana-<version>, then
 # re-opens the next -SNAPSHOT (see the release-helm-chart skill). CI validates the
 # tag == this value.
-version: 0.1.0
+version: 0.1.1-SNAPSHOT
 # appVersion is synced to the latest app tag at publish time by CI.
 appVersion: "latest"
 home: https://github.com/epistola-app/epistola-suite

--- a/charts/epistola/Chart.yaml
+++ b/charts/epistola/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # Source of truth for the chart version. Dev carries the next version with
 # -SNAPSHOT; a release strips it, tags epistola-<version>, then re-opens the next
 # -SNAPSHOT (see the release-helm-chart skill). CI validates the tag == this value.
-version: 0.10.0
+version: 0.10.1-SNAPSHOT
 # appVersion is synced to the latest app tag at publish time by CI.
 appVersion: "latest"
 maintainers:


### PR DESCRIPTION
Follow-up to the 0.10.0 / 0.1.0 chart releases: re-open development snapshots.

- epistola: 0.10.0 → 0.10.1-SNAPSHOT
- epistola-grafana: 0.1.0 → 0.1.1-SNAPSHOT