### PR TITLE
fix(editor): label stencil parameters separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 
+- **[user]** fix(editor): **Stencil parameters are labeled separately in the expression dialog.** Expression field pickers now group `params.*` stencil inputs under **Stencil parameters** instead of lumping them together with loop/datatable scoped fields under **Iteration variables**. Expression behavior is unchanged; this is a discoverability fix.
 - **[dev]** chore(git-hooks): **Pulls that merge frontend build inputs now rebuild automatically.** The Husky `post-merge` hook checks whether package metadata, the pnpm lock/workspace files, or the editor/design-system sources changed and runs `pnpm build` when they did, keeping `modules/editor/dist` current after relevant pulls.
 - **[dev]** feat(editor,mcp): **Editor vocabulary now comes from `epistola-model`.** The static style registry is imported from `@epistola.app/epistola-model` 0.13.0, MCP reads component descriptors from `app.epistola.contract:epistola-model` 0.13.0 at `META-INF/epistola-model/component-registry.json`, and the editor build now compares its runtime registry projection against the contract registry so drift fails in CI.
 - **[dev]** feat(editor,mcp): **Component parameter metadata uses an explicit shape.** The editor registry dump and MCP component tools now expose dynamic component parameters as `{ "kind": "dynamic" }` and future static schemas as `{ "kind": "static", "schema": { ... } }`, matching the hardened `epistola-model` registry contract.

--- a/modules/editor/src/main/typescript/engine/parameter-scope.test.ts
+++ b/modules/editor/src/main/typescript/engine/parameter-scope.test.ts
@@ -50,6 +50,19 @@ describe('buildParameterScope', () => {
     expect(paths).toEqual(['params.pageCount', 'params.recipientName']);
   });
 
+  it('marks declared parameters as stencil parameter scope', () => {
+    const node = makeStencilNode({
+      type: 'object',
+      properties: {
+        recipientName: { type: 'string', description: 'Recipient' },
+      },
+    });
+    const scope = buildParameterScope(node, { schemaFieldPaths: [] });
+
+    expect(scope!.variables[0]?.scope).toBe('params');
+    expect(scope!.variables[0]?.scopeKind).toBe('stencil-parameter');
+  });
+
   it('uses the configured paramsAlias for scope variable paths', () => {
     const node = makeStencilNode(
       { type: 'object', properties: { title: { type: 'string' } } },

--- a/modules/editor/src/main/typescript/engine/parameter-scope.ts
+++ b/modules/editor/src/main/typescript/engine/parameter-scope.ts
@@ -48,6 +48,7 @@ export function buildParameterScope(
     path: `${alias}.${name}`,
     type: typeFromSchema(propSchema),
     scope: alias,
+    scopeKind: 'stencil-parameter',
     description: propSchema?.description,
   }));
 

--- a/modules/editor/src/main/typescript/engine/schema-paths.ts
+++ b/modules/editor/src/main/typescript/engine/schema-paths.ts
@@ -28,8 +28,10 @@ export interface FieldPath {
   system?: boolean;
   /** Human-readable description (used for system parameter tooltips). */
   description?: string;
-  /** Loop scope alias (e.g., "item") — marks this as an iteration-scoped variable. */
+  /** Scope alias (e.g., "item" or "params") — marks this as a scoped variable. */
   scope?: string;
+  /** Classifies scoped variables for UI grouping. Missing means legacy iteration scope. */
+  scopeKind?: 'iteration' | 'stencil-parameter';
   /** When true, this parameter is only available inside page headers/footers. */
   pageOnly?: boolean;
 }

--- a/modules/editor/src/main/typescript/engine/scoped-fields.test.ts
+++ b/modules/editor/src/main/typescript/engine/scoped-fields.test.ts
@@ -83,6 +83,15 @@ describe('buildIterationScope', () => {
     }
   });
 
+  it('marks all variables as iteration scope', () => {
+    const node = makeLoopNode('item', 'items', 'idx');
+    const scope = buildIterationScope(node, { schemaFieldPaths })!;
+
+    for (const fp of scope.variables) {
+      expect(fp.scopeKind).toBe('iteration');
+    }
+  });
+
   it('uses custom alias', () => {
     const node = makeLoopNode('row', 'items');
     const scope = buildIterationScope(node, { schemaFieldPaths })!;

--- a/modules/editor/src/main/typescript/engine/scoped-fields.ts
+++ b/modules/editor/src/main/typescript/engine/scoped-fields.ts
@@ -69,6 +69,7 @@ function buildAliasedFieldPaths(
     path: itemAlias,
     type: 'string',
     scope: itemAlias,
+    scopeKind: 'iteration',
     description: 'Current iteration item',
   });
 
@@ -80,6 +81,7 @@ function buildAliasedFieldPaths(
         path: `${itemAlias}.${subPath}`,
         type: fp.type,
         scope: itemAlias,
+        scopeKind: 'iteration',
       });
     }
   }
@@ -90,18 +92,21 @@ function buildAliasedFieldPaths(
       path: `${itemAlias}_index`,
       type: 'integer',
       scope: itemAlias,
+      scopeKind: 'iteration',
       description: 'Zero-based iteration index',
     },
     {
       path: `${itemAlias}_first`,
       type: 'boolean',
       scope: itemAlias,
+      scopeKind: 'iteration',
       description: 'True for the first item',
     },
     {
       path: `${itemAlias}_last`,
       type: 'boolean',
       scope: itemAlias,
+      scopeKind: 'iteration',
       description: 'True for the last item',
     },
   );
@@ -111,6 +116,7 @@ function buildAliasedFieldPaths(
       path: indexAlias,
       type: 'integer',
       scope: itemAlias,
+      scopeKind: 'iteration',
       description: 'Iteration index (custom alias)',
     });
   }

--- a/modules/editor/src/main/typescript/ui/EpExpressionDialog.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpExpressionDialog.test.ts
@@ -13,8 +13,9 @@ const testFieldPaths: FieldPath[] = [
   { path: 'customer.birthDate', type: 'date' },
   { path: 'total', type: 'number' },
   { path: 'items', type: 'array' },
-  { path: 'item.name', type: 'string', scope: 'item' },
-  { path: 'item.date', type: 'date', scope: 'item' },
+  { path: 'item.name', type: 'string', scope: 'item', scopeKind: 'iteration' },
+  { path: 'item.date', type: 'date', scope: 'item', scopeKind: 'iteration' },
+  { path: 'params.recipientName', type: 'string', scope: 'params', scopeKind: 'stencil-parameter' },
   { path: '$pageNumber', type: 'number', system: true },
 ];
 
@@ -341,6 +342,35 @@ describe('EpExpressionDialog builder mode', () => {
     expect(fieldSelect?.value).toBe('invoiceDate');
     fresh.close(null);
     fresh.remove();
+  });
+
+  it('renders builder field options grouped by scoped field kind', async () => {
+    const dialog = component.querySelector<HTMLDialogElement>('dialog')!;
+    vi.spyOn(dialog, 'showModal').mockImplementation(() => {});
+    component.show();
+    await component.updateComplete;
+
+    const fieldSelect = component.querySelector<HTMLSelectElement>(
+      '.expression-dialog-field-select',
+    );
+    const groups = Array.from(fieldSelect?.querySelectorAll('optgroup') ?? []).map((group) => ({
+      label: group.label,
+      values: Array.from(group.querySelectorAll('option')).map((option) => option.value),
+    }));
+
+    expect(groups).toContainEqual(
+      expect.objectContaining({
+        label: 'Iteration variables',
+        values: expect.arrayContaining(['item.name']),
+      }),
+    );
+    expect(groups).toContainEqual(
+      expect.objectContaining({
+        label: 'Stencil parameters',
+        values: expect.arrayContaining(['params.recipientName']),
+      }),
+    );
+    component.close(null);
   });
 
   it('shows format dropdown for date fields in builder mode after show', async () => {
@@ -1360,8 +1390,22 @@ describe('EpExpressionDialog field paths', () => {
     expect(list).not.toBeNull();
     expect(list?.textContent).toContain('Template variables');
     expect(list?.textContent).toContain('name');
+    expect(list?.textContent).toContain('Iteration variables');
+    expect(list?.textContent).toContain('item.name');
+    expect(list?.textContent).toContain('Stencil parameters');
+    expect(list?.textContent).toContain('params.recipientName');
     expect(list?.textContent).toContain('System parameters');
     expect(list?.textContent).toContain('$pageNumber');
+  });
+
+  it('treats legacy scoped fields without scopeKind as iteration variables', async () => {
+    component.fieldPaths = [{ path: 'row.name', type: 'string', scope: 'row' }];
+    await component.updateComplete;
+
+    const list = component.querySelector('.expression-dialog-paths-list');
+    expect(list?.textContent).toContain('Iteration variables');
+    expect(list?.textContent).toContain('row.name');
+    expect(list?.textContent).not.toContain('Stencil parameters');
   });
 
   it('shows empty message when no field paths', async () => {

--- a/modules/editor/src/main/typescript/ui/EpExpressionDialog.ts
+++ b/modules/editor/src/main/typescript/ui/EpExpressionDialog.ts
@@ -141,8 +141,14 @@ export class EpExpressionDialog extends LitElement {
     return this.fieldPaths.filter((fp) => !fp.system && !fp.scope);
   }
 
-  private get _scopedFields(): FieldPath[] {
-    return this.fieldPaths.filter((fp) => fp.scope);
+  private get _iterationFields(): FieldPath[] {
+    return this.fieldPaths.filter(
+      (fp) => fp.scope && (fp.scopeKind === 'iteration' || !fp.scopeKind),
+    );
+  }
+
+  private get _stencilParameterFields(): FieldPath[] {
+    return this.fieldPaths.filter((fp) => fp.scope && fp.scopeKind === 'stencil-parameter');
   }
 
   private get _systemFields(): FieldPath[] {
@@ -179,8 +185,12 @@ export class EpExpressionDialog extends LitElement {
     );
   }
 
-  private get _builderScopedFields(): FieldPath[] {
-    return this._scopedFields.filter(this._isPickableForBuilder);
+  private get _builderIterationFields(): FieldPath[] {
+    return this._iterationFields.filter(this._isPickableForBuilder);
+  }
+
+  private get _builderStencilParameterFields(): FieldPath[] {
+    return this._stencilParameterFields.filter(this._isPickableForBuilder);
   }
 
   private get _builderSystemFields(): FieldPath[] {
@@ -757,10 +767,17 @@ export class EpExpressionDialog extends LitElement {
             </optgroup>
           `
         : nothing}
-      ${this._builderScopedFields.length > 0
+      ${this._builderIterationFields.length > 0
         ? html`
             <optgroup label="Iteration variables">
-              ${this._builderScopedFields.map((fp) => this._renderFieldOption(fp))}
+              ${this._builderIterationFields.map((fp) => this._renderFieldOption(fp))}
+            </optgroup>
+          `
+        : nothing}
+      ${this._builderStencilParameterFields.length > 0
+        ? html`
+            <optgroup label="Stencil parameters">
+              ${this._builderStencilParameterFields.map((fp) => this._renderFieldOption(fp))}
             </optgroup>
           `
         : nothing}
@@ -1033,7 +1050,8 @@ export class EpExpressionDialog extends LitElement {
     }
 
     const dataFields = this._dataFields;
-    const scopedFields = this._scopedFields;
+    const iterationFields = this._iterationFields;
+    const stencilParameterFields = this._stencilParameterFields;
     const systemFields = this._systemFields;
 
     return html`
@@ -1056,7 +1074,8 @@ export class EpExpressionDialog extends LitElement {
         </div>
         <ul class="expression-dialog-paths-list">
           ${this._renderFieldPathsSection('Template variables', dataFields)}
-          ${this._renderFieldPathsSection('Iteration variables', scopedFields)}
+          ${this._renderFieldPathsSection('Iteration variables', iterationFields)}
+          ${this._renderFieldPathsSection('Stencil parameters', stencilParameterFields)}
           ${this._renderFieldPathsSection('System parameters', systemFields)}
         </ul>
       </div>


### PR DESCRIPTION
## Summary

- Add scoped-field metadata so the expression dialog can distinguish loop/datatable iteration variables from stencil parameters.
- Group `params.*` stencil inputs under **Stencil parameters** in both the builder dropdown and available-fields list.
- Keep legacy scoped fields without a scope kind grouped as iteration variables.

## Root Cause

The editor represented both iteration variables and stencil parameters using the same `FieldPath.scope` marker, so the expression dialog labeled every scoped field as **Iteration variables** even when the field came from a stencil parameter scope.

## Validation

- `pnpm --filter @epistola/editor test`
- `pnpm format:check`
- `pnpm lint:check` (exits 0, existing warnings remain)
- `pnpm --filter @epistola/editor build`