### PR TITLE
fix(changelog): handle release-candidate versions correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased]
 
-- **[user]** fix(changelog): **Release-candidate versions now appear in the in-app changelog.** The version-heading parser only matched a bare `X.Y.Z`, so pre-release sections like `## [1.0.0-RC2]` were silently skipped and never shown in the changelog dialog. It now accepts a SemVer pre-release suffix (`-RC2`, `-beta.1`, …), and version ordering treats a release as newer than its pre-releases.
+- **[user]** fix(changelog): **Release-candidate versions are handled correctly by the in-app changelog.** Two bugs conspired to hide RC releases: the version-heading parser only matched a bare `X.Y.Z`, so pre-release sections like `## [1.0.0-RC2]` were silently skipped from the dialog; and version normalization stripped everything after the first `-`, collapsing `1.0.0-RC2` to `1.0.0` so acknowledgments and the "new entries" badge could neither match an RC's changelog section nor tell one RC from the next. Now the parser accepts a SemVer pre-release suffix (`-RC2`, `-beta.1`, …), only the `-SNAPSHOT` dev marker is stripped (`1.0.0-RC3-SNAPSHOT` → `1.0.0-RC3`), and version comparison is pre-release-aware (a final release outranks its pre-releases; `RC1 < RC2`) so the badge fires when a newer RC ships.
 
 ## [1.0.0-RC2] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- **[user]** fix(changelog): **Release-candidate versions now appear in the in-app changelog.** The version-heading parser only matched a bare `X.Y.Z`, so pre-release sections like `## [1.0.0-RC2]` were silently skipped and never shown in the changelog dialog. It now accepts a SemVer pre-release suffix (`-RC2`, `-beta.1`, …), and version ordering treats a release as newer than its pre-releases.
+
 ## [1.0.0-RC2] - 2026-07-05
 
 This release hardens the UI with a strict Content-Security-Policy (`script-src 'self'`, no inline scripts, no external origins) and self-hosts the Inter font so no page request ever reaches Google. The REST API's list endpoints are now paginated with a `{ items, page }` envelope — a deliberate breaking change ahead of the 1.0 API freeze — and gain tenant rename and stencil parameter-schema support. Document preview now matches the final PDF exactly (same embedded fonts and pagination) and carries a "PREVIEW" watermark, and name/title fields now enforce a consistent 100-character limit.

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ChangelogRenderer.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ChangelogRenderer.kt
@@ -166,7 +166,9 @@ class ChangelogRenderer {
     private fun parseVersions(markdown: String): List<ParsedVersion> {
         if (markdown.isBlank()) return emptyList()
 
-        val versionPattern = Regex("""^## \[(\d+\.\d+\.\d+)] - (\d{4}-\d{2}-\d{2})""", RegexOption.MULTILINE)
+        // Accept an optional SemVer pre-release suffix (e.g. 1.0.0-RC2, 1.0.0-beta.1) so
+        // release-candidate sections are not silently dropped from the dialog.
+        val versionPattern = Regex("""^## \[(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)] - (\d{4}-\d{2}-\d{2})""", RegexOption.MULTILINE)
         val matches = versionPattern.findAll(markdown).toList()
 
         val result = mutableListOf<ParsedVersion>()

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/ChangelogRendererTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/ChangelogRendererTest.kt
@@ -48,7 +48,7 @@ class ChangelogRendererTest {
         val entries = renderer.entries()
         assertThat(entries).isNotEmpty()
         entries.forEach { entry ->
-            assertThat(entry.version).matches("\\d+\\.\\d+\\.\\d+")
+            assertThat(entry.version).matches("\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?")
             assertThat(entry.date).matches("\\d{4}-\\d{2}-\\d{2}")
             assertThat(entry.html).isNotBlank()
         }
@@ -257,6 +257,38 @@ class ChangelogRendererTest {
     }
 
     @Test
+    fun `pre-release versions (RC) are parsed and not dropped`() {
+        // Regression: the version heading regex must accept a SemVer pre-release suffix, otherwise
+        // release-candidate sections like [1.0.0-RC2] were silently skipped by the dialog.
+        // language=markdown
+        val md =
+            """
+            # Changelog
+
+            ## [Unreleased]
+
+            ## [1.0.0-RC2] - 2026-07-05
+
+            - **[user]** feat(editor): **RC2 thing.** Ships in the candidate.
+
+            ## [1.0.0-RC1] - 2026-06-25
+
+            - **[user]** fix(pdf): **RC1 fix.**
+
+            ## [0.26.0] - 2026-06-25
+
+            - feat(core): **Prior release.**
+            """.trimIndent()
+
+        val entries = renderer.entriesFrom(md, ChangelogAudience.ALL)
+        // The RC versions appear, in file order, ahead of the prior stable release.
+        assertThat(entries.map { it.version }).containsExactly("1.0.0-RC2", "1.0.0-RC1", "0.26.0")
+        assertThat(entries.first { it.version == "1.0.0-RC2" }.date).isEqualTo("2026-07-05")
+        assertThat(entries.first { it.version == "1.0.0-RC2" }.html).contains("RC2 thing.")
+        assertThat(entries.first { it.version == "1.0.0-RC1" }.html).contains("RC1 fix.")
+    }
+
+    @Test
     fun `a release summary paragraph renders above the entries`() {
         // language=markdown
         val md =
@@ -288,7 +320,7 @@ class ChangelogRendererTest {
                 .withFailMessage("Bundled CHANGELOG.md produced no entries for the %s view", view)
                 .isNotEmpty()
             entries.forEach { entry ->
-                assertThat(entry.version).matches("\\d+\\.\\d+\\.\\d+")
+                assertThat(entry.version).matches("\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?")
                 assertThat(entry.date).matches("\\d{4}-\\d{2}-\\d{2}")
                 assertThat(entry.html).isNotBlank()
                 assertThat(entry.summary).isNotBlank()
@@ -393,12 +425,21 @@ class ChangelogRendererTest {
     }
 
     private fun compareVersions(a: String, b: String): Int {
-        val aParts = a.split(".").map { it.toInt() }
-        val bParts = b.split(".").map { it.toInt() }
+        val aParts = a.substringBefore("-").split(".").map { it.toInt() }
+        val bParts = b.substringBefore("-").split(".").map { it.toInt() }
         for (i in 0..2) {
             val cmp = aParts[i].compareTo(bParts[i])
             if (cmp != 0) return cmp
         }
-        return 0
+        // Same base version: a release (no pre-release suffix) outranks a pre-release,
+        // and among pre-releases compare the suffix (RC1 < RC2).
+        val aPre = a.substringAfter("-", "")
+        val bPre = b.substringAfter("-", "")
+        return when {
+            aPre == bPre -> 0
+            aPre == "" -> 1
+            bPre == "" -> -1
+            else -> aPre.compareTo(bPre)
+        }
     }
 }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/ChangelogRendererTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/ChangelogRendererTest.kt
@@ -1,6 +1,7 @@
 package app.epistola.suite.handlers
 
 import app.epistola.suite.changelog.ChangelogAudience
+import app.epistola.suite.changelog.ChangelogEntry
 import app.epistola.suite.changelog.ChangelogService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
@@ -133,6 +134,45 @@ class ChangelogRendererTest {
         val older = entries.last().version
         assertThat(service.hasUnseenEntries(entries, latest, older)).isTrue()
     }
+
+    @Test
+    fun `stripSuffix keeps the pre-release identifier and drops only -SNAPSHOT`() {
+        // The RC is part of the version; only the dev/build marker is stripped.
+        assertThat(service.stripSuffix("1.0.0-RC3-SNAPSHOT")).isEqualTo("1.0.0-RC3")
+        assertThat(service.stripSuffix("1.0.0-SNAPSHOT")).isEqualTo("1.0.0")
+        assertThat(service.stripSuffix("1.0.0-RC2")).isEqualTo("1.0.0-RC2")
+        assertThat(service.stripSuffix("1.0.0")).isEqualTo("1.0.0")
+    }
+
+    @Test
+    fun `effectiveVersion of a release candidate is the full RC version, not the base`() {
+        val entries = listOf(entry("1.0.0-RC2"), entry("1.0.0-RC1"))
+        // A released RC build and its -SNAPSHOT dev build both resolve to the RC version,
+        // so acknowledgment matches the RC's own changelog section (not a phantom 1.0.0).
+        assertThat(service.effectiveVersion("1.0.0-RC2", entries)).isEqualTo("1.0.0-RC2")
+        assertThat(service.effectiveVersion("1.0.0-RC2-SNAPSHOT", entries)).isEqualTo("1.0.0-RC2")
+    }
+
+    @Test
+    fun `entriesSince distinguishes one release candidate from the next`() {
+        val entries = listOf(entry("1.0.0-RC2"), entry("1.0.0-RC1"), entry("0.26.0"))
+        // Having acknowledged RC1, RC2 is newer and shows; RC1 and older do not.
+        assertThat(service.entriesSince(entries, "1.0.0-RC1").map { it.version }).containsExactly("1.0.0-RC2")
+        // The final 1.0.0 release outranks every pre-release of it.
+        assertThat(service.entriesSince(listOf(entry("1.0.0"), entry("1.0.0-RC2")), "1.0.0-RC2").map { it.version })
+            .containsExactly("1.0.0")
+    }
+
+    @Test
+    fun `hasUnseenEntries fires when a newer release candidate ships`() {
+        val entries = listOf(entry("1.0.0-RC2"), entry("1.0.0-RC1"))
+        // On RC2, having acknowledged RC1 -> there are unseen entries.
+        assertThat(service.hasUnseenEntries(entries, "1.0.0-RC2", "1.0.0-RC1")).isTrue()
+        // On an RC2 dev build, having acknowledged RC2 -> nothing new.
+        assertThat(service.hasUnseenEntries(entries, "1.0.0-RC2-SNAPSHOT", "1.0.0-RC2")).isFalse()
+    }
+
+    private fun entry(version: String) = ChangelogEntry(version = version, date = "2026-01-01", html = "", summary = "", released = true)
 
     @Test
     fun `entries have non-empty summaries`() {

--- a/charts/epistola-grafana/Chart.yaml
+++ b/charts/epistola-grafana/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # -SNAPSHOT; a release strips it, tags epistola-grafana-<version>, then
 # re-opens the next -SNAPSHOT (see the release-helm-chart skill). CI validates the
 # tag == this value.
-version: 0.1.1
+version: 0.1.2-SNAPSHOT
 # appVersion is synced to the latest app tag at publish time by CI.
 appVersion: "latest"
 home: https://github.com/epistola-app/epistola-suite

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/changelog/ChangelogService.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/changelog/ChangelogService.kt
@@ -32,20 +32,50 @@ class ChangelogService {
 
     private fun countItems(summary: String): Int = Regex("""(\d+)""").findAll(summary).sumOf { it.value.toIntOrNull() ?: 0 }
 
-    fun stripSuffix(version: String): String = version.substringBefore("-")
+    /**
+     * Strips only the dev/build marker (`-SNAPSHOT`). The SemVer pre-release identifier (e.g. `-RC2`)
+     * is part of the version and is preserved: it must match the version's own changelog section
+     * (`[1.0.0-RC2]`) and distinguish one release candidate from the next. So `1.0.0-RC3-SNAPSHOT`
+     * → `1.0.0-RC3`, `1.0.0-SNAPSHOT` → `1.0.0`, and `1.0.0-RC2` is left untouched.
+     */
+    fun stripSuffix(version: String): String = version.removeSuffix("-SNAPSHOT")
 
-    private fun parseVersion(version: String): List<Int>? {
-        val base = stripSuffix(version)
-        val parts = base.split(".")
-        if (parts.size != 3) return null
-        return parts.mapNotNull { it.toIntOrNull() }.takeIf { it.size == 3 }
+    private fun parseVersion(version: String): SemVer? {
+        val v = stripSuffix(version)
+        val core = v.substringBefore("-").split(".")
+        if (core.size != 3) return null
+        val numbers = core.map { it.toIntOrNull() ?: return null }
+        val pre = v.substringAfter("-", "").let { if (it.isEmpty()) emptyList() else it.split(".") }
+        return SemVer(numbers, pre)
     }
 
-    private fun compareVersions(a: List<Int>, b: List<Int>): Int {
-        for (i in a.indices) {
-            val cmp = a[i].compareTo(b[i])
+    private fun compareVersions(a: SemVer, b: SemVer): Int {
+        for (i in 0..2) {
+            val cmp = a.core[i].compareTo(b.core[i])
             if (cmp != 0) return cmp
         }
-        return 0
+        // Equal X.Y.Z: a final release outranks any of its pre-releases (SemVer §11), and among
+        // pre-releases compare identifier-by-identifier — numeric parts numerically, otherwise ASCII.
+        if (a.pre.isEmpty() && b.pre.isEmpty()) return 0
+        if (a.pre.isEmpty()) return 1
+        if (b.pre.isEmpty()) return -1
+        for (i in 0 until minOf(a.pre.size, b.pre.size)) {
+            val cmp = comparePreReleaseId(a.pre[i], b.pre[i])
+            if (cmp != 0) return cmp
+        }
+        return a.pre.size.compareTo(b.pre.size)
     }
+
+    private fun comparePreReleaseId(a: String, b: String): Int {
+        val an = a.toIntOrNull()
+        val bn = b.toIntOrNull()
+        return when {
+            an != null && bn != null -> an.compareTo(bn)
+            an != null -> -1 // a numeric identifier ranks below an alphanumeric one
+            bn != null -> 1
+            else -> a.compareTo(b)
+        }
+    }
+
+    private data class SemVer(val core: List<Int>, val pre: List<String>)
 }


### PR DESCRIPTION
## Problem

The in-app changelog mishandled release-candidate versions in two compounding ways:

1. **RC sections never rendered.** `ChangelogRenderer` parsed version headings with `^## \[(\d+\.\d+\.\d+)] - …`. For `## [1.0.0-RC2] - 2026-07-05` the group matches `1.0.0`, then the pattern expects ` - ` but hits `-RC2`, so the whole match fails and the section is **silently dropped**. The dialog skipped `1.0.0-RC1` and `1.0.0-RC2`, jumping from *Unreleased* to `0.26.0`.

2. **The RC identifier was stripped from the version.** `ChangelogService.stripSuffix` used `substringBefore("-")`, throwing away the pre-release identifier along with the intended `-SNAPSHOT` dev marker (`1.0.0-RC2` → `1.0.0`). So acknowledgment stored a phantom `1.0.0` that matched no changelog section, and RC1/RC2 compared equal — the "new entries" badge could never fire when a newer RC shipped.

## Fix

- **Parser:** accept an optional SemVer pre-release suffix — `(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)`. RC/beta sections render, in authored file order.
- **`stripSuffix`:** drop only `-SNAPSHOT` (`1.0.0-RC3-SNAPSHOT` → `1.0.0-RC3`, `1.0.0-SNAPSHOT` → `1.0.0`, `1.0.0-RC2` untouched). The RC is part of the version and is preserved, so acknowledgment matches the RC's own section.
- **Comparison:** `parseVersion`/`compareVersions` are now pre-release-aware per SemVer §11 — a final release outranks its pre-releases, and `RC1 < RC2` — so the unseen-entry badge fires when a newer RC ships.

`changelog_acknowledgments.version` is `VARCHAR(20)`, ample for `1.0.0-RC2` — no migration needed.

## Verification

- `ChangelogRendererTest` (39, incl. new RC parsing + `stripSuffix`/`effectiveVersion`/`entriesSince`/`hasUnseenEntries`-across-RCs tests) + `ChangelogHandlerHtmxTest` (6) — all green.
- `ktlintCheck` (both modules) + `pnpm format:check` clean.