### PR TITLE
chore: re-open 1.0.0-RC4-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # a release strips it, tags v<version>, then re-opens the next -SNAPSHOT (see the
 # `release` skill). CI validates the v* tag equals this value. A -PreleaseVersion
 # override (PR snapshot builds) still wins over this.
-version=1.0.0-RC3
+version=1.0.0-RC4-SNAPSHOT
 
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Re-opens development after the v1.0.0-RC3 release: `gradle.properties` `version=1.0.0-RC4-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)