### PR TITLE
fix(epistola-grafana): add allowCrossNamespaceImport for central Grafana

### DIFF
--- a/charts/epistola-grafana/CHANGELOG.md
+++ b/charts/epistola-grafana/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `grafana.allowCrossNamespaceImport` value (default `false`), rendered on the `GrafanaFolder`, all `GrafanaDashboard`s and the `GrafanaAlertRuleGroup`. grafana-operator only binds a CR to a Grafana instance in the **same namespace** unless this is set; enable it when a central Grafana (e.g. in an `observability` namespace) must adopt dashboards defined in an application namespace. Without it the CRs report `NoMatchingInstance` and never reach Grafana.
+
 ## [0.1.0] - 2026-07-05
 
 ### Added

--- a/charts/epistola-grafana/templates/folder.yaml
+++ b/charts/epistola-grafana/templates/folder.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "epistola-grafana.labels" . | nindent 4 }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.grafana.allowCrossNamespaceImport }}
   instanceSelector:
     {{- toYaml .Values.grafana.instanceSelector | nindent 4 }}
   uid: {{ include "epistola-grafana.folderUid" . | quote }}

--- a/charts/epistola-grafana/templates/grafana-alerts.yaml
+++ b/charts/epistola-grafana/templates/grafana-alerts.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "epistola-grafana.labels" . | nindent 4 }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.grafana.allowCrossNamespaceImport }}
   instanceSelector:
     {{- toYaml .Values.grafana.instanceSelector | nindent 4 }}
   folderUID: {{ include "epistola-grafana.folderUid" . | quote }}

--- a/charts/epistola-grafana/templates/grafana-dashboard-api-security.yaml
+++ b/charts/epistola-grafana/templates/grafana-dashboard-api-security.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "epistola-grafana.labels" . | nindent 4 }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.grafana.allowCrossNamespaceImport }}
   instanceSelector:
     {{- toYaml .Values.grafana.instanceSelector | nindent 4 }}
   folderUID: {{ include "epistola-grafana.folderUid" . | quote }}

--- a/charts/epistola-grafana/templates/grafana-dashboard-generation.yaml
+++ b/charts/epistola-grafana/templates/grafana-dashboard-generation.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "epistola-grafana.labels" . | nindent 4 }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.grafana.allowCrossNamespaceImport }}
   instanceSelector:
     {{- toYaml .Values.grafana.instanceSelector | nindent 4 }}
   folderUID: {{ include "epistola-grafana.folderUid" . | quote }}

--- a/charts/epistola-grafana/templates/grafana-dashboard-infrastructure.yaml
+++ b/charts/epistola-grafana/templates/grafana-dashboard-infrastructure.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "epistola-grafana.labels" . | nindent 4 }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.grafana.allowCrossNamespaceImport }}
   instanceSelector:
     {{- toYaml .Values.grafana.instanceSelector | nindent 4 }}
   folderUID: {{ include "epistola-grafana.folderUid" . | quote }}

--- a/charts/epistola-grafana/templates/grafana-dashboard-mediator.yaml
+++ b/charts/epistola-grafana/templates/grafana-dashboard-mediator.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "epistola-grafana.labels" . | nindent 4 }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.grafana.allowCrossNamespaceImport }}
   instanceSelector:
     {{- toYaml .Values.grafana.instanceSelector | nindent 4 }}
   folderUID: {{ include "epistola-grafana.folderUid" . | quote }}

--- a/charts/epistola-grafana/templates/grafana-dashboard-overview.yaml
+++ b/charts/epistola-grafana/templates/grafana-dashboard-overview.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "epistola-grafana.labels" . | nindent 4 }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.grafana.allowCrossNamespaceImport }}
   instanceSelector:
     {{- toYaml .Values.grafana.instanceSelector | nindent 4 }}
   folderUID: {{ include "epistola-grafana.folderUid" . | quote }}

--- a/charts/epistola-grafana/values.yaml
+++ b/charts/epistola-grafana/values.yaml
@@ -11,6 +11,12 @@ grafana:
   instanceSelector:
     matchLabels:
       dashboards: "grafana"
+  # Allow these CRs to bind a Grafana instance in a DIFFERENT namespace.
+  # grafana-operator only matches same-namespace instances unless this is true.
+  # Leave false when the Grafana instance lives alongside these resources; set
+  # true for a central Grafana (e.g. an `observability` namespace) with the
+  # dashboards defined in an app namespace.
+  allowCrossNamespaceImport: false
   # UID of the Prometheus datasource the dashboard panels + alerts query.
   datasourceUid: "Prometheus"
   # The Grafana folder that holds the dashboards and alerts. Identity is the UID


### PR DESCRIPTION
## Problem

The `epistola-grafana` chart deploys its `GrafanaFolder` / `GrafanaDashboard`s / `GrafanaAlertRuleGroup` into the **consuming app's namespace** (e.g. `epistola-demo`). grafana-operator only binds a CR to a Grafana **instance in the same namespace** unless `allowCrossNamespaceImport: true` is set.

The demo's Grafana lives centrally in the `observability` namespace, so after the 0.1.0 extraction every CR reported `NoMatchingInstance` (`EmptyAPIReply`) and **nothing reached Grafana**. This was latent in the old app-chart wiring too (same layout, field never rendered) — the extraction just made it visible.

## Fix

- Add `grafana.allowCrossNamespaceImport` value (default `false`).
- Render it on the folder, all five dashboards, and the alert group.

Version stays `0.1.1-SNAPSHOT`; the `epistola-grafana-0.1.1` release tag (cut after merge) strips the suffix and publishes. Default stays `false` (correct when Grafana is co-located). The demo will set it `true` in its HelmRelease (separate infra change) so the central `observability` Grafana adopts the dashboards.

## Verification

- `helm lint` clean; `helm template` renders the field on all 7 CRs; `--set grafana.allowCrossNamespaceImport=true` flips all to `true`.
- folderUID anchor unchanged (still pinned, immutable-safe).