### PR TITLE
feat(editor): gate AI tab with generic feature state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 
+- **[dev]** refactor(editor): **Editor feature state now carries metadata, not just booleans.** The editor host config now exposes a generic `features` map where each feature has resolved `enabled` state plus optional maturity badge metadata from `KnownFeatures`. The engine keeps `isFeatureEnabled()` as the boolean read API, while plugin setup can use the same feature object for badges such as the AI tab's Alpha marker.
 - **[user]** feat(editor): **The AI editor tab is now an alpha feature toggle.** The template editor no longer loads or shows the AI chat tab by default; tenant managers can enable the alpha `ai-chat` feature from Settings → Features, and the tab is marked Alpha when it appears.
 - **[dev]** docs(editor): **A draft ADR now records editor plugin selection intents.** The editor plugin contract uses typed host actions for plugin-driven selections that need UI behavior metadata, while existing DOM events remain scoped to shell commands such as save and preview toggles.
 - **[dev]** refactor(quality): **Quality checks no longer run on a daily backend sweep while the feature is alpha.** In-process checks now run only on publish and explicit editor **Check now**, keeping background cost and latency out of the scheduler until the run-lifecycle work for remote/expensive checks exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 
+- **[dev]** refactor(editor): **Editor plugin loading is descriptor-driven.** The template editor host page now declares available plugins as descriptors, and a generic loader skips disabled feature plugins before importing their code or stylesheet. AI remains lazy-loaded, while Quality uses the same descriptor path from the main editor bundle.
 - **[dev]** refactor(editor): **Editor feature state now carries metadata, not just booleans.** The editor host config now exposes a generic `features` map where each feature has resolved `enabled` state plus optional maturity badge metadata from `KnownFeatures`. The engine keeps `isFeatureEnabled()` as the boolean read API, while plugin setup can use the same feature object for badges such as the AI tab's Alpha marker.
 - **[user]** feat(editor): **The AI editor tab is now an alpha feature toggle.** The template editor no longer loads or shows the AI chat tab by default; tenant managers can enable the alpha `ai-chat` feature from Settings → Features, and the tab is marked Alpha when it appears.
 - **[dev]** docs(editor): **A draft ADR now records editor plugin selection intents.** The editor plugin contract uses typed host actions for plugin-driven selections that need UI behavior metadata, while existing DOM events remain scoped to shell commands such as save and preview toggles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 
+- **[user]** feat(editor): **The AI editor tab is now an alpha feature toggle.** The template editor no longer loads or shows the AI chat tab by default; tenant managers can enable the alpha `ai-chat` feature from Settings → Features, and the tab is marked Alpha when it appears.
 - **[dev]** docs(editor): **A draft ADR now records editor plugin selection intents.** The editor plugin contract uses typed host actions for plugin-driven selections that need UI behavior metadata, while existing DOM events remain scoped to shell commands such as save and preview toggles.
 - **[dev]** refactor(quality): **Quality checks no longer run on a daily backend sweep while the feature is alpha.** In-process checks now run only on publish and explicit editor **Check now**, keeping background cost and latency out of the scheduler until the run-lifecycle work for remote/expensive checks exists.
 - **[user]** fix(editor): **Sidebar tabs stay usable when feature panels add more tabs.** The editor sidebar tab strip now uses stable tab widths plus hover-visible left/right controls when tabs overflow, instead of squeezing every label into the fixed sidebar width, so plugin tabs such as Quality remain readable and discoverable without a persistent scrollbar.

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
@@ -6,6 +6,7 @@ import app.epistola.suite.catalog.CatalogType
 import app.epistola.suite.catalog.queries.ListCatalogs
 import app.epistola.suite.common.ids.CatalogId
 import app.epistola.suite.common.ids.CatalogKey
+import app.epistola.suite.common.ids.FeatureKey
 import app.epistola.suite.common.ids.TemplateId
 import app.epistola.suite.common.ids.TemplateKey
 import app.epistola.suite.common.ids.TenantId
@@ -128,6 +129,11 @@ class DocumentTemplateHandler(
 
     private companion object {
         const val PAGE_SIZE = 10
+
+        val EDITOR_FEATURES: Map<String, FeatureKey> = mapOf(
+            "quality" to KnownFeatures.QUALITY,
+            "aiChat" to KnownFeatures.AI_CHAT,
+        )
     }
 
     fun list(request: ServerRequest): ServerResponse {
@@ -401,12 +407,21 @@ class DocumentTemplateHandler(
                 "dataModel" to context.dataModel,
                 "leaderTiming" to leaderTiming,
                 "resolvedLocale" to resolvedLocale,
-                "featureFlags" to mapOf(
-                    "quality" to (featureToggles[KnownFeatures.QUALITY] == true),
-                    "aiChat" to (featureToggles[KnownFeatures.AI_CHAT] == true),
-                ),
-                "aiChatStage" to KnownFeatures.stageOf(KnownFeatures.AI_CHAT),
+                "editorFeatures" to editorFeatures(featureToggles),
             ),
+        )
+    }
+
+    private fun editorFeatures(featureToggles: Map<FeatureKey, Boolean>): Map<String, Any?> = EDITOR_FEATURES.mapValues { (_, featureKey) ->
+        val stage = KnownFeatures.stageOf(featureKey)
+        mapOf(
+            "enabled" to (featureToggles[featureKey] == true),
+            "badge" to stage.label?.let { label ->
+                mapOf(
+                    "label" to label,
+                    "className" to stage.badgeClass,
+                )
+            },
         )
     }
 

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
@@ -403,7 +403,9 @@ class DocumentTemplateHandler(
                 "resolvedLocale" to resolvedLocale,
                 "featureFlags" to mapOf(
                     "quality" to (featureToggles[KnownFeatures.QUALITY] == true),
+                    "aiChat" to (featureToggles[KnownFeatures.AI_CHAT] == true),
                 ),
+                "aiChatStage" to KnownFeatures.stageOf(KnownFeatures.AI_CHAT),
             ),
         )
     }

--- a/apps/epistola/src/main/resources/application.yaml
+++ b/apps/epistola/src/main/resources/application.yaml
@@ -144,6 +144,8 @@ epistola:
     # When false, the whole Spring AI MCP server is disabled (see
     # spring.ai.mcp.server.enabled above) and the endpoint returns 404.
     enabled: true
+  features:
+    ai-chat: false
   generation:
     # Whether THIS node performs PDF rendering. When true (default) the node advertises the
     # cluster `pdf-render` capability and claims render jobs; set false to keep the suite as a

--- a/apps/epistola/src/main/resources/static/js/editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/editor-boot.js
@@ -17,18 +17,19 @@ async function mount(container) {
   const catalogId = config.catalogId;
   const templateId = config.templateId;
   const variantId = config.variantId;
+  const features = config.features ?? {};
 
   // Load plugins dynamically
   const plugins = [];
 
-  if (config.ai?.enabled) {
+  if (features.aiChat?.enabled) {
     // AI chat plugin — uses mock transport until backend is wired up.
     try {
       const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
       plugins.push(
         createAiPlugin({
           sendMessage: createMockTransport(),
-          badge: config.ai.badge,
+          badge: features.aiChat.badge,
         }),
       );
     } catch (e) {
@@ -36,7 +37,7 @@ async function mount(container) {
     }
   }
 
-  if (config.featureFlags?.quality && config.quality) {
+  if (features.quality?.enabled && config.quality) {
     plugins.push(
       createQualityPlugin({
         findingsUrl: config.quality.findingsUrl,
@@ -52,7 +53,7 @@ async function mount(container) {
     dataExamples: config.dataExamples,
     dataModel: config.dataModel,
     plugins: plugins,
-    featureFlags: config.featureFlags,
+    features: features,
     locale: config.locale,
     fontOptions: {
       listFonts: async () => {

--- a/apps/epistola/src/main/resources/static/js/editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/editor-boot.js
@@ -21,14 +21,19 @@ async function mount(container) {
   // Load plugins dynamically
   const plugins = [];
 
-  // AI chat plugin — uses mock transport until backend is wired up.
-  // When enabledPlugins is provided by the backend, the Thymeleaf
-  // conditional (th:if) will control whether this block is rendered.
-  try {
-    const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
-    plugins.push(createAiPlugin({ sendMessage: createMockTransport() }));
-  } catch (e) {
-    console.warn('AI plugin failed to load:', e);
+  if (config.ai?.enabled) {
+    // AI chat plugin — uses mock transport until backend is wired up.
+    try {
+      const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
+      plugins.push(
+        createAiPlugin({
+          sendMessage: createMockTransport(),
+          badge: config.ai.badge,
+        }),
+      );
+    } catch (e) {
+      console.warn('AI plugin failed to load:', e);
+    }
   }
 
   if (config.featureFlags?.quality && config.quality) {

--- a/apps/epistola/src/main/resources/static/js/editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/editor-boot.js
@@ -11,7 +11,8 @@ async function mount(container) {
   container.dataset.editorMounted = 'true';
   const config = JSON.parse(island.textContent);
 
-  const { createQualityPlugin, mountEditor } = await import(config.editorModuleUrl);
+  const editorModule = await import(config.editorModuleUrl);
+  const { loadEditorPlugins, mountEditor } = editorModule;
 
   const tenantId = config.tenantId;
   const catalogId = config.catalogId;
@@ -19,33 +20,11 @@ async function mount(container) {
   const variantId = config.variantId;
   const features = config.features ?? {};
 
-  // Load plugins dynamically
-  const plugins = [];
-
-  if (features.aiChat?.enabled) {
-    // AI chat plugin — uses mock transport until backend is wired up.
-    try {
-      const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
-      plugins.push(
-        createAiPlugin({
-          sendMessage: createMockTransport(),
-          badge: features.aiChat.badge,
-        }),
-      );
-    } catch (e) {
-      console.warn('AI plugin failed to load:', e);
-    }
-  }
-
-  if (features.quality?.enabled && config.quality) {
-    plugins.push(
-      createQualityPlugin({
-        findingsUrl: config.quality.findingsUrl,
-        checkUrl: config.quality.checkUrl,
-        csrfToken: () => window.getCsrfToken(),
-      }),
-    );
-  }
+  const plugins = await loadEditorPlugins(config.plugins, {
+    features,
+    bundledModule: editorModule,
+    csrfToken: () => window.getCsrfToken(),
+  });
 
   mountEditor({
     container: container,

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -8,7 +8,6 @@
     <th:block th:replace="~{fragments/htmx :: htmx}" />
     <link rel="stylesheet" th:href="@{/css/shell.css}">
     <link rel="stylesheet" th:href="@{/editor/template-editor.css}">
-    <link rel="stylesheet" th:href="@{/editor/ai-plugin.css}" th:if="${editorFeatures['aiChat']['enabled']}">
     <style>
         .editor-page {
             display: flex;
@@ -81,7 +80,6 @@
     <script type="application/json" id="editor-config" th:inline="javascript">
     {
         "editorModuleUrl": [[@{/editor/template-editor.js}]],
-        "aiPluginUrl": [[@{/editor/ai-plugin.js}]],
         "templateModel": [[${templateModel}]],
         "templateId": [[${templateId}]],
         "tenantId": [[${tenantId}]],
@@ -91,10 +89,24 @@
         "dataModel": [[${dataModel}]],
         "locale": [[${resolvedLocale}]],
         "features": [[${editorFeatures}]],
-        "quality": {
-            "findingsUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]],
-            "checkUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality/check(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]]
-        }
+        "plugins": [
+            {
+                "id": "ai",
+                "feature": "aiChat",
+                "moduleUrl": [[@{/editor/ai-plugin.js}]],
+                "stylesheetUrl": [[@{/editor/ai-plugin.css}]],
+                "factoryExport": "createEditorPlugin"
+            },
+            {
+                "id": "quality",
+                "feature": "quality",
+                "factoryExport": "createQualityEditorPlugin",
+                "config": {
+                    "findingsUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]],
+                    "checkUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality/check(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]]
+                }
+            }
+        ]
     }
     </script>
     <script type="module" th:src="@{/js/editor-boot.js}"></script>

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -8,7 +8,7 @@
     <th:block th:replace="~{fragments/htmx :: htmx}" />
     <link rel="stylesheet" th:href="@{/css/shell.css}">
     <link rel="stylesheet" th:href="@{/editor/template-editor.css}">
-    <link rel="stylesheet" th:href="@{/editor/ai-plugin.css}" th:if="${featureFlags['aiChat']}">
+    <link rel="stylesheet" th:href="@{/editor/ai-plugin.css}" th:if="${editorFeatures['aiChat']['enabled']}">
     <style>
         .editor-page {
             display: flex;
@@ -90,14 +90,7 @@
         "dataExamples": [[${dataExamples}]],
         "dataModel": [[${dataModel}]],
         "locale": [[${resolvedLocale}]],
-        "featureFlags": [[${featureFlags}]],
-        "ai": {
-            "enabled": [[${featureFlags['aiChat']}]],
-            "badge": {
-                "label": [[${aiChatStage.label}]],
-                "className": [[${aiChatStage.badgeClass}]]
-            }
-        },
+        "features": [[${editorFeatures}]],
         "quality": {
             "findingsUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]],
             "checkUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality/check(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]]

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -8,10 +8,7 @@
     <th:block th:replace="~{fragments/htmx :: htmx}" />
     <link rel="stylesheet" th:href="@{/css/shell.css}">
     <link rel="stylesheet" th:href="@{/editor/template-editor.css}">
-    <!-- AI plugin CSS — loaded conditionally when AI plugin is enabled -->
-    <link rel="stylesheet" th:href="@{/editor/ai-plugin.css}" th:if="${enabledPlugins != null and enabledPlugins.contains('ai')}">
-    <!-- TODO: Remove static fallback once backend provides enabledPlugins -->
-    <link rel="stylesheet" th:href="@{/editor/ai-plugin.css}" th:if="${enabledPlugins == null}">
+    <link rel="stylesheet" th:href="@{/editor/ai-plugin.css}" th:if="${featureFlags['aiChat']}">
     <style>
         .editor-page {
             display: flex;
@@ -94,6 +91,13 @@
         "dataModel": [[${dataModel}]],
         "locale": [[${resolvedLocale}]],
         "featureFlags": [[${featureFlags}]],
+        "ai": {
+            "enabled": [[${featureFlags['aiChat']}]],
+            "badge": {
+                "label": [[${aiChatStage.label}]],
+                "className": [[${aiChatStage.badgeClass}]]
+            }
+        },
         "quality": {
             "findingsUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]],
             "checkUrl": [[@{/tenants/{tenantId}/templates/{catalogId}/{id}/variants/{variantId}/quality/check(tenantId=${tenantId},catalogId=${catalogId},id=${templateId},variantId=${variantId})}]]

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/FeatureTogglePageHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/FeatureTogglePageHtmxTest.kt
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus
 
 /**
  * Verifies the admin Features page renders feature display metadata: the human title (not the raw
- * key) and the maturity badge for non-stable features (Backups is Beta).
+ * key) and the maturity badge for non-stable features.
  */
 class FeatureTogglePageHtmxTest : BaseIntegrationTest() {
 
@@ -17,7 +17,7 @@ class FeatureTogglePageHtmxTest : BaseIntegrationTest() {
     private lateinit var restTemplate: TestRestTemplate
 
     @Test
-    fun `features page shows titles and the beta badge for backups`() {
+    fun `features page shows titles and maturity badges`() {
         val tenant = createTenant("Features Page")
 
         val response = restTemplate.getForEntity("/tenants/${tenant.id.value}/features", String::class.java)
@@ -30,5 +30,9 @@ class FeatureTogglePageHtmxTest : BaseIntegrationTest() {
         assertThat(body).contains(">Beta<")
         // The toggle checkbox still posts under the raw feature key.
         assertThat(body).contains("name=\"support-backups\"")
+        assertThat(body).contains("AI Chat")
+        assertThat(body).contains("badge badge-alpha")
+        assertThat(body).contains(">Alpha<")
+        assertThat(body).contains("name=\"ai-chat\"")
     }
 }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/quality/QualityHandlerHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/quality/QualityHandlerHtmxTest.kt
@@ -355,8 +355,8 @@ class QualityHandlerHtmxTest : BaseIntegrationTest() {
         )
 
         val body = response.body!!
-        assertThat(body).contains("\"featureFlags\"")
-        assertThat(body).contains("\"quality\":true")
+        assertThat(body).contains("\"features\"")
+        assertThat(body).contains("\"quality\":{\"enabled\":true")
         assertThat(body).contains(
             "/tenants/${subject.tenantKey.value}/templates/${subject.catalogKey.value}" +
                 "/${subject.templateKey.value}/variants/${subject.variantKey}/quality",

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/quality/QualityHandlerHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/quality/QualityHandlerHtmxTest.kt
@@ -357,6 +357,8 @@ class QualityHandlerHtmxTest : BaseIntegrationTest() {
         val body = response.body!!
         assertThat(body).contains("\"features\"")
         assertThat(body).contains("\"quality\":{\"enabled\":true")
+        assertThat(body).contains("\"id\": \"quality\"")
+        assertThat(body).contains("\"factoryExport\": \"createQualityEditorPlugin\"")
         assertThat(body).contains(
             "/tenants/${subject.tenantKey.value}/templates/${subject.catalogKey.value}" +
                 "/${subject.templateKey.value}/variants/${subject.variantKey}/quality",

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -8,6 +8,8 @@ import app.epistola.suite.common.ids.TemplateId
 import app.epistola.suite.common.ids.TemplateKey
 import app.epistola.suite.common.ids.TenantId
 import app.epistola.suite.common.ids.VariantKey
+import app.epistola.suite.features.KnownFeatures
+import app.epistola.suite.features.commands.SaveFeatureToggle
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.templates.commands.CreateDocumentTemplate
 import app.epistola.suite.templates.commands.UpdateDocumentTemplate
@@ -1356,6 +1358,40 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
                 assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
                 assertThat(response.body).contains("id=\"editor-container\"")
                 assertThat(response.body).contains("/editor/template-editor-")
+                assertThat(response.body).contains("\"ai\": {")
+                assertThat(response.body).contains("\"enabled\": false")
+                assertThat(response.body).doesNotContain("/editor/ai-plugin.css")
+            }
+        }
+
+        @Test
+        fun `GET editor page includes AI assets when ai chat is enabled`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+            var variantId: VariantKey? = null
+
+            given {
+                testTenant = tenant("AI Editor Tenant")
+                template = template(testTenant, "AI Editor Template")
+                variantId = variant(testTenant, template, "Default").id
+                SaveFeatureToggle(testTenant.id, KnownFeatures.AI_CHAT, enabled = true).execute()
+            }
+
+            whenever {
+                restTemplate.getForEntity(
+                    "/tenants/${testTenant.id}/templates/default/${template.id}/variants/$variantId/editor",
+                    String::class.java,
+                )
+            }
+
+            then {
+                val response = result<org.springframework.http.ResponseEntity<String>>()
+                assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+                assertThat(response.body).contains("/editor/ai-plugin-")
+                assertThat(response.body).contains("\"ai\": {")
+                assertThat(response.body).contains("\"enabled\": true")
+                assertThat(response.body).contains("\"label\": \"Alpha\"")
+                assertThat(response.body).contains("\"className\": \"badge-alpha\"")
             }
         }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -1358,8 +1358,9 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
                 assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
                 assertThat(response.body).contains("id=\"editor-container\"")
                 assertThat(response.body).contains("/editor/template-editor-")
-                assertThat(response.body).contains("\"ai\": {")
-                assertThat(response.body).contains("\"enabled\": false")
+                assertThat(response.body).contains("\"features\": {")
+                assertThat(response.body).contains("\"aiChat\":{\"enabled\":false")
+                assertThat(response.body).contains("\"badge\":{\"label\":\"Alpha\",\"className\":\"badge-alpha\"}")
                 assertThat(response.body).doesNotContain("/editor/ai-plugin.css")
             }
         }
@@ -1388,10 +1389,9 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
                 val response = result<org.springframework.http.ResponseEntity<String>>()
                 assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
                 assertThat(response.body).contains("/editor/ai-plugin-")
-                assertThat(response.body).contains("\"ai\": {")
-                assertThat(response.body).contains("\"enabled\": true")
-                assertThat(response.body).contains("\"label\": \"Alpha\"")
-                assertThat(response.body).contains("\"className\": \"badge-alpha\"")
+                assertThat(response.body).contains("\"features\": {")
+                assertThat(response.body).contains("\"aiChat\":{\"enabled\":true")
+                assertThat(response.body).contains("\"badge\":{\"label\":\"Alpha\",\"className\":\"badge-alpha\"}")
             }
         }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -1361,7 +1361,9 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
                 assertThat(response.body).contains("\"features\": {")
                 assertThat(response.body).contains("\"aiChat\":{\"enabled\":false")
                 assertThat(response.body).contains("\"badge\":{\"label\":\"Alpha\",\"className\":\"badge-alpha\"}")
-                assertThat(response.body).doesNotContain("/editor/ai-plugin.css")
+                assertThat(response.body).contains("\"moduleUrl\": \"/editor/ai-plugin-")
+                assertThat(response.body).contains("\"stylesheetUrl\": \"/editor/ai-plugin-")
+                assertThat(response.body).doesNotContain("<link rel=\"stylesheet\" href=\"/editor/ai-plugin-")
             }
         }
 
@@ -1388,7 +1390,9 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
             then {
                 val response = result<org.springframework.http.ResponseEntity<String>>()
                 assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-                assertThat(response.body).contains("/editor/ai-plugin-")
+                assertThat(response.body).contains("\"moduleUrl\": \"/editor/ai-plugin-")
+                assertThat(response.body).contains("\"stylesheetUrl\": \"/editor/ai-plugin-")
+                assertThat(response.body).doesNotContain("<link rel=\"stylesheet\" href=\"/editor/ai-plugin-")
                 assertThat(response.body).contains("\"features\": {")
                 assertThat(response.body).contains("\"aiChat\":{\"enabled\":true")
                 assertThat(response.body).contains("\"badge\":{\"label\":\"Alpha\",\"className\":\"badge-alpha\"}")

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the design for the AI assistant plugin — the first plugin built on Epistola's [plugin architecture](plugins.md). The AI plugin enables users to build and modify templates through a conversational interface — describing what they want in natural language and having the AI produce structural changes to the template document.
+This document describes the design for the AI assistant plugin — the first plugin built on Epistola's [plugin architecture](plugins.md). The AI plugin enables users to build and modify templates through a conversational interface — describing what they want in natural language and having the AI produce structural changes to the template document. The current editor tab is an alpha surface behind the per-tenant `ai-chat` feature toggle, which is disabled by default.
 
 For the general plugin model (backend auto-configuration, frontend `EditorPlugin` interface, dynamic sidebar), see [docs/plugins.md](plugins.md). This document focuses on the AI-specific design.
 
@@ -441,19 +441,18 @@ export class EpistolaAiPanel extends LitElement {
 
 ### Host Page Wiring
 
-The host page (Thymeleaf) conditionally constructs the AI plugin based on backend-provided `enabledPlugins` data. HTTP concerns (endpoint URLs, CSRF tokens) stay in the host page — the plugin receives them via its factory function:
+The host page (Thymeleaf) conditionally constructs the current AI plugin based on the resolved `ai-chat` feature toggle in the editor config JSON. The alpha tab uses the mock transport until the backend AI module is wired:
 
 ```javascript
 // editor.html — conditional AI plugin loading
 const plugins = [];
 
-if (window.ENABLED_PLUGINS.includes("ai")) {
-  const { createAiPlugin } = await import("/editor/plugins/ai.js");
+if (config.ai?.enabled) {
+  const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
   plugins.push(
     createAiPlugin({
-      tenantId: window.TENANT_ID,
-      templateId: window.TEMPLATE_ID,
-      getCsrfToken: window.getCsrfToken,
+      sendMessage: createMockTransport(),
+      badge: config.ai.badge,
     }),
   );
 }
@@ -642,7 +641,7 @@ Plugin infrastructure (prerequisite — benefits all future plugins):
 - Plugin lifecycle in `EpistolaEditor.ts` (init/dispose)
 - `plugins` array on `EditorOptions`
 - Backend `EpistolaPlugin` marker interface in `epistola-core`
-- `enabledPlugins` Thymeleaf model attribute + conditional loading in `editor.html`
+- Backend-provided editor config + conditional loading in `editor.html`
 
 AI plugin backend:
 - `modules/plugins/ai/` Gradle module with auto-configuration
@@ -780,6 +779,6 @@ The plugin sidebar tab approach means the AI tab only appears when the plugin is
 | `modules/editor/src/main/typescript/engine/commands.ts` | Command types (InsertNode, RemoveNode, MoveNode, etc.) the AI must produce |
 | `modules/editor/src/main/typescript/engine/registry.ts` | Component definitions and types available for the system prompt |
 | `modules/editor/src/main/typescript/ui/preview-service.ts` | Reference pattern for `AiChatService` (state machine, abort, dispose) |
-| `apps/epistola/src/main/resources/templates/templates/editor.html` | Host page — conditional plugin loading, `ENABLED_PLUGINS` |
+| `apps/epistola/src/main/resources/templates/templates/editor.html` | Host page — feature-gated conditional plugin loading |
 | `apps/epistola/src/main/resources/application.yaml` | Where `epistola.plugins.ai.*` configuration goes |
 ````

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -441,25 +441,21 @@ export class EpistolaAiPanel extends LitElement {
 
 ### Host Page Wiring
 
-The host page (Thymeleaf) conditionally constructs the current AI plugin based on the resolved `ai-chat` feature toggle in the editor config JSON. The alpha tab uses the mock transport until the backend AI module is wired:
+The host page (Thymeleaf) declares the AI plugin as an editor plugin descriptor. The generic plugin loader checks the resolved `ai-chat` feature state before importing the AI entry point, so disabled tenants do not load the AI plugin JavaScript or stylesheet. The alpha tab uses the mock transport until the backend AI module is wired:
 
 ```javascript
-// editor.html — conditional AI plugin loading
-const plugins = [];
-
-if (config.ai?.enabled) {
-  const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
-  plugins.push(
-    createAiPlugin({
-      sendMessage: createMockTransport(),
-      badge: config.ai.badge,
-    }),
-  );
-}
+const features = config.features ?? {};
+const editorModule = await import(config.editorModuleUrl);
+const plugins = await editorModule.loadEditorPlugins(config.plugins, {
+  features,
+  bundledModule: editorModule,
+  csrfToken: () => window.getCsrfToken(),
+});
 
 mountEditor({
   container: document.getElementById("editor-container"),
   template: window.TEMPLATE_MODEL,
+  features,
   plugins,
   onSave: async (template) => {
     /* ... */

--- a/docs/feature-toggles.md
+++ b/docs/feature-toggles.md
@@ -140,5 +140,7 @@ rule in `components.css`.
 | `support-feedback`            | Support → Feedback (local; hub sync gated on the support tier)       | Stable | `true`  |
 | `support-backups`             | Support → Backups (faithful full-fidelity tenant backups + restore)  | Beta   | tier\*  |
 | `support-compatibility-check` | Support → Upgrading (compatibility checks against upcoming releases) | Stable | tier\*  |
+| `quality`                     | Quality checks ledger, report, and template-editor panel             | Alpha  | `false` |
+| `ai-chat`                     | AI chat panel in the template editor                                 | Alpha  | `false` |
 
 \* Hub-only features (`KnownFeatures.HUB_ONLY`) default to `epistola.support.enabled` — see above.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,7 +8,7 @@ Epistola plugins are optional, self-contained feature modules that extend the ed
 - **Frontend editor UI** — sidebar tabs, toolbar actions, custom panels
 - **Configuration** — per-plugin settings under the `epistola.plugins.<name>` namespace
 
-Plugins are **disabled by default** and explicitly enabled via configuration:
+Backend plugins are **disabled by default** and explicitly enabled via configuration:
 
 ```yaml
 epistola:
@@ -17,7 +17,7 @@ epistola:
       enabled: true
 ```
 
-The AI assistant (see [docs/ai.md](ai.md)) is the first plugin built on this architecture. The design should support future plugins such as version history, collaboration, or analytics.
+The AI assistant (see [docs/ai.md](ai.md)) is the first plugin built on this architecture. Its current editor tab is also hidden behind the per-tenant `ai-chat` feature toggle, which is alpha and off by default, so the browser does not load the AI plugin bundle unless that toggle is enabled.
 
 ---
 
@@ -130,7 +130,7 @@ fun aiPlugin(): EpistolaPlugin = object : EpistolaPlugin {
 This enables:
 
 - A `/plugins` UI handler endpoint that lists active plugins (for the frontend to know which plugins to load)
-- A Thymeleaf model attribute (`enabledPlugins`) injected into editor pages
+- Backend-provided editor config that tells host pages which plugin bundles to load
 - Admin/diagnostic visibility into which plugins are active
 
 ### Configuration Pattern
@@ -356,12 +356,16 @@ disconnectedCallback() {
 
 ### Host Page Wiring
 
-The Thymeleaf host page conditionally constructs plugin instances based on backend-provided data about which plugins are enabled:
+The Thymeleaf host page conditionally constructs plugin instances based on backend-provided data. The current AI chat surface uses the resolved per-tenant `ai-chat` feature toggle in the editor config JSON:
 
 ```html
 <!-- editor.html -->
-<script th:inline="javascript">
-  window.ENABLED_PLUGINS = /*[[${enabledPlugins}]]*/ [];
+<script type="application/json" id="editor-config" th:inline="javascript">
+  {
+    "ai": {
+      "enabled": [[${featureFlags['aiChat']}]]
+    }
+  }
 </script>
 ```
 
@@ -369,13 +373,12 @@ The Thymeleaf host page conditionally constructs plugin instances based on backe
 // Editor mount script — conditional plugin loading
 const plugins = [];
 
-if (window.ENABLED_PLUGINS.includes("ai")) {
-  const { createAiPlugin } = await import("/editor/plugins/ai.js");
+if (config.ai?.enabled) {
+  const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
   plugins.push(
     createAiPlugin({
-      tenantId: window.TENANT_ID,
-      templateId: window.TEMPLATE_ID,
-      getCsrfToken: window.getCsrfToken,
+      sendMessage: createMockTransport(),
+      badge: config.ai.badge,
     }),
   );
 }
@@ -390,8 +393,8 @@ mountEditor({
 
 This pattern:
 
-- Only loads plugin JS when the plugin is enabled (code splitting)
-- Passes host-page concerns (tenant context, CSRF) to the plugin factory
+- Only loads plugin JS when the feature/plugin is enabled (code splitting)
+- Passes host-page concerns to the plugin factory
 - Keeps the editor module unaware of specific plugin implementations
 
 ---
@@ -431,7 +434,7 @@ These constraints keep the plugin surface area small and predictable. They can b
 
 ### 4. Dynamic Import for Plugin Frontend Code
 
-**Decision**: Plugin frontend code is loaded via dynamic `import()` in the host page, conditional on `ENABLED_PLUGINS`.
+**Decision**: Plugin frontend code is loaded via dynamic `import()` in the host page, conditional on backend-provided editor config such as the resolved `ai-chat` feature toggle.
 
 **Rationale**: This keeps the main editor bundle small. Plugin code is only loaded when needed. The alternative (always bundling all plugin code) would increase the initial load even when plugins are disabled.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -356,7 +356,7 @@ disconnectedCallback() {
 
 ### Host Page Wiring
 
-The Thymeleaf host page conditionally constructs plugin instances based on backend-provided data. The current AI chat surface uses the resolved per-tenant `ai-chat` feature toggle in the editor config JSON:
+The Thymeleaf host page declares available plugin descriptors and resolved feature state. The generic editor plugin loader skips disabled descriptors before importing plugin code, so lazy plugins such as AI stay out of the page until their feature is enabled.
 
 ```html
 <!-- editor.html -->
@@ -367,25 +367,28 @@ The Thymeleaf host page conditionally constructs plugin instances based on backe
         "enabled": [[${editorFeatures['aiChat']['enabled']}]],
         "badge": [[${editorFeatures['aiChat']['badge']}]]
       }
-    }
+    },
+    "plugins": [
+      {
+        "id": "ai",
+        "feature": "aiChat",
+        "moduleUrl": [[@{/editor/ai-plugin.js}]],
+        "stylesheetUrl": [[@{/editor/ai-plugin.css}]],
+        "factoryExport": "createEditorPlugin"
+      }
+    ]
   }
 </script>
 ```
 
 ```javascript
-// Editor mount script — conditional plugin loading
-const plugins = [];
 const features = config.features ?? {};
-
-if (features.aiChat?.enabled) {
-  const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
-  plugins.push(
-    createAiPlugin({
-      sendMessage: createMockTransport(),
-      badge: features.aiChat.badge,
-    }),
-  );
-}
+const editorModule = await import(config.editorModuleUrl);
+const plugins = await editorModule.loadEditorPlugins(config.plugins, {
+  features,
+  bundledModule: editorModule,
+  csrfToken: () => window.getCsrfToken(),
+});
 
 mountEditor({
   container: document.getElementById("editor-container"),
@@ -399,8 +402,8 @@ mountEditor({
 This pattern:
 
 - Only loads plugin JS when the feature/plugin is enabled (code splitting)
-- Passes host-page concerns to the plugin factory
-- Keeps the editor module unaware of specific plugin implementations
+- Passes host-page concerns through plugin descriptor config
+- Keeps page bootstrap code unaware of specific plugin implementations
 
 ---
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -362,8 +362,11 @@ The Thymeleaf host page conditionally constructs plugin instances based on backe
 <!-- editor.html -->
 <script type="application/json" id="editor-config" th:inline="javascript">
   {
-    "ai": {
-      "enabled": [[${featureFlags['aiChat']}]]
+    "features": {
+      "aiChat": {
+        "enabled": [[${editorFeatures['aiChat']['enabled']}]],
+        "badge": [[${editorFeatures['aiChat']['badge']}]]
+      }
     }
   }
 </script>
@@ -372,13 +375,14 @@ The Thymeleaf host page conditionally constructs plugin instances based on backe
 ```javascript
 // Editor mount script — conditional plugin loading
 const plugins = [];
+const features = config.features ?? {};
 
-if (config.ai?.enabled) {
+if (features.aiChat?.enabled) {
   const { createAiPlugin, createMockTransport } = await import(config.aiPluginUrl);
   plugins.push(
     createAiPlugin({
       sendMessage: createMockTransport(),
-      badge: config.ai.badge,
+      badge: features.aiChat.badge,
     }),
   );
 }
@@ -386,6 +390,7 @@ if (config.ai?.enabled) {
 mountEditor({
   container: document.getElementById("editor-container"),
   template: window.TEMPLATE_MODEL,
+  features,
   plugins,
   // ... other options
 });

--- a/modules/editor/src/main/typescript/ai-plugin-lib.ts
+++ b/modules/editor/src/main/typescript/ai-plugin-lib.ts
@@ -12,8 +12,12 @@
 
 import './styles/ai-panel.css';
 
-export { createAiPlugin, type AiPluginOptions } from './plugins/ai/ai-plugin.js';
-export { createMockTransport, type MockTransportOptions } from './plugins/ai/mock-transport.js';
+import type { EditorPluginFactoryContext } from './plugins/plugin-loader.js';
+import { createAiPlugin, type AiPluginOptions } from './plugins/ai/ai-plugin.js';
+import { createMockTransport, type MockTransportOptions } from './plugins/ai/mock-transport.js';
+
+export { createAiPlugin, createMockTransport };
+export type { AiPluginOptions, MockTransportOptions };
 export type {
   SendMessageFn,
   ChatRequest,
@@ -21,3 +25,10 @@ export type {
   ChatAttachment,
   AiProposal,
 } from './plugins/ai/types.js';
+
+export function createEditorPlugin(context: EditorPluginFactoryContext) {
+  return createAiPlugin({
+    sendMessage: createMockTransport(),
+    badge: context.feature.badge ?? undefined,
+  });
+}

--- a/modules/editor/src/main/typescript/engine/EditorEngine.ts
+++ b/modules/editor/src/main/typescript/engine/EditorEngine.ts
@@ -18,7 +18,13 @@ import { CommandChange } from './command-change.js';
 import { TextChange } from './text-change.js';
 import type { TextChangeOps } from './undo.js';
 import { type ComponentRegistry, isAnchoredPageBlock } from './registry.js';
-import type { EditorFeatureFlags, EditorFeatureFlag } from './feature-flags.js';
+import {
+  featuresToFlags,
+  flagsToFeatures,
+  type EditorFeatures,
+  type EditorFeatureFlag,
+  type EditorFeatureFlags,
+} from './feature-flags.js';
 import { DEFAULT_LOCALE } from './locale.js';
 import { deepFreeze } from './freeze.js';
 import { defaultStyleRegistry } from './style-registry.js';
@@ -54,11 +60,14 @@ export class EditorEngine {
   private _fieldPathsCache: FieldPath[] | undefined;
 
   /**
-   * Resolved feature flags forwarded by the host. The contract is the
-   * `EditorFeatureFlags` interface; `isFeatureEnabled(flag)` is the typed
-   * read API and catches typos at the call site. Always defined; an
-   * unset flag reads as `false`.
+   * Resolved feature state forwarded by the host. The contract is the
+   * `EditorFeatures` interface; `isFeatureEnabled(flag)` is the typed boolean
+   * read API and catches typos at the call site. Always defined; an unset
+   * feature reads as disabled.
    */
+  readonly features: Readonly<EditorFeatures>;
+
+  /** Derived boolean flags kept for callers that still read the old property. */
   readonly featureFlags: Readonly<EditorFeatureFlags>;
 
   /**
@@ -89,6 +98,7 @@ export class EditorEngine {
       undoDepth?: number;
       dataModel?: object;
       dataExamples?: object[];
+      features?: EditorFeatures;
       featureFlags?: EditorFeatureFlags;
       locale?: string;
     },
@@ -102,7 +112,10 @@ export class EditorEngine {
     this._inheritableKeys = getInheritableKeys(this.styleRegistry);
     this._dataModel = options?.dataModel;
     this._dataExamples = options?.dataExamples;
-    this.featureFlags = Object.freeze({ ...options?.featureFlags });
+    this.features = Object.freeze({
+      ...(options?.features ?? flagsToFeatures(options?.featureFlags)),
+    });
+    this.featureFlags = Object.freeze(featuresToFlags(this.features));
     this.locale =
       options?.locale && options.locale.trim().length > 0 ? options.locale : DEFAULT_LOCALE;
     this._recomputeStyles();
@@ -143,12 +156,12 @@ export class EditorEngine {
 
   /**
    * Returns true when the named flag is set to `true` on the engine.
-   * The `flag` parameter is constrained to keys of `EditorFeatureFlags`
+   * The `flag` parameter is constrained to keys of `EditorFeatures`
    * so typos fail the compile rather than silently reading `undefined`.
    * Unset flags read as `false`.
    */
   isFeatureEnabled(flag: EditorFeatureFlag): boolean {
-    return this.featureFlags[flag] === true;
+    return this.features[flag]?.enabled === true;
   }
 
   // -----------------------------------------------------------------------

--- a/modules/editor/src/main/typescript/engine/EditorEngine.ts
+++ b/modules/editor/src/main/typescript/engine/EditorEngine.ts
@@ -18,13 +18,7 @@ import { CommandChange } from './command-change.js';
 import { TextChange } from './text-change.js';
 import type { TextChangeOps } from './undo.js';
 import { type ComponentRegistry, isAnchoredPageBlock } from './registry.js';
-import {
-  featuresToFlags,
-  flagsToFeatures,
-  type EditorFeatures,
-  type EditorFeatureFlag,
-  type EditorFeatureFlags,
-} from './feature-flags.js';
+import type { EditorFeatures, EditorFeatureFlag } from './feature-flags.js';
 import { DEFAULT_LOCALE } from './locale.js';
 import { deepFreeze } from './freeze.js';
 import { defaultStyleRegistry } from './style-registry.js';
@@ -67,9 +61,6 @@ export class EditorEngine {
    */
   readonly features: Readonly<EditorFeatures>;
 
-  /** Derived boolean flags kept for callers that still read the old property. */
-  readonly featureFlags: Readonly<EditorFeatureFlags>;
-
   /**
    * Effective BCP-47 locale for this editing session. Resolved by the host
    * (variant attribute `system.locale`/`locale` → tenant default → app
@@ -99,7 +90,6 @@ export class EditorEngine {
       dataModel?: object;
       dataExamples?: object[];
       features?: EditorFeatures;
-      featureFlags?: EditorFeatureFlags;
       locale?: string;
     },
   ) {
@@ -112,10 +102,7 @@ export class EditorEngine {
     this._inheritableKeys = getInheritableKeys(this.styleRegistry);
     this._dataModel = options?.dataModel;
     this._dataExamples = options?.dataExamples;
-    this.features = Object.freeze({
-      ...(options?.features ?? flagsToFeatures(options?.featureFlags)),
-    });
-    this.featureFlags = Object.freeze(featuresToFlags(this.features));
+    this.features = Object.freeze({ ...options?.features });
     this.locale =
       options?.locale && options.locale.trim().length > 0 ? options.locale : DEFAULT_LOCALE;
     this._recomputeStyles();

--- a/modules/editor/src/main/typescript/engine/feature-flags.test.ts
+++ b/modules/editor/src/main/typescript/engine/feature-flags.test.ts
@@ -14,22 +14,5 @@ describe('EditorEngine feature state', () => {
     expect(engine.isFeatureEnabled('quality')).toBe(true);
     expect(engine.isFeatureEnabled('aiChat')).toBe(false);
     expect(engine.features.quality?.badge).toEqual({ label: 'Alpha', className: 'badge-alpha' });
-    expect(engine.featureFlags).toEqual({ quality: true, aiChat: false });
-  });
-
-  it('accepts legacy boolean feature flags', () => {
-    const engine = new EditorEngine(createTestDocument(), testRegistry(), {
-      featureFlags: {
-        quality: true,
-        aiChat: false,
-      },
-    });
-
-    expect(engine.isFeatureEnabled('quality')).toBe(true);
-    expect(engine.isFeatureEnabled('aiChat')).toBe(false);
-    expect(engine.features).toEqual({
-      quality: { enabled: true },
-      aiChat: { enabled: false },
-    });
   });
 });

--- a/modules/editor/src/main/typescript/engine/feature-flags.test.ts
+++ b/modules/editor/src/main/typescript/engine/feature-flags.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { EditorEngine } from './EditorEngine.js';
+import { createTestDocument, testRegistry } from './test-helpers.js';
+
+describe('EditorEngine feature state', () => {
+  it('reads enablement from feature configs', () => {
+    const engine = new EditorEngine(createTestDocument(), testRegistry(), {
+      features: {
+        quality: { enabled: true, badge: { label: 'Alpha', className: 'badge-alpha' } },
+        aiChat: { enabled: false, badge: { label: 'Alpha', className: 'badge-alpha' } },
+      },
+    });
+
+    expect(engine.isFeatureEnabled('quality')).toBe(true);
+    expect(engine.isFeatureEnabled('aiChat')).toBe(false);
+    expect(engine.features.quality?.badge).toEqual({ label: 'Alpha', className: 'badge-alpha' });
+    expect(engine.featureFlags).toEqual({ quality: true, aiChat: false });
+  });
+
+  it('accepts legacy boolean feature flags', () => {
+    const engine = new EditorEngine(createTestDocument(), testRegistry(), {
+      featureFlags: {
+        quality: true,
+        aiChat: false,
+      },
+    });
+
+    expect(engine.isFeatureEnabled('quality')).toBe(true);
+    expect(engine.isFeatureEnabled('aiChat')).toBe(false);
+    expect(engine.features).toEqual({
+      quality: { enabled: true },
+      aiChat: { enabled: false },
+    });
+  });
+});

--- a/modules/editor/src/main/typescript/engine/feature-flags.ts
+++ b/modules/editor/src/main/typescript/engine/feature-flags.ts
@@ -29,19 +29,3 @@ export interface EditorFeatures {
 }
 
 export type EditorFeatureFlag = keyof EditorFeatures;
-
-export type EditorFeatureFlags = Partial<Record<EditorFeatureFlag, boolean>>;
-
-export function featuresToFlags(features?: EditorFeatures): EditorFeatureFlags {
-  if (!features) return {};
-  return Object.fromEntries(
-    Object.entries(features).map(([key, feature]) => [key, feature?.enabled === true]),
-  ) as EditorFeatureFlags;
-}
-
-export function flagsToFeatures(flags?: EditorFeatureFlags): EditorFeatures {
-  if (!flags) return {};
-  return Object.fromEntries(
-    Object.entries(flags).map(([key, enabled]) => [key, { enabled: enabled === true }]),
-  ) as EditorFeatures;
-}

--- a/modules/editor/src/main/typescript/engine/feature-flags.ts
+++ b/modules/editor/src/main/typescript/engine/feature-flags.ts
@@ -1,19 +1,47 @@
 /**
- * Typed contract for editor feature flags.
+ * Typed contract for editor feature state.
  *
  * The host page resolves these from the backend's tenant-aware feature
- * toggle service and forwards them to `mountEditor`. The engine exposes
- * them via `engine.isFeatureEnabled(flag)`; consumers consult the engine
- * directly rather than threading boolean props through every component.
+ * toggle service and forwards them to `mountEditor`. Each feature carries
+ * resolved enablement plus optional UI metadata from the backend feature
+ * registry. The engine exposes booleans via `engine.isFeatureEnabled(flag)`;
+ * consumers consult the engine directly rather than threading boolean props
+ * through every component.
  *
  * To add one: add a field below, register the matching key in the backend's
- * `KnownFeatures`, and surface it on the host (Thymeleaf model → JSON config
- * → `mountEditor` options). The compile-time union on `isFeatureEnabled` then
+ * `KnownFeatures`, and surface it on the host (Thymeleaf model -> JSON config
+ * -> `mountEditor` options). The compile-time union on `isFeatureEnabled` then
  * catches typos at the call site.
  */
-export interface EditorFeatureFlags {
-  quality?: boolean;
-  aiChat?: boolean;
+export interface EditorFeatureBadge {
+  label: string;
+  className: string;
 }
 
-export type EditorFeatureFlag = keyof EditorFeatureFlags;
+export interface EditorFeatureConfig {
+  enabled: boolean;
+  badge?: EditorFeatureBadge | null;
+}
+
+export interface EditorFeatures {
+  quality?: EditorFeatureConfig;
+  aiChat?: EditorFeatureConfig;
+}
+
+export type EditorFeatureFlag = keyof EditorFeatures;
+
+export type EditorFeatureFlags = Partial<Record<EditorFeatureFlag, boolean>>;
+
+export function featuresToFlags(features?: EditorFeatures): EditorFeatureFlags {
+  if (!features) return {};
+  return Object.fromEntries(
+    Object.entries(features).map(([key, feature]) => [key, feature?.enabled === true]),
+  ) as EditorFeatureFlags;
+}
+
+export function flagsToFeatures(flags?: EditorFeatureFlags): EditorFeatures {
+  if (!flags) return {};
+  return Object.fromEntries(
+    Object.entries(flags).map(([key, enabled]) => [key, { enabled: enabled === true }]),
+  ) as EditorFeatures;
+}

--- a/modules/editor/src/main/typescript/engine/feature-flags.ts
+++ b/modules/editor/src/main/typescript/engine/feature-flags.ts
@@ -13,6 +13,7 @@
  */
 export interface EditorFeatureFlags {
   quality?: boolean;
+  aiChat?: boolean;
 }
 
 export type EditorFeatureFlag = keyof EditorFeatureFlags;

--- a/modules/editor/src/main/typescript/lib.ts
+++ b/modules/editor/src/main/typescript/lib.ts
@@ -14,7 +14,7 @@ import type { TemplateDocument, NodeId, SlotId } from './types/index.js';
 import type { FetchPreviewFn } from './ui/preview-service.js';
 import type { EditorPlugin } from './plugins/types.js';
 import { createDefaultRegistry } from './engine/registry.js';
-import type { EditorFeatures, EditorFeatureFlags } from './engine/feature-flags.js';
+import type { EditorFeatures } from './engine/feature-flags.js';
 import { createImageDefinition } from './components/image/image-registration.js';
 import type { AssetInfo, CatalogInfo } from './components/image/asset-picker-dialog.js';
 import { setFontCatalog, type FontInfo } from './engine/font-catalog.js';
@@ -122,8 +122,6 @@ export interface EditorOptions {
    * end-to-end and renames/removals fail the compile.
    */
   features?: EditorFeatures;
-  /** @deprecated Prefer `features`, which carries enablement and feature metadata. */
-  featureFlags?: EditorFeatureFlags;
   /**
    * Effective BCP-47 locale for this editing session. Resolved server-side
    * via the variant-attribute → tenant default → app default chain
@@ -138,7 +136,6 @@ export type {
   EditorFeatureBadge,
   EditorFeatureConfig,
   EditorFeatureFlag,
-  EditorFeatureFlags,
   EditorFeatures,
 } from './engine/feature-flags.js';
 
@@ -254,7 +251,6 @@ export function mountEditor(options: EditorOptions): EditorInstance {
     dataModel,
     dataExamples,
     features: options.features,
-    featureFlags: options.featureFlags,
     locale: options.locale,
   });
 

--- a/modules/editor/src/main/typescript/lib.ts
+++ b/modules/editor/src/main/typescript/lib.ts
@@ -45,11 +45,19 @@ export type {
 } from './components/stencil/types.js';
 export { EditorEngine } from './engine/EditorEngine.js';
 export { createQualityPlugin } from './ui/quality-plugin.js';
+export { createQualityEditorPlugin } from './ui/quality-plugin.js';
 export type {
   QualityFinding,
   QualityPanelData,
   QualityPluginOptions,
 } from './ui/quality-plugin.js';
+export { loadEditorPlugins } from './plugins/plugin-loader.js';
+export type {
+  EditorPluginDescriptor,
+  EditorPluginFactory,
+  EditorPluginFactoryContext,
+  EditorPluginLoadOptions,
+} from './plugins/plugin-loader.js';
 export { createDefaultRegistry, ComponentRegistry } from './engine/registry.js';
 export type {
   EditorPlugin,

--- a/modules/editor/src/main/typescript/lib.ts
+++ b/modules/editor/src/main/typescript/lib.ts
@@ -14,7 +14,7 @@ import type { TemplateDocument, NodeId, SlotId } from './types/index.js';
 import type { FetchPreviewFn } from './ui/preview-service.js';
 import type { EditorPlugin } from './plugins/types.js';
 import { createDefaultRegistry } from './engine/registry.js';
-import type { EditorFeatureFlags } from './engine/feature-flags.js';
+import type { EditorFeatures, EditorFeatureFlags } from './engine/feature-flags.js';
 import { createImageDefinition } from './components/image/image-registration.js';
 import type { AssetInfo, CatalogInfo } from './components/image/asset-picker-dialog.js';
 import { setFontCatalog, type FontInfo } from './engine/font-catalog.js';
@@ -105,15 +105,16 @@ export interface EditorOptions {
   /** Optional stencil support with search/get/upgrade callbacks. */
   stencilOptions?: StencilCallbacks;
   /**
-   * Optional feature toggles. The host page reads these from the backend's
-   * feature-toggle service and forwards the resolved booleans here. The
-   * engine exposes them via `engine.isFeatureEnabled(flag)`; components
-   * that need to gate preview/experimental affordances consult the engine
-   * directly rather than receiving flags through their own constructors.
+   * Optional feature state. The host page reads this from the backend's
+   * feature-toggle service and feature metadata registry. The engine exposes
+   * booleans via `engine.isFeatureEnabled(flag)`; host/plugin setup can read
+   * UI metadata such as badges directly from the same feature object.
    *
-   * The shape is governed by `EditorFeatureFlags` so flag names are typed
+   * The shape is governed by `EditorFeatures` so feature names are typed
    * end-to-end and renames/removals fail the compile.
    */
+  features?: EditorFeatures;
+  /** @deprecated Prefer `features`, which carries enablement and feature metadata. */
   featureFlags?: EditorFeatureFlags;
   /**
    * Effective BCP-47 locale for this editing session. Resolved server-side
@@ -125,7 +126,13 @@ export interface EditorOptions {
   locale?: string;
 }
 
-export type { EditorFeatureFlags, EditorFeatureFlag } from './engine/feature-flags.js';
+export type {
+  EditorFeatureBadge,
+  EditorFeatureConfig,
+  EditorFeatureFlag,
+  EditorFeatureFlags,
+  EditorFeatures,
+} from './engine/feature-flags.js';
 
 export interface EditorInstance {
   /** Tear down the editor and clean up */
@@ -238,6 +245,7 @@ export function mountEditor(options: EditorOptions): EditorInstance {
   editorEl.initEngine(doc, registry, {
     dataModel,
     dataExamples,
+    features: options.features,
     featureFlags: options.featureFlags,
     locale: options.locale,
   });

--- a/modules/editor/src/main/typescript/plugins/ai/ai-plugin.ts
+++ b/modules/editor/src/main/typescript/plugins/ai/ai-plugin.ts
@@ -18,6 +18,11 @@ export interface AiPluginOptions {
   sendMessage: SendMessageFn;
   /** Optional conversation ID (defaults to auto-generated) */
   conversationId?: string;
+  /** Optional maturity/status badge provided by the host feature metadata. */
+  badge?: {
+    label: string;
+    className: string;
+  };
 }
 
 export function createAiPlugin(options: AiPluginOptions): EditorPlugin {
@@ -29,6 +34,7 @@ export function createAiPlugin(options: AiPluginOptions): EditorPlugin {
     sidebarTab: {
       id: 'ai',
       label: 'AI',
+      badge: options.badge,
       icon: 'sparkles',
       render: (ctx: PluginContext) => {
         return html`

--- a/modules/editor/src/main/typescript/plugins/plugin-loader.test.ts
+++ b/modules/editor/src/main/typescript/plugins/plugin-loader.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadEditorPlugins, type EditorPluginDescriptor } from './plugin-loader.js';
+import type { EditorPlugin } from './types.js';
+
+const aiDescriptor: EditorPluginDescriptor = {
+  id: 'ai',
+  feature: 'aiChat',
+  moduleUrl: '/editor/ai-plugin.js',
+  stylesheetUrl: '/editor/ai-plugin.css',
+  factoryExport: 'createEditorPlugin',
+};
+
+describe('loadEditorPlugins', () => {
+  it('does not import a module for a disabled feature', async () => {
+    const importModule = vi.fn();
+
+    const plugins = await loadEditorPlugins([aiDescriptor], {
+      features: { aiChat: { enabled: false } },
+      importModule,
+    });
+
+    expect(plugins).toEqual([]);
+    expect(importModule).not.toHaveBeenCalled();
+  });
+
+  it('imports an enabled lazy plugin and passes feature metadata to the factory', async () => {
+    const plugin: EditorPlugin = { id: 'ai', init: () => () => {} };
+    const factory = vi.fn(() => plugin);
+    const importModule = vi.fn(async () => ({ createEditorPlugin: factory }));
+
+    const plugins = await loadEditorPlugins([aiDescriptor], {
+      features: {
+        aiChat: { enabled: true, badge: { label: 'Alpha', className: 'badge-alpha' } },
+      },
+      importModule,
+      csrfToken: () => 'csrf-token',
+    });
+
+    expect(importModule).toHaveBeenCalledWith('/editor/ai-plugin.js');
+    expect(factory).toHaveBeenCalledWith({
+      descriptor: aiDescriptor,
+      feature: { enabled: true, badge: { label: 'Alpha', className: 'badge-alpha' } },
+      config: undefined,
+      csrfToken: expect.any(Function),
+    });
+    expect(plugins).toEqual([plugin]);
+  });
+
+  it('loads an enabled plugin stylesheet once', async () => {
+    const appended: Array<{ rel?: string; href?: string; dataset: Record<string, string> }> = [];
+    const documentRef = {
+      head: {
+        querySelector: vi.fn().mockReturnValueOnce(null).mockReturnValueOnce({ rel: 'stylesheet' }),
+        appendChild: vi.fn((link) => appended.push(link)),
+      },
+      createElement: vi.fn(() => ({ dataset: {} })),
+    } as unknown as Document;
+
+    const importModule = vi.fn(async () => ({
+      createEditorPlugin: () => ({ id: 'ai', init: () => () => {} }),
+    }));
+
+    await loadEditorPlugins([aiDescriptor, aiDescriptor], {
+      features: { aiChat: { enabled: true } },
+      importModule,
+      document: documentRef,
+    });
+
+    expect(appended).toEqual([
+      {
+        rel: 'stylesheet',
+        href: '/editor/ai-plugin.css',
+        dataset: { editorPluginStyle: 'ai' },
+      },
+    ]);
+  });
+
+  it('ignores factories that return null', async () => {
+    const plugins = await loadEditorPlugins(
+      [{ id: 'quality', feature: 'quality', factoryExport: 'createQualityEditorPlugin' }],
+      {
+        features: { quality: { enabled: true } },
+        bundledModule: { createQualityEditorPlugin: () => null },
+      },
+    );
+
+    expect(plugins).toEqual([]);
+  });
+});

--- a/modules/editor/src/main/typescript/plugins/plugin-loader.ts
+++ b/modules/editor/src/main/typescript/plugins/plugin-loader.ts
@@ -1,0 +1,94 @@
+import type {
+  EditorFeatures,
+  EditorFeatureFlag,
+  EditorFeatureConfig,
+} from '../engine/feature-flags.js';
+import type { EditorPlugin } from './types.js';
+
+export interface EditorPluginDescriptor {
+  id: string;
+  feature: EditorFeatureFlag;
+  factoryExport: string;
+  moduleUrl?: string;
+  stylesheetUrl?: string;
+  config?: unknown;
+}
+
+export interface EditorPluginFactoryContext {
+  descriptor: EditorPluginDescriptor;
+  feature: EditorFeatureConfig;
+  config: unknown;
+  csrfToken: () => string;
+}
+
+export interface EditorPluginLoadOptions {
+  features?: EditorFeatures;
+  csrfToken?: () => string;
+  bundledModule?: Record<string, unknown>;
+  importModule?: (url: string) => Promise<Record<string, unknown>>;
+  document?: Document;
+  logger?: Pick<Console, 'warn'>;
+}
+
+export type EditorPluginFactory = (
+  context: EditorPluginFactoryContext,
+) => EditorPlugin | null | undefined | Promise<EditorPlugin | null | undefined>;
+
+export async function loadEditorPlugins(
+  descriptors: EditorPluginDescriptor[] = [],
+  options: EditorPluginLoadOptions = {},
+): Promise<EditorPlugin[]> {
+  const plugins: EditorPlugin[] = [];
+  const features = options.features ?? {};
+  const importModule = options.importModule ?? ((url: string) => import(/* @vite-ignore */ url));
+  const logger = options.logger ?? console;
+
+  for (const descriptor of descriptors) {
+    const feature = features[descriptor.feature];
+    if (feature?.enabled !== true) continue;
+
+    try {
+      loadStylesheet(descriptor, options.document ?? globalThis.document);
+      const pluginModule = descriptor.moduleUrl
+        ? await importModule(descriptor.moduleUrl)
+        : (options.bundledModule ?? {});
+      const factory = pluginModule[descriptor.factoryExport];
+      if (typeof factory !== 'function') {
+        throw new Error(`Plugin factory export '${descriptor.factoryExport}' was not found`);
+      }
+
+      const plugin = await (factory as EditorPluginFactory)({
+        descriptor,
+        feature,
+        config: descriptor.config,
+        csrfToken: options.csrfToken ?? (() => ''),
+      });
+      if (plugin) plugins.push(plugin);
+    } catch (e) {
+      logger.warn(`Editor plugin '${descriptor.id}' failed to load:`, e);
+    }
+  }
+
+  return plugins;
+}
+
+function loadStylesheet(
+  descriptor: EditorPluginDescriptor,
+  documentRef: Document | undefined,
+): void {
+  if (!descriptor.stylesheetUrl || !documentRef) return;
+  const existing = documentRef.head.querySelector(
+    `link[data-editor-plugin-style="${cssEscape(descriptor.id)}"]`,
+  );
+  if (existing) return;
+
+  const link = documentRef.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = descriptor.stylesheetUrl;
+  link.dataset.editorPluginStyle = descriptor.id;
+  documentRef.head.appendChild(link);
+}
+
+function cssEscape(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/modules/editor/src/main/typescript/plugins/plugins.test.ts
+++ b/modules/editor/src/main/typescript/plugins/plugins.test.ts
@@ -136,6 +136,7 @@ describe('SidebarTabContribution', () => {
     const tab: SidebarTabContribution = {
       id: 'ai-chat',
       label: 'AI Chat',
+      badge: { label: 'Alpha', className: 'badge-alpha' },
       icon: 'bot',
       render: (ctx) => html`<div>AI panel for ${ctx.doc.root}</div>`,
     };
@@ -145,6 +146,7 @@ describe('SidebarTabContribution', () => {
     expect(plugin.sidebarTab).toBeDefined();
     expect(plugin.sidebarTab!.id).toBe('ai-chat');
     expect(plugin.sidebarTab!.label).toBe('AI Chat');
+    expect(plugin.sidebarTab!.badge).toEqual({ label: 'Alpha', className: 'badge-alpha' });
     expect(plugin.sidebarTab!.icon).toBe('bot');
   });
 

--- a/modules/editor/src/main/typescript/plugins/types.ts
+++ b/modules/editor/src/main/typescript/plugins/types.ts
@@ -65,6 +65,12 @@ export interface SidebarTabContribution {
   /** Display label shown on the tab button */
   label: string;
 
+  /** Optional maturity/status badge shown next to the tab label. */
+  badge?: {
+    label: string;
+    className: string;
+  };
+
   /** Optional icon identifier (Lucide icon name) */
   icon?: string;
 

--- a/modules/editor/src/main/typescript/styles/sidebar.css
+++ b/modules/editor/src/main/typescript/styles/sidebar.css
@@ -76,6 +76,10 @@
   .sidebar-tab {
     flex: 0 0 auto;
     min-width: 5.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--ep-space-1);
     padding: var(--ep-space-2) var(--ep-space-2);
     font-size: 0.6875rem;
     font-weight: 600;
@@ -100,6 +104,12 @@
       color: var(--ep-primary-strong);
       border-bottom-color: var(--ep-primary);
     }
+  }
+
+  .sidebar-tab-badge {
+    font-size: 0.5625rem;
+    line-height: 1;
+    padding: 0.125rem 0.25rem;
   }
 
   .sidebar-content {

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
@@ -15,7 +15,7 @@ import {
   bindingErrorsForSaveState,
 } from '../components/stencil/binding-errors.js';
 import type { ComponentRegistry, ComponentDefinition } from '../engine/registry.js';
-import type { EditorFeatureFlags } from '../engine/feature-flags.js';
+import type { EditorFeatures, EditorFeatureFlags } from '../engine/feature-flags.js';
 import type { FetchPreviewFn } from './preview-service.js';
 import { SaveService, type SaveState, type SaveFn } from './save-service.js';
 import { EpistolaResizeHandle } from './EpistolaResizeHandle.js';
@@ -210,6 +210,7 @@ export class EpistolaEditor extends LitElement {
     options?: {
       dataModel?: object;
       dataExamples?: object[];
+      features?: EditorFeatures;
       featureFlags?: EditorFeatureFlags;
       locale?: string;
     },
@@ -225,6 +226,7 @@ export class EpistolaEditor extends LitElement {
     this._engine = new EditorEngine(doc, reg, {
       dataModel: options?.dataModel,
       dataExamples: options?.dataExamples,
+      features: options?.features,
       featureFlags: options?.featureFlags,
       locale: options?.locale,
     });

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
@@ -15,7 +15,7 @@ import {
   bindingErrorsForSaveState,
 } from '../components/stencil/binding-errors.js';
 import type { ComponentRegistry, ComponentDefinition } from '../engine/registry.js';
-import type { EditorFeatures, EditorFeatureFlags } from '../engine/feature-flags.js';
+import type { EditorFeatures } from '../engine/feature-flags.js';
 import type { FetchPreviewFn } from './preview-service.js';
 import { SaveService, type SaveState, type SaveFn } from './save-service.js';
 import { EpistolaResizeHandle } from './EpistolaResizeHandle.js';
@@ -211,7 +211,6 @@ export class EpistolaEditor extends LitElement {
       dataModel?: object;
       dataExamples?: object[];
       features?: EditorFeatures;
-      featureFlags?: EditorFeatureFlags;
       locale?: string;
     },
   ): void {
@@ -227,7 +226,6 @@ export class EpistolaEditor extends LitElement {
       dataModel: options?.dataModel,
       dataExamples: options?.dataExamples,
       features: options?.features,
-      featureFlags: options?.featureFlags,
       locale: options?.locale,
     });
     this._doc = this._engine.doc;

--- a/modules/editor/src/main/typescript/ui/EpistolaSidebar.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaSidebar.ts
@@ -16,6 +16,10 @@ import './EpistolaInspector.js';
 interface TabDefinition {
   id: string;
   label: string | (() => string);
+  badge?: {
+    label: string;
+    className: string;
+  };
   icon?: string;
   render: () => TemplateResult;
 }
@@ -189,6 +193,7 @@ export class EpistolaSidebar extends LitElement {
     const pluginDefs: TabDefinition[] = (this.pluginTabs ?? []).map((tab) => ({
       id: tab.id,
       label: tab.label,
+      badge: tab.badge,
       icon: tab.icon,
       render: () => {
         if (!this.pluginContext) return html``;
@@ -230,6 +235,11 @@ export class EpistolaSidebar extends LitElement {
                   @click=${() => this._setTab(tab.id)}
                 >
                   ${label}
+                  ${tab.badge
+                    ? html`<span class="sidebar-tab-badge badge ${tab.badge.className}"
+                        >${tab.badge.label}</span
+                      >`
+                    : nothing}
                 </button>
               `;
             })}

--- a/modules/editor/src/main/typescript/ui/quality-plugin.test.ts
+++ b/modules/editor/src/main/typescript/ui/quality-plugin.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment happy-dom
 
 import { describe, expect, it, vi } from 'vitest';
-import { EpistolaQualityPanel, type QualityFinding } from './quality-plugin.js';
+import {
+  createQualityEditorPlugin,
+  EpistolaQualityPanel,
+  type QualityFinding,
+} from './quality-plugin.js';
 import type { PluginContext } from '../plugins/types.js';
 
 function finding(overrides: Partial<QualityFinding> = {}): QualityFinding {
@@ -47,5 +51,28 @@ describe('EpistolaQualityPanel', () => {
     );
 
     expect(selectNode).not.toHaveBeenCalled();
+  });
+});
+
+describe('createQualityEditorPlugin', () => {
+  it('applies the feature badge to the sidebar tab', () => {
+    const plugin = createQualityEditorPlugin({
+      descriptor: {
+        id: 'quality',
+        feature: 'quality',
+        factoryExport: 'createQualityEditorPlugin',
+      },
+      feature: {
+        enabled: true,
+        badge: { label: 'Alpha', className: 'badge-alpha' },
+      },
+      config: {
+        findingsUrl: '/quality',
+        checkUrl: '/quality/check',
+      },
+      csrfToken: () => 'csrf-token',
+    });
+
+    expect(plugin?.sidebarTab?.badge).toEqual({ label: 'Alpha', className: 'badge-alpha' });
   });
 });

--- a/modules/editor/src/main/typescript/ui/quality-plugin.ts
+++ b/modules/editor/src/main/typescript/ui/quality-plugin.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { EditorPlugin, PluginContext } from '../plugins/types.js';
+import type { EditorPluginFactoryContext } from '../plugins/plugin-loader.js';
 import type { NodeId } from '../types/index.js';
 
 export interface QualityPluginOptions {
@@ -75,6 +76,16 @@ export function createQualityPlugin(options: QualityPluginOptions): EditorPlugin
     },
     init: () => () => {},
   };
+}
+
+export function createQualityEditorPlugin(
+  context: EditorPluginFactoryContext,
+): EditorPlugin | null {
+  if (!isQualityPluginOptions(context.config)) return null;
+  return createQualityPlugin({
+    ...context.config,
+    csrfToken: context.csrfToken,
+  });
 }
 
 @customElement('epistola-quality-panel')
@@ -228,6 +239,16 @@ function severityOrder(severity: string): number {
   if (severity === 'ERROR') return 0;
   if (severity === 'WARNING') return 1;
   return 2;
+}
+
+function isQualityPluginOptions(value: unknown): value is Omit<QualityPluginOptions, 'csrfToken'> {
+  if (!value || typeof value !== 'object') return false;
+  return (
+    'findingsUrl' in value &&
+    typeof value.findingsUrl === 'string' &&
+    'checkUrl' in value &&
+    typeof value.checkUrl === 'string'
+  );
 }
 
 declare global {

--- a/modules/editor/src/main/typescript/ui/quality-plugin.ts
+++ b/modules/editor/src/main/typescript/ui/quality-plugin.ts
@@ -2,12 +2,14 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { EditorPlugin, PluginContext } from '../plugins/types.js';
 import type { EditorPluginFactoryContext } from '../plugins/plugin-loader.js';
+import type { EditorFeatureBadge } from '../engine/feature-flags.js';
 import type { NodeId } from '../types/index.js';
 
 export interface QualityPluginOptions {
   findingsUrl: string;
   checkUrl: string;
   csrfToken: () => string;
+  badge?: EditorFeatureBadge | null;
 }
 
 export interface QualityPanelData {
@@ -68,6 +70,7 @@ export function createQualityPlugin(options: QualityPluginOptions): EditorPlugin
     sidebarTab: {
       id: 'quality',
       label: 'Quality',
+      badge: options.badge ?? undefined,
       render: (context) =>
         html`<epistola-quality-panel
           .service=${service}
@@ -85,6 +88,7 @@ export function createQualityEditorPlugin(
   return createQualityPlugin({
     ...context.config,
     csrfToken: context.csrfToken,
+    badge: context.feature.badge,
   });
 }
 

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureDefaults.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/FeatureDefaults.kt
@@ -20,10 +20,17 @@ data class FeatureDefaults(
      * deliberate edit and not a silent change of meaning.
      */
     val quality: Boolean = false,
+    /**
+     * AI chat in the template editor. This is an editor-only alpha surface for now, using the same
+     * toggle-only model as quality: no support-tier entitlement and no hub-only default. Off by
+     * default until the assistant surface is production-ready.
+     */
+    val aiChat: Boolean = false,
 ) {
     fun isEnabled(featureKey: FeatureKey): Boolean = when (featureKey) {
         KnownFeatures.SUPPORT_FEEDBACK -> supportFeedback
         KnownFeatures.QUALITY -> quality
+        KnownFeatures.AI_CHAT -> aiChat
         else -> false
     }
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/KnownFeatures.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/features/KnownFeatures.kt
@@ -29,8 +29,9 @@ object KnownFeatures {
      * `V20260618204750__core_rename_compatibility_check_feature_key.sql`).
      */
     val QUALITY = FeatureKey.of("quality")
+    val AI_CHAT = FeatureKey.of("ai-chat")
 
-    val all: List<FeatureKey> = listOf(SUPPORT_FEEDBACK, SUPPORT_BACKUPS, SUPPORT_COMPATIBILITY_CHECK, QUALITY)
+    val all: List<FeatureKey> = listOf(SUPPORT_FEEDBACK, SUPPORT_BACKUPS, SUPPORT_COMPATIBILITY_CHECK, QUALITY, AI_CHAT)
 
     /**
      * Features whose availability is gated by a hub **entitlement** when the support tier is enabled
@@ -88,6 +89,12 @@ object KnownFeatures {
             "Enables quality checks — a ledger of findings about templates, surfaced in a report and " +
                 "in the template editor. Findings are submitted by check sources (in-process or remote) " +
                 "and by reviewers; checks only ever analyse a template's example data.",
+            stage = FeatureStage.ALPHA,
+        ),
+        AI_CHAT to FeatureMetadata(
+            "AI Chat",
+            "Enables the alpha AI chat panel in the template editor. The current panel is an " +
+                "experimental editor assistant surface and is hidden by default.",
             stage = FeatureStage.ALPHA,
         ),
     )

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureDefaultsTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/FeatureDefaultsTest.kt
@@ -17,6 +17,13 @@ class FeatureDefaultsTest {
     }
 
     @Test
+    fun `alpha editor features default off here`() {
+        val defaults = FeatureDefaults()
+        assertFalse(defaults.isEnabled(KnownFeatures.QUALITY))
+        assertFalse(defaults.isEnabled(KnownFeatures.AI_CHAT))
+    }
+
+    @Test
     fun `hub-only features are not resolved here (their default follows the support tier)`() {
         // FeatureDefaults intentionally does not configure hub-only support features; FeatureToggleService
         // derives their default from epistola.support.enabled. isEnabled treats them as unknown → false.

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/KnownFeaturesTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/features/KnownFeaturesTest.kt
@@ -37,6 +37,12 @@ class KnownFeaturesTest {
         assertThat(KnownFeatures.HUB_ONLY).doesNotContain(KnownFeatures.QUALITY)
     }
 
+    @Test
+    fun `ai chat is toggle-only and never hub-gated`() {
+        assertThat(KnownFeatures.SUPPORT_TIER).doesNotContain(KnownFeatures.AI_CHAT)
+        assertThat(KnownFeatures.HUB_ONLY).doesNotContain(KnownFeatures.AI_CHAT)
+    }
+
     /**
      * Quality is alpha: the ledger's semantics are settled but its surfaces are not, and the
      * badge is how a tenant admin is told that on the Features page before switching it on.
@@ -44,6 +50,11 @@ class KnownFeaturesTest {
     @Test
     fun `quality is marked alpha`() {
         assertThat(KnownFeatures.stageOf(KnownFeatures.QUALITY)).isEqualTo(KnownFeatures.FeatureStage.ALPHA)
+    }
+
+    @Test
+    fun `ai chat is marked alpha`() {
+        assertThat(KnownFeatures.stageOf(KnownFeatures.AI_CHAT)).isEqualTo(KnownFeatures.FeatureStage.ALPHA)
     }
 
     /**
@@ -55,6 +66,12 @@ class KnownFeaturesTest {
     fun `quality default is off and resolved by its own branch`() {
         assertThat(FeatureDefaults().isEnabled(KnownFeatures.QUALITY)).isFalse()
         assertThat(FeatureDefaults(quality = true).isEnabled(KnownFeatures.QUALITY)).isTrue()
+    }
+
+    @Test
+    fun `ai chat default is off and resolved by its own branch`() {
+        assertThat(FeatureDefaults().isEnabled(KnownFeatures.AI_CHAT)).isFalse()
+        assertThat(FeatureDefaults(aiChat = true).isEnabled(KnownFeatures.AI_CHAT)).isTrue()
     }
 
     @Test

--- a/modules/epistola-quality/src/main/kotlin/app/epistola/suite/quality/ui/QualityHandler.kt
+++ b/modules/epistola-quality/src/main/kotlin/app/epistola/suite/quality/ui/QualityHandler.kt
@@ -431,7 +431,7 @@ class QualityHandler(
 
     private companion object {
         /**
-     * The template filter's dropdown. It populates a picker, so a tenant beyond
+         * The template filter's dropdown. It populates a picker, so a tenant beyond
          * this many templates gets a truncated *filter list*, never a truncated report — the report
          * itself pages in SQL over everything.
          */


### PR DESCRIPTION
## Summary

- Adds the `ai-chat` tenant feature toggle, marked Alpha and disabled by default.
- Gates the editor AI plugin CSS and dynamic JS import behind the resolved tenant feature state.
- Replaces the AI-specific `aiChatStage` model value with a generic editor `features` map where each feature carries `enabled` plus optional badge metadata from `KnownFeatures`.
- Keeps `engine.isFeatureEnabled()` as the boolean editor API while letting plugin setup consume feature metadata such as the AI tab's Alpha badge.
- Updates feature-toggle/plugin docs, changelog, and route/frontend tests.

## Validation

- `pnpm format`
- `./gradlew ktlintFormat`
- `pnpm --filter @epistola/editor test`
- `./gradlew :modules:epistola-core:test --tests app.epistola.suite.features.KnownFeaturesTest --tests app.epistola.suite.features.FeatureDefaultsTest`
- `./gradlew :apps:epistola:test --tests app.epistola.suite.handlers.FeatureTogglePageHtmxTest --tests app.epistola.suite.templates.DocumentTemplateRoutesTest`
- `./gradlew :apps:epistola:test --tests app.epistola.suite.templates.DocumentTemplateRoutesTest --tests app.epistola.suite.quality.QualityHandlerHtmxTest`
- `pnpm --filter @epistola/editor build`
- `pnpm format:check`
- `./gradlew ktlintCheck`