### PR TITLE
chore(chart): re-open epistola-grafana 0.1.2-SNAPSHOT

### DIFF
--- a/charts/epistola-grafana/Chart.yaml
+++ b/charts/epistola-grafana/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # -SNAPSHOT; a release strips it, tags epistola-grafana-<version>, then
 # re-opens the next -SNAPSHOT (see the release-helm-chart skill). CI validates the
 # tag == this value.
-version: 0.1.1
+version: 0.1.2-SNAPSHOT
 # appVersion is synced to the latest app tag at publish time by CI.
 appVersion: "latest"
 home: https://github.com/epistola-app/epistola-suite


### PR DESCRIPTION
Post-release: re-open the `epistola-grafana` dev line at `0.1.2-SNAPSHOT` after publishing `epistola-grafana-0.1.1`. Mirrors #704.