### PR TITLE
fix(auth): show OIDC display names consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 
+- **[user]** fix(auth): **OIDC users now show their display name consistently.** The top navigation and footer render the identity provider's human-readable `name` claim from the signed-in Epistola principal instead of Spring's provider-dependent principal name, which defaulted to the opaque `sub` UUID on some installations. Email and display name are refreshed at login while `sub` remains the stable account key; rendering uses the existing session principal and adds no per-request user lookup.
 - **[dev]** chore(build): **Warnings now fail fast.** Kotlin compiler warnings and Gradle deprecations fail builds by default, with a documented narrow exception policy for unavoidable upstream diagnostics.
 - **[dev]** test(kotlin): **Test compiler warnings removed.** Test fixtures now avoid redundant null assertions and conversions, use typed exception assertions, and follow the current Jackson 3 and AssertJ APIs.
 - **[dev]** refactor(kotlin): **Production compiler warnings removed.** Kotlin sources now use idiomatic nullability, primitive wrappers, Jackson type references, and iText border APIs, with regression coverage for typed theme-style conversion and per-side PDF borders.

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CommonViewModel.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CommonViewModel.kt
@@ -15,8 +15,8 @@ import org.springframework.stereotype.Component
 
 /**
  * The one source of truth for the common tenant-view model attributes that every
- * tenant-scoped UI render needs — `tenantName`, `auth`, `isManager`, and footer
- * chrome.
+ * tenant-scoped UI render needs — `tenantName`, `currentUserDisplayName`,
+ * `auth`, `isManager`, and footer chrome.
  *
  * Two render paths consume it, so they can't drift:
  * - [ShellModelInterceptor] — normal MVC view renders (interceptor `postHandle`).
@@ -34,6 +34,8 @@ class CommonViewModel(
     /**
      * The attributes to add for a tenant view, computed from [model]:
      * - `tenantName` — resolved from `tenantId` (only if not already in [model]).
+     * - `currentUserDisplayName` — read from the already-bound principal; no user
+     *   lookup is performed.
      * - `auth` — resolved from the current principal + `tenantId` (only if not
      *   already in [model], so a handler that set its own `auth` keeps it).
      * - `isManager` — derived from the effective `auth`.
@@ -46,15 +48,19 @@ class CommonViewModel(
     fun attributes(model: Map<String, Any?>): Map<String, Any?> {
         val result = LinkedHashMap<String, Any?>()
         val tenantId = model["tenantId"]?.toString()
+        val principal = SecurityContext.currentOrNull()
 
         if (tenantId != null && model["tenantName"] == null) {
             val tenant = GetTenant(TenantKey.of(tenantId)).query()
             result["tenantName"] = tenant?.name ?: tenantId
         }
 
+        if (model["currentUserDisplayName"] == null) {
+            result["currentUserDisplayName"] = principal?.displayLabel()
+        }
+
         // Resolve auth context — always present so templates never need null checks.
         val auth = model["auth"] as? AuthContext ?: run {
-            val principal = SecurityContext.currentOrNull()
             when {
                 principal != null && tenantId != null -> AuthContext.from(principal, TenantKey.of(tenantId))
                 principal != null -> AuthContext.platformOnly(principal)

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/security/OAuth2UserProvisioningService.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/security/OAuth2UserProvisioningService.kt
@@ -9,8 +9,8 @@ import app.epistola.suite.mediator.Mediator
 import app.epistola.suite.users.AuthProvider
 import app.epistola.suite.users.User
 import app.epistola.suite.users.commands.CreateUser
+import app.epistola.suite.users.commands.RecordUserLogin
 import app.epistola.suite.users.commands.SyncTenantMemberships
-import app.epistola.suite.users.commands.UpdateLastLogin
 import app.epistola.suite.users.queries.GetUserByExternalId
 import org.slf4j.LoggerFactory
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
@@ -99,8 +99,12 @@ class OAuth2UserProvisioningService(
         )
     }
 
-    private fun updateLastLogin(userId: app.epistola.suite.common.ids.UserKey) {
-        mediator.send(UpdateLastLogin(userId))
+    private fun recordLogin(
+        userId: app.epistola.suite.common.ids.UserKey,
+        email: String,
+        displayName: String,
+    ) {
+        mediator.send(RecordUserLogin(userId, email, displayName))
     }
 
     /**
@@ -142,9 +146,11 @@ class OAuth2UserProvisioningService(
                 OAuth2Error("missing_email_claim"),
                 "Missing 'email' claim in OAuth2 user info",
             )
-        val displayName = oauth2User.getAttribute<String>("name") ?: email
+        val displayName = oauth2User.getAttribute<String>("name")
+            ?.takeIf { it.isNotBlank() }
+            ?: email
 
-        val user = try {
+        val storedUser = try {
             getOrCreateUser(externalId, email, displayName, provider)
         } catch (e: Exception) {
             logger.error("Failed to provision user: $email", e)
@@ -155,7 +161,8 @@ class OAuth2UserProvisioningService(
             )
         }
 
-        updateLastLogin(user.id)
+        recordLogin(storedUser.id, email, displayName)
+        val user = storedUser.copy(email = email, displayName = displayName)
 
         val groups = extractGroupsList(oauth2User)
         val flatRoles = extractFlatRolesList(oauth2User)

--- a/apps/epistola/src/main/resources/templates/fragments/footer.html
+++ b/apps/epistola/src/main/resources/templates/fragments/footer.html
@@ -21,7 +21,7 @@
             </button>
             <span sec:authorize="isAuthenticated()" class="user-info">
                 <span class="separator">|</span>
-                <a th:href="@{/profile}" sec:authentication="name" title="Your profile">username</a>
+                <a th:href="@{/profile}" th:text="${currentUserDisplayName}" title="Your profile">username</a>
                 <span class="separator">|</span>
                 <form th:action="@{/logout}" method="post" style="display: inline;">
                     <button type="submit" class="ep-btn ep-btn-primary ep-btn-sm">Logout</button>

--- a/apps/epistola/src/main/resources/templates/layout/nav.html
+++ b/apps/epistola/src/main/resources/templates/layout/nav.html
@@ -48,7 +48,7 @@
                 </a>
 
                 <div class="app-nav-user" sec:authorize="isAuthenticated()">
-                    <a th:href="@{/profile}" class="app-nav-username" sec:authentication="name" title="Your profile">user</a>
+                    <a th:href="@{/profile}" class="app-nav-username" th:text="${currentUserDisplayName}" title="Your profile">user</a>
                     <span class="app-nav-separator">|</span>
                     <a th:href="@{/api-docs}" class="app-nav-link-sm" hx-boost="false" target="_blank" rel="noopener">API Docs</a>
                     <span class="app-nav-separator">|</span>

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/NavRenderHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/NavRenderHtmxTest.kt
@@ -8,6 +8,7 @@ import app.epistola.suite.BaseIntegrationTest
 import app.epistola.suite.features.KnownFeatures
 import app.epistola.suite.features.commands.SaveFeatureToggle
 import app.epistola.suite.mediator.execute
+import app.epistola.suite.testing.TestPrincipalUser
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -40,6 +41,18 @@ class NavRenderHtmxTest : BaseIntegrationTest() {
         // (Thymeleaf classappend can emit extra whitespace, so normalise before matching.)
         assertThat(body).contains("nav-item-templates")
         assertThat(body.replace(Regex("\\s+"), " ")).contains("app-nav-dropdown-item active")
+    }
+
+    @Test
+    fun `shared chrome renders the application display name`() {
+        val tenant = createTenant("Nav Display Name")
+
+        val body = restTemplate.getForEntity("/tenants/${tenant.id.value}/templates", String::class.java).body!!
+        val navUser = body.substringAfter("""class="app-nav-username"""").substringBefore("</a>")
+        val footerUser = body.substringAfter("""class="user-info"""").substringBefore("</footer>")
+
+        assertThat(navUser).contains(">${TestPrincipalUser.DISPLAY_NAME}")
+        assertThat(footerUser).contains(">${TestPrincipalUser.DISPLAY_NAME}</a>")
     }
 
     @Test

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/security/OAuth2UserProvisioningServiceTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/security/OAuth2UserProvisioningServiceTest.kt
@@ -12,10 +12,11 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.users.AuthProvider
 import app.epistola.suite.users.User
 import app.epistola.suite.users.commands.CreateUser
+import app.epistola.suite.users.commands.RecordUserLogin
 import app.epistola.suite.users.commands.SyncTenantMemberships
-import app.epistola.suite.users.commands.UpdateLastLogin
 import app.epistola.suite.users.queries.GetUserByExternalId
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
@@ -25,8 +26,16 @@ import java.time.OffsetDateTime
 @Tag("unit")
 class OAuth2UserProvisioningServiceTest {
 
-    private fun oauth2User(attributes: Map<String, Any>): OAuth2User {
-        val attrs = mapOf("sub" to "test-subject", "email" to "user@example.com", "name" to "Test User") + attributes
+    private fun oauth2User(
+        attributes: Map<String, Any>,
+        name: String? = "Test User",
+    ): OAuth2User {
+        val attrs = buildMap<String, Any> {
+            put("sub", "test-subject")
+            put("email", "user@example.com")
+            if (name != null) put("name", name)
+            putAll(attributes)
+        }
         return DefaultOAuth2User(emptyList(), attrs, "sub")
     }
 
@@ -47,11 +56,15 @@ class OAuth2UserProvisioningServiceTest {
         authProperties: AuthProperties = AuthProperties(),
         membershipResolver: LoginMembershipResolver? = null,
         syncCalls: MutableList<Map<TenantKey, Set<TenantRole>>> = mutableListOf(),
+        loginCalls: MutableList<RecordUserLogin> = mutableListOf(),
     ): OAuth2UserProvisioningService {
         val mediator = object : Mediator {
             @Suppress("UNCHECKED_CAST")
             override fun <R> send(command: Command<R>): R = when (command) {
-                is UpdateLastLogin -> Unit as R
+                is RecordUserLogin -> {
+                    loginCalls.add(command)
+                    Unit as R
+                }
                 is SyncTenantMemberships -> {
                     syncCalls.add(command.memberships)
                     Unit as R
@@ -199,6 +212,67 @@ class OAuth2UserProvisioningServiceTest {
         assertThat(syncCalls.single()[TenantKey.of("beta-org")]).containsExactly(TenantRole.CONTENT_AUTHOR)
     }
 
+    @Test
+    fun `refreshes mutable profile claims and returns them in the principal`() {
+        val loginCalls = mutableListOf<RecordUserLogin>()
+        val staleUser = existingUser().copy(email = "old@example.com", displayName = "Old Name")
+
+        val principal = service(staleUser, loginCalls = loginCalls).provision(
+            oauth2User(
+                mapOf(
+                    "email" to "current@example.com",
+                    "name" to "Current Name",
+                ),
+            ),
+            "keycloak",
+        )
+
+        assertThat(loginCalls).containsExactly(
+            RecordUserLogin(
+                userId = staleUser.id,
+                email = "current@example.com",
+                displayName = "Current Name",
+            ),
+        )
+        assertThat(principal.userId).isEqualTo(staleUser.id)
+        assertThat(principal.email).isEqualTo("current@example.com")
+        assertThat(principal.displayName).isEqualTo("Current Name")
+    }
+
+    @Test
+    fun `falls back to email when the name claim is absent or blank`() {
+        val absentNameCalls = mutableListOf<RecordUserLogin>()
+        val blankNameCalls = mutableListOf<RecordUserLogin>()
+
+        val absentNamePrincipal = service(existingUser(), loginCalls = absentNameCalls).provision(
+            oauth2User(emptyMap(), name = null),
+            "keycloak",
+        )
+        val blankNamePrincipal = service(existingUser(), loginCalls = blankNameCalls).provision(
+            oauth2User(mapOf("name" to "  ")),
+            "keycloak",
+        )
+
+        assertThat(absentNamePrincipal.displayName).isEqualTo("user@example.com")
+        assertThat(absentNameCalls.single().displayName).isEqualTo("user@example.com")
+        assertThat(blankNamePrincipal.displayName).isEqualTo("user@example.com")
+        assertThat(blankNameCalls.single().displayName).isEqualTo("user@example.com")
+    }
+
+    @Test
+    fun `does not refresh profile claims for a disabled user`() {
+        val loginCalls = mutableListOf<RecordUserLogin>()
+
+        assertThatThrownBy {
+            service(existingUser().copy(enabled = false), loginCalls = loginCalls).provision(
+                oauth2User(mapOf("name" to "New Name")),
+                "keycloak",
+            )
+        }.hasMessageContaining("Failed to provision user")
+
+        assertThat(loginCalls).isEmpty()
+    }
+
     // --- Provider derivation (provider-neutral: any non-Keycloak registration is GENERIC_OIDC) ---
 
     @Test
@@ -222,7 +296,7 @@ class OAuth2UserProvisioningServiceTest {
         val mediator = object : Mediator {
             @Suppress("UNCHECKED_CAST")
             override fun <R> send(command: Command<R>): R = when (command) {
-                is UpdateLastLogin -> Unit as R
+                is RecordUserLogin -> Unit as R
                 is CreateUser -> {
                     created.add(command)
                     newUser as R

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -101,7 +101,7 @@ Commands and queries have **opposite default polarity**:
 - **Commands → opt-out** (`operation = WRITE`). Every command is recorded _except_
   `SystemInternal` ones (background/system work) and those marked `NotAudited`
   (the high-frequency opt-out). `NotAudited` covers `RecordApiKeyUsage` /
-  `UpdateLastLogin` (housekeeping) and `GenerateDocument` /
+  `RecordUserLogin` (housekeeping) and `GenerateDocument` /
   `GenerateDocumentBatch` (high-volume, and already tracked in full by the
   generation subsystem — they would bury the trail without adding much).
 - **Queries → opt-in** (`operation = READ`). Queries are recorded _only_ when

--- a/docs/authentik-setup.md
+++ b/docs/authentik-setup.md
@@ -100,6 +100,10 @@ oidc:
 ```
 
 `autoProvision` defaults to `true`, so a user's local record is created on first login.
+Epistola uses the OIDC `name` claim as the signed-in user's display label and
+refreshes it together with `email` on every login. The stable account link remains
+the `sub` claim. `userNameAttribute` only controls Spring Security's technical
+principal name; it does not control the label shown in Epistola's navigation.
 
 ### Plain environment variables (non-Helm)
 

--- a/docs/keycloak-setup.md
+++ b/docs/keycloak-setup.md
@@ -21,6 +21,11 @@ see [Recommended: client roles (step by step)](#recommended-client-roles-step-by
 The realm-role, group, and client-role mappers are configured in Keycloak (realm import or by
 hand); Epistola only reads the resulting claims.
 
+For user identity, Epistola links the account by the stable `sub` claim and shows the
+human-readable `name` claim in its navigation. The `email` and display name stored in
+Epistola are refreshed on every successful login, so profile changes do not create a
+new user or require a per-request identity lookup.
+
 > **Recommendation — prefer flat roles (client roles) over hierarchical groups.** The flat
 > `roles` claim keeps the Epistola authorization model scoped to its own client, is portable
 > across every IdP (Keycloak, authentik, Auth0, Cognito, …), and is simpler to reason about.

--- a/modules/epistola-audit/src/test/kotlin/app/epistola/suite/audit/AuditRecorderIT.kt
+++ b/modules/epistola-audit/src/test/kotlin/app/epistola/suite/audit/AuditRecorderIT.kt
@@ -21,7 +21,7 @@ import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
 import app.epistola.suite.tenants.commands.SetTenantDefaultLocale
 import app.epistola.suite.testing.IntegrationTestBase
-import app.epistola.suite.users.commands.UpdateLastLogin
+import app.epistola.suite.users.commands.RecordUserLogin
 import org.assertj.core.api.Assertions.assertThat
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.Test
@@ -187,14 +187,18 @@ class AuditRecorderIT : IntegrationTestBase() {
 
     @Test
     fun `SystemInternal and NotAudited commands are not recorded`() {
-        val before = countAction("UpdateLastLogin")
+        val before = countAction("RecordUserLogin")
 
         withMediator {
-            // UpdateLastLogin is SystemInternal + NotAudited.
-            UpdateLastLogin(userId = testUser.userId).execute()
+            // RecordUserLogin is SystemInternal + NotAudited.
+            RecordUserLogin(
+                userId = testUser.userId,
+                email = testUser.email,
+                displayName = testUser.displayName,
+            ).execute()
         }
 
-        assertThat(countAction("UpdateLastLogin")).isEqualTo(before)
+        assertThat(countAction("RecordUserLogin")).isEqualTo(before)
     }
 
     // -- helpers --------------------------------------------------------------

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/security/EpistolaPrincipal.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/security/EpistolaPrincipal.kt
@@ -43,6 +43,16 @@ data class EpistolaPrincipal(
     }
 
     /**
+     * Human-readable label for signed-in UI chrome.
+     *
+     * Identity-provider display names are preferred. Email and the immutable
+     * external subject keep the label useful for incomplete provider profiles.
+     */
+    fun displayLabel(): String = displayName.takeIf { it.isNotBlank() }
+        ?: email.takeIf { it.isNotBlank() }
+        ?: externalId
+
+    /**
      * Check if the user has access to the specified tenant.
      * Returns true if the user has per-tenant membership OR has any global roles
      * (global roles grant access to all tenants).

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/users/commands/RecordUserLogin.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/users/commands/RecordUserLogin.kt
@@ -14,28 +14,37 @@ import org.jdbi.v3.core.kotlin.withHandleUnchecked
 import org.springframework.stereotype.Component
 
 /**
- * Command to update the last login timestamp for a user.
+ * Records a successful identity-provider login.
+ *
+ * The external subject remains the stable account key; email and display name
+ * are mutable profile attributes and are refreshed from the latest login.
  */
-data class UpdateLastLogin(
+data class RecordUserLogin(
     val userId: UserKey,
+    val email: String,
+    val displayName: String,
 ) : Command<Unit>,
     SystemInternal,
     NotAudited
 
 @Component
-class UpdateLastLoginHandler(
+class RecordUserLoginHandler(
     private val jdbi: Jdbi,
-) : CommandHandler<UpdateLastLogin, Unit> {
-    override fun handle(command: UpdateLastLogin) {
+) : CommandHandler<RecordUserLogin, Unit> {
+    override fun handle(command: RecordUserLogin) {
         jdbi.withHandleUnchecked { handle ->
             handle.createUpdate(
                 """
                 UPDATE users
-                SET last_login_at = NOW()
+                SET email = :email,
+                    display_name = :displayName,
+                    last_login_at = NOW()
                 WHERE id = :userId
                 """,
             )
                 .bind("userId", command.userId.value)
+                .bind("email", command.email)
+                .bind("displayName", command.displayName)
                 .execute()
         }
     }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/security/EpistolaPrincipalTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/security/EpistolaPrincipalTest.kt
@@ -102,6 +102,15 @@ class EpistolaPrincipalTest {
         assertThat(principal(platformRoles = setOf(PlatformRole.TENANT_MANAGER)).isTenantManager()).isTrue()
     }
 
+    @Test
+    fun `display label prefers display name then email then external id`() {
+        val principal = principal()
+
+        assertThat(principal.displayLabel()).isEqualTo("Test User")
+        assertThat(principal.copy(displayName = " ").displayLabel()).isEqualTo("test@example.com")
+        assertThat(principal.copy(displayName = "", email = " ").displayLabel()).isEqualTo("test-user")
+    }
+
     // --- Global roles ---
 
     @Test

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/users/RecordUserLoginIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/users/RecordUserLoginIntegrationTest.kt
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.users
+
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.mediator.query
+import app.epistola.suite.testing.IntegrationTestBase
+import app.epistola.suite.users.commands.CreateUser
+import app.epistola.suite.users.commands.RecordUserLogin
+import app.epistola.suite.users.queries.GetUserByExternalId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class RecordUserLoginIntegrationTest : IntegrationTestBase() {
+
+    @Test
+    fun `record login refreshes mutable profile attributes on the same user`(): Unit = withMediator {
+        val externalId = "oidc-${UUID.randomUUID()}"
+        val created = CreateUser(
+            externalId = externalId,
+            email = "old@example.com",
+            displayName = "Old Name",
+            provider = AuthProvider.GENERIC_OIDC,
+        ).execute()
+
+        RecordUserLogin(
+            userId = created.id,
+            email = "new@example.com",
+            displayName = "New Name",
+        ).execute()
+
+        val refreshed = GetUserByExternalId(externalId, AuthProvider.GENERIC_OIDC).query()
+        assertThat(refreshed).isNotNull
+        assertThat(refreshed!!.id).isEqualTo(created.id)
+        assertThat(refreshed.email).isEqualTo("new@example.com")
+        assertThat(refreshed.displayName).isEqualTo("New Name")
+        assertThat(refreshed.lastLoginAt).isNotNull()
+    }
+}


### PR DESCRIPTION
## What

- show the OIDC display name in shared navigation and footer chrome
- refresh mutable email and display-name fields whenever an OIDC user logs in
- fall back from display name to email and then the stable external ID
- retain stable user matching by provider and subject

## Why

The shared chrome used Spring Security's authentication name. Depending on the identity provider, that value can be the OIDC subject UUID instead of a human-readable name. Sittard-Geleen therefore displayed the UUID while demo displayed the preferred username.

The display label now comes from the Epistola principal populated at login, so regular requests do not query the user database or identity provider.

## Impact

Existing users keep the same stable identity and database record. Mutable profile fields are synchronized on their next login. No database migration is required.

## Verification

- ./gradlew test
- ./gradlew ktlintCheck unitTest integrationTest
- pnpm format:check -- . (excluding the unrelated untracked ADR)
- pnpm license:check
- git diff --check