### PR TITLE
chore(release): re-open 1.0.0-RC6-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # a release strips it, tags v<version>, then re-opens the next -SNAPSHOT (see the
 # `release` skill). CI validates the v* tag equals this value. A -PreleaseVersion
 # override (PR snapshot builds) still wins over this.
-version=1.0.0-RC5
+version=1.0.0-RC6-SNAPSHOT
 
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
## Summary

Re-open development after the `v1.0.0-RC5` application release.

- set the application version to `1.0.0-RC6-SNAPSHOT`
- preserve the empty `[Unreleased]` changelog section for the next development cycle

## Validation

- `pnpm format:check`
- `./gradlew unitTest integrationTest`
- `./gradlew ktlintCheck`
- `pnpm license:check`
- `git diff --check`
