### PR TITLE
feat(ui): add shell-aware not-found page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+- **[user]** feat(ui): **Missing pages retain the Epistola shell.** Browser navigations that
+  resolve to an empty or unmatched 404 now show a clear recovery page with the usual header,
+  navigation, and footer. Tenant URLs retain their accessible tenant context, while API,
+  download, structured, and HTMX fragment error contracts remain unchanged.
+
 ## [1.0.0-RC5] - 2026-07-29
 
 This release preserves exact stencil draft provenance across catalogs, with clear recovery choices

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundHandlerMapping.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundHandlerMapping.kt
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.config
+
+import app.epistola.suite.handlers.ShellModelInterceptor
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.servlet.HandlerMapping
+import org.springframework.web.servlet.ModelAndView
+import org.springframework.web.servlet.function.support.RouterFunctionMapping
+import org.springframework.web.servlet.handler.AbstractHandlerMapping
+import org.springframework.web.servlet.mvc.Controller
+
+/**
+ * Handles unmatched HTML page navigations after annotated and functional routes, but before
+ * Spring's static-resource fallback turns them into a framework exception.
+ *
+ * Order 4 is immediately after Spring MVC's functional [RouterFunctionMapping] (order 3).
+ * Structured, fragment, API, probe, and static-resource requests deliberately fall through to
+ * their existing handlers and error contracts.
+ */
+@Configuration
+class UiNotFoundHandlerMappingConfiguration(
+    private val versionInterceptor: VersionInterceptor,
+    private val shellModelInterceptor: ShellModelInterceptor,
+    private val siteBannerInterceptor: SiteBannerInterceptor,
+) {
+    @Bean
+    fun uiNotFoundHandlerMapping(): HandlerMapping = UiNotFoundHandlerMapping(UiNotFoundController()).apply {
+        order = ROUTER_FUNCTION_MAPPING_ORDER + 1
+        setInterceptors(versionInterceptor, shellModelInterceptor, siteBannerInterceptor)
+    }
+}
+
+private class UiNotFoundHandlerMapping(
+    private val handler: Controller,
+) : AbstractHandlerMapping() {
+    override fun getHandlerInternal(request: HttpServletRequest): Any? = handler.takeIf { request.isUiPageNavigation() }
+}
+
+private class UiNotFoundController : Controller {
+    override fun handleRequest(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): ModelAndView {
+        if (request.isFullPageHtmx()) {
+            response.setHeader("HX-Reswap", "innerHTML")
+        }
+        return ModelAndView(
+            "layout/shell",
+            notFoundPageModel(request.requestURI),
+            HttpStatus.NOT_FOUND,
+        )
+    }
+}
+
+internal fun HttpServletRequest.isUiPageNavigation(): Boolean {
+    if (method != HttpMethod.GET.name()) return false
+    if (isExcludedNotFoundPath(requestURI)) return false
+    if (isFragmentHtmx()) return false
+
+    val accepted = getHeader("Accept")?.let {
+        runCatching { MediaType.parseMediaTypes(it) }.getOrDefault(emptyList())
+    }.orEmpty()
+    return accepted.any {
+        it.type.equals(MediaType.TEXT_HTML.type, ignoreCase = true) &&
+            (it.subtype == "*" || it.subtype.equals(MediaType.TEXT_HTML.subtype, ignoreCase = true))
+    }
+}
+
+private fun HttpServletRequest.isFragmentHtmx(): Boolean = getHeader("HX-Request") == "true" && !isFullPageHtmx()
+
+internal fun HttpServletRequest.isFullPageHtmx(): Boolean = getHeader("HX-Request") == "true" &&
+    (getHeader("HX-Boosted") == "true" || getHeader("HX-History-Restore-Request") == "true")
+
+private fun isExcludedNotFoundPath(path: String): Boolean = path in EXCLUDED_EXACT_PATHS || EXCLUDED_PATH_PREFIXES.any(path::startsWith)
+
+private const val ROUTER_FUNCTION_MAPPING_ORDER = 3
+
+private val EXCLUDED_PATH_PREFIXES = listOf(
+    "/api/",
+    "/api-docs/",
+    "/actuator/",
+    "/errors/",
+    "/css/",
+    "/js/",
+    "/fonts/",
+    "/images/",
+    "/design-system/",
+    "/webjars/",
+)
+
+private val EXCLUDED_EXACT_PATHS = setOf(
+    "/livez",
+    "/readyz",
+    "/error",
+    "/errors",
+    "/favicon.ico",
+)

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundModel.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundModel.kt
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.config
+
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.query
+import app.epistola.suite.security.TenantAccessDeniedException
+import app.epistola.suite.tenants.queries.GetTenant
+
+/**
+ * Builds the shell model for a not-found page.
+ *
+ * A tenant from the requested path is used only when it still exists and is visible to the
+ * current principal. Guessed, deleted, and inaccessible tenant paths therefore use the generic
+ * application shell.
+ */
+internal fun notFoundPageModel(requestPath: String): Map<String, Any?> {
+    val tenant = tenantKeyFromPath(requestPath)?.let {
+        try {
+            GetTenant(it).query()
+        } catch (_: TenantAccessDeniedException) {
+            null
+        }
+    }
+
+    return buildMap {
+        put("contentView", "error/404")
+        put("pageTitle", "Page Not Found - Epistola")
+        if (tenant != null) {
+            put("tenantId", tenant.id)
+            put("tenantName", tenant.name)
+        }
+    }
+}
+
+private fun tenantKeyFromPath(path: String): TenantKey? {
+    val value = TENANT_PATH.find(path)?.groupValues?.get(1) ?: return null
+    return TenantKey.validateOrNull(value)
+}
+
+private val TENANT_PATH = Regex("^/tenants/([^/]+)(?:/|$)")

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundResponseFilter.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundResponseFilter.kt
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletOutputStream
+import jakarta.servlet.WriteListener
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponseWrapper
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.io.PrintWriter
+import java.io.Writer
+
+/**
+ * Converts empty 404 responses from page handlers into the shared not-found page.
+ *
+ * Existing handlers can keep returning `ServerResponse.notFound().build()`. Only browser page
+ * navigations are wrapped; API, structured, static-resource, download, and HTMX fragment
+ * contracts remain unchanged.
+ */
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+class UiNotFoundResponseFilter : OncePerRequestFilter() {
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean = request.requestURI == NOT_FOUND_RENDER_PATH || !request.isUiPageNavigation()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val wrappedResponse = DeferredNotFoundResponse(response)
+        filterChain.doFilter(request, wrappedResponse)
+
+        if (
+            wrappedResponse.status == HttpServletResponse.SC_NOT_FOUND &&
+            !wrappedResponse.bodyWritten &&
+            !wrappedResponse.isCommitted
+        ) {
+            wrappedResponse.reset()
+            request.setAttribute(NOT_FOUND_ORIGINAL_PATH_ATTRIBUTE, request.requestURI)
+            wrappedResponse.status = HttpServletResponse.SC_NOT_FOUND
+            if (request.isFullPageHtmx()) {
+                wrappedResponse.setHeader("HX-Reswap", "innerHTML")
+            }
+            request.getRequestDispatcher(NOT_FOUND_RENDER_PATH).include(request, wrappedResponse)
+        }
+    }
+}
+
+private class DeferredNotFoundResponse(response: HttpServletResponse) : HttpServletResponseWrapper(response) {
+    var bodyWritten = false
+        private set
+
+    private var trackingOutputStream: ServletOutputStream? = null
+    private var trackingWriter: PrintWriter? = null
+
+    override fun sendError(status: Int) {
+        if (status == HttpServletResponse.SC_NOT_FOUND) {
+            setStatus(status)
+        } else {
+            super.sendError(status)
+        }
+    }
+
+    override fun sendError(
+        status: Int,
+        message: String,
+    ) {
+        if (status == HttpServletResponse.SC_NOT_FOUND) {
+            setStatus(status)
+        } else {
+            super.sendError(status, message)
+        }
+    }
+
+    override fun getOutputStream(): ServletOutputStream {
+        check(trackingWriter == null) { "getWriter() has already been called for this response" }
+        return trackingOutputStream ?: TrackingServletOutputStream(super.getOutputStream()) {
+            bodyWritten = true
+        }.also { trackingOutputStream = it }
+    }
+
+    override fun getWriter(): PrintWriter {
+        check(trackingOutputStream == null) { "getOutputStream() has already been called for this response" }
+        return trackingWriter ?: PrintWriter(
+            TrackingWriter(super.getWriter()) {
+                bodyWritten = true
+            },
+        ).also { trackingWriter = it }
+    }
+}
+
+private class TrackingServletOutputStream(
+    private val delegate: ServletOutputStream,
+    private val onWrite: () -> Unit,
+) : ServletOutputStream() {
+    override fun write(value: Int) {
+        onWrite()
+        delegate.write(value)
+    }
+
+    override fun write(
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+    ) {
+        if (length > 0) onWrite()
+        delegate.write(bytes, offset, length)
+    }
+
+    override fun isReady(): Boolean = delegate.isReady
+
+    override fun setWriteListener(listener: WriteListener) = delegate.setWriteListener(listener)
+}
+
+private class TrackingWriter(
+    private val delegate: Writer,
+    private val onWrite: () -> Unit,
+) : Writer() {
+    override fun write(
+        characters: CharArray,
+        offset: Int,
+        length: Int,
+    ) {
+        if (length > 0) onWrite()
+        delegate.write(characters, offset, length)
+    }
+
+    override fun flush() = delegate.flush()
+
+    override fun close() = delegate.close()
+}
+
+internal const val NOT_FOUND_RENDER_PATH = "/internal/not-found"
+internal const val NOT_FOUND_ORIGINAL_PATH_ATTRIBUTE =
+    "app.epistola.suite.config.UiNotFoundResponseFilter.originalPath"

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundRoutes.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/config/UiNotFoundRoutes.kt
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.function.RouterFunction
+import org.springframework.web.servlet.function.ServerResponse
+import org.springframework.web.servlet.function.router
+
+@Configuration
+class UiNotFoundRoutes {
+    @Bean
+    fun uiNotFoundRenderRoute(): RouterFunction<ServerResponse> = router {
+        GET(NOT_FOUND_RENDER_PATH) { request ->
+            val originalPath = request.attribute(NOT_FOUND_ORIGINAL_PATH_ATTRIBUTE).orElse(null) as? String
+                ?: return@GET ServerResponse.notFound().build()
+            ServerResponse.ok().render("layout/shell", notFoundPageModel(originalPath))
+        }
+    }
+}

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/config/WebMvcConfig.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/config/WebMvcConfig.kt
@@ -21,7 +21,7 @@ class WebMvcConfig(
         registry.addInterceptor(versionInterceptor)
             .addPathPatterns("/**")
         registry.addInterceptor(shellModelInterceptor)
-            .addPathPatterns("/tenants/**")
+            .addPathPatterns("/**")
         registry.addInterceptor(siteBannerInterceptor)
             .addPathPatterns("/**")
     }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CommonViewModel.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CommonViewModel.kt
@@ -74,6 +74,8 @@ class CommonViewModel(
             val context = UiRequestContext(TenantKey.of(tenantId)) { auth.has(it) }
             // Module-contributed footer chrome (e.g. the feedback FAB).
             result["footerFragments"] = footerFragmentResolver.resolve(context)
+        } else {
+            result["footerFragments"] = emptyList<Any>()
         }
         return result
     }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ShellModelInterceptor.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ShellModelInterceptor.kt
@@ -5,6 +5,7 @@
 package app.epistola.suite.handlers
 
 import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.config.NOT_FOUND_ORIGINAL_PATH_ATTRIBUTE
 import app.epistola.suite.htmx.UiRequestContext
 import app.epistola.suite.htmx.nav.NavMenuAggregator
 import jakarta.servlet.http.HttpServletRequest
@@ -52,10 +53,17 @@ class ShellModelInterceptor(
         // The module-contributed nav menu is shell-only; contributors resolve their own
         // visibility, so the host owns no feature flags for it.
         if (viewName != "layout/shell") return
-        val tenantId = modelAndView.model["tenantId"]?.toString() ?: return
+        val tenantId = modelAndView.model["tenantId"]?.toString()
+        if (tenantId == null) {
+            modelAndView.addObject("navGroups", emptyList<Any>())
+            modelAndView.addObject("activeNavSection", "")
+            return
+        }
         val auth = modelAndView.model["auth"] as AuthContext
         val context = UiRequestContext(TenantKey.of(tenantId)) { auth.has(it) }
-        val nav = navMenuAggregator.build(context, request.requestURI)
+        val requestPath =
+            request.getAttribute(NOT_FOUND_ORIGINAL_PATH_ATTRIBUTE) as? String ?: request.requestURI
+        val nav = navMenuAggregator.build(context, requestPath)
         modelAndView.addObject("navGroups", nav.groups)
         modelAndView.addObject("activeNavSection", nav.activeNavSection)
     }

--- a/apps/epistola/src/main/resources/static/css/shell.css
+++ b/apps/epistola/src/main/resources/static/css/shell.css
@@ -342,6 +342,65 @@
     padding: var(--ep-space-8);
   }
 
+  /* ── Not-found page ──────────────────────────────────────────────────── */
+
+  .not-found-page {
+    min-height: min(32rem, calc(100vh - 10rem));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: var(--ep-space-12) var(--ep-space-6);
+  }
+
+  .not-found-code {
+    color: var(--ep-stone-200);
+    font-size: clamp(5rem, 14vw, 9rem);
+    font-weight: 700;
+    letter-spacing: -0.08em;
+    line-height: 0.8;
+    margin-right: 0.08em;
+    user-select: none;
+  }
+
+  .not-found-icon {
+    width: 3.5rem;
+    height: 3.5rem;
+    display: grid;
+    place-items: center;
+    margin-top: calc(var(--ep-space-6) * -1);
+    margin-bottom: var(--ep-space-5);
+    color: var(--ep-muted-foreground);
+    background: var(--ep-white);
+    border: 1px solid var(--ep-border-color);
+    border-radius: 50%;
+    box-shadow: var(--ep-shadow-sm);
+  }
+
+  .not-found-icon .ep-icon {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .not-found-page h1 {
+    margin-bottom: var(--ep-space-3);
+    font-size: var(--ep-text-2xl);
+  }
+
+  .not-found-page p {
+    max-width: 30rem;
+    margin-bottom: var(--ep-space-6);
+    color: var(--ep-muted-foreground);
+  }
+
+  .not-found-actions {
+    display: flex;
+    justify-content: center;
+    gap: var(--ep-space-3);
+    flex-wrap: wrap;
+  }
+
   /* ── HTMX swap indicator ─────────────────────────────────────────────── */
 
   .htmx-request .main-content {

--- a/apps/epistola/src/main/resources/templates/error/404.html
+++ b/apps/epistola/src/main/resources/templates/error/404.html
@@ -5,14 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found - Epistola</title>
     <th:block th:replace="~{fragments/styles :: styles}" />
+    <link rel="stylesheet" th:href="@{/css/shell.css}">
 </head>
-<body style="display: flex; align-items: center; justify-content: center; min-height: 100vh; background: var(--ep-bg-secondary);">
-    <div style="text-align: center; max-width: 480px; padding: var(--ep-space-8);">
-        <h1 style="font-size: 1.5rem; margin-bottom: var(--ep-space-4);">Page Not Found</h1>
-        <p style="color: var(--ep-text-secondary); margin-bottom: var(--ep-space-6);">
-            The page you're looking for doesn't exist or has been moved.
+<body>
+    <section th:fragment="content" class="not-found-page" aria-labelledby="not-found-title">
+        <div class="not-found-code" aria-hidden="true">404</div>
+        <div class="not-found-icon">
+            <th:block th:replace="~{epistola-web/icon :: icon(name='search', class='ep-icon')}" />
+        </div>
+        <h1 id="not-found-title">Page not found</h1>
+        <p>
+            The page you’re looking for doesn’t exist, may have moved, or is no longer available.
         </p>
-        <a href="/" class="ep-btn ep-btn-primary">Back to Home</a>
-    </div>
+        <div class="not-found-actions">
+            <a th:if="${tenantId != null}"
+               th:href="@{/tenants/{id}(id=${tenantId})}"
+               class="ep-btn ep-btn-primary">Go to tenant home</a>
+            <a th:unless="${tenantId != null}"
+               th:href="@{/}"
+               class="ep-btn ep-btn-primary">View tenants</a>
+            <a th:if="${tenantId != null}"
+               th:href="@{/}"
+               class="ep-btn ep-btn-outline">View all tenants</a>
+        </div>
+    </section>
 </body>
 </html>

--- a/apps/epistola/src/main/resources/templates/layout/nav.html
+++ b/apps/epistola/src/main/resources/templates/layout/nav.html
@@ -5,13 +5,16 @@
         <!-- Top bar (always visible) -->
         <div class="app-nav-bar">
             <div class="app-nav-left">
-                <a th:href="@{/tenants/{id}(id=${tenantId})}" class="app-nav-logo" title="Tenant home" aria-label="Epistola — Tenant home">
+                <a th:href="${tenantId != null} ? @{/tenants/{id}(id=${tenantId})} : @{/}"
+                   class="app-nav-logo"
+                   th:title="${tenantId != null} ? 'Tenant home' : 'Epistola home'"
+                   th:aria-label="${tenantId != null} ? 'Epistola — Tenant home' : 'Epistola home'">
                     <img class="ep-icon ep-icon-lg" th:src="@{/design-system/epistola-logo.svg}" alt="Epistola" />
                     <span>Epistola</span>
                 </a>
 
                 <!-- Module-contributed dropdowns (see NavMenuAggregator / NavContributor) -->
-                <div class="app-nav-links">
+                <div class="app-nav-links" th:if="${tenantId != null}">
                     <div th:each="group : ${navGroups}" class="app-nav-dropdown"
                          th:classappend="${group.active} ? ' active' : ''">
                         <button class="app-nav-dropdown-trigger" type="button"
@@ -36,7 +39,8 @@
                 </div>
 
                 <!-- Mobile hamburger toggle -->
-                <button class="app-nav-hamburger" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav">
+                <button sec:authorize="isAuthenticated()"
+                        class="app-nav-hamburger" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav">
                     <th:block th:replace="~{epistola-web/icon :: icon(name='menu', class='ep-icon')}" />
                 </button>
             </div>
@@ -44,7 +48,7 @@
             <div class="app-nav-right">
                 <a th:href="@{/}" class="app-nav-tenant" title="Switch tenant">
                     <th:block th:replace="~{epistola-web/icon :: icon(name='building-2', class='ep-icon ep-icon-sm')}" />
-                    <span th:text="${tenantName} ?: 'Tenant'">Tenant</span>
+                    <span th:text="${tenantName} ?: 'Tenants'">Tenants</span>
                 </a>
 
                 <div class="app-nav-user" sec:authorize="isAuthenticated()">
@@ -60,10 +64,10 @@
         </div>
 
         <!-- Mobile menu panel (below header, overlay) -->
-        <div id="mobile-nav" class="app-nav-mobile" role="menu">
+        <div sec:authorize="isAuthenticated()" id="mobile-nav" class="app-nav-mobile" role="menu">
             <div class="app-nav-mobile-backdrop"></div>
             <div class="app-nav-mobile-panel">
-                <div th:each="group : ${navGroups}" class="app-nav-mobile-group">
+                <div th:if="${tenantId != null}" th:each="group : ${navGroups}" class="app-nav-mobile-group">
                     <div class="app-nav-mobile-label" th:text="${group.label}">Group</div>
                     <a th:each="item : ${group.items}"
                        th:href="@{/tenants/{id}/{p}(id=${tenantId}, p=${item.pathSuffix})}"

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/UiNotFoundPageTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/UiNotFoundPageTest.kt
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.handlers
+
+import app.epistola.suite.BaseIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import java.util.UUID
+
+class UiNotFoundPageTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @Test
+    fun `unmatched tenant page renders tenant shell with 404 status`() {
+        val tenant = createTenant("Not Found Shell")
+
+        val response = getHtml("/tenants/${tenant.id.value}/does-not-exist")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body)
+            .withFailMessage("404 response headers: %s", response.headers)
+            .contains("id=\"app-nav\"", "class=\"app-footer\"", "Page not found")
+            .contains("/tenants/${tenant.id.value}")
+            .contains("Not Found Shell")
+    }
+
+    @Test
+    fun `empty handler 404 is upgraded generically to tenant shell`() {
+        val tenant = createTenant("Handled Not Found")
+
+        val response = getHtml("/tenants/${tenant.id.value}/load-tests/${UUID.randomUUID()}")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body)
+            .withFailMessage("404 response headers: %s", response.headers)
+            .contains("id=\"app-nav\"", "class=\"app-footer\"", "Page not found")
+            .contains("Handled Not Found")
+    }
+
+    @Test
+    fun `unmatched application page renders generic shell`() {
+        val response = getHtml("/does-not-exist")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body)
+            .contains("id=\"app-nav\"", "class=\"app-footer\"", "Page not found")
+            .contains("View tenants")
+    }
+
+    @Test
+    fun `boosted navigation receives shell and error swap override`() {
+        val tenant = createTenant("Boosted Not Found")
+        val headers = htmlHeaders().apply {
+            set("HX-Request", "true")
+            set("HX-Boosted", "true")
+        }
+
+        val response = restTemplate.exchange(
+            "/tenants/${tenant.id.value}/load-tests/${UUID.randomUUID()}",
+            HttpMethod.GET,
+            HttpEntity<Void>(headers),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.headers.getFirst("HX-Reswap"))
+            .withFailMessage("404 response headers: %s", response.headers)
+            .isEqualTo("innerHTML")
+        assertThat(response.body)
+            .withFailMessage("404 response headers: %s", response.headers)
+            .contains("id=\"app-nav\"", "Page not found")
+    }
+
+    @Test
+    fun `fragment and structured 404 contracts are unchanged`() {
+        val problemDocResponse = getHtml("/errors/does-not-exist")
+        val fragmentHeaders = htmlHeaders().apply { set("HX-Request", "true") }
+        val fragmentResponse = restTemplate.exchange(
+            "/errors/does-not-exist",
+            HttpMethod.GET,
+            HttpEntity<Void>(fragmentHeaders),
+            String::class.java,
+        )
+        val jsonHeaders = HttpHeaders().apply { accept = listOf(MediaType.APPLICATION_JSON) }
+        val jsonResponse = restTemplate.exchange(
+            "/does-not-exist",
+            HttpMethod.GET,
+            HttpEntity<Void>(jsonHeaders),
+            String::class.java,
+        )
+
+        assertThat(problemDocResponse.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(problemDocResponse.body).isNullOrEmpty()
+        assertThat(fragmentResponse.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(fragmentResponse.body).isNullOrEmpty()
+        assertThat(jsonResponse.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(jsonResponse.body).doesNotContain("Page not found", "id=\"app-nav\"")
+    }
+
+    private fun getHtml(path: String) = restTemplate.exchange(
+        path,
+        HttpMethod.GET,
+        HttpEntity<Void>(htmlHeaders()),
+        String::class.java,
+    )
+
+    private fun htmlHeaders() = HttpHeaders().apply { accept = listOf(MediaType.TEXT_HTML) }
+}


### PR DESCRIPTION
## What changed

- add a designed not-found page that renders inside the normal Epistola header, navigation, and footer
- handle both unmatched routes and existing page handlers that return an empty 404 through one generic navigation-only boundary
- retain accessible tenant context for tenant-scoped URLs and fall back to the generic application shell otherwise
- support boosted and history-restored HTMX navigations with the required error swap override
- add integration coverage and document the user-facing change

## Why

Missing browser pages previously returned either an empty response or a standalone error template, dropping the application chrome and useful recovery navigation. Individual handler changes would also be repetitive and easy to miss.

The generic response path applies only to `GET` requests explicitly accepting HTML. API paths, JSON and Problem Details responses, static assets, probes, and HTMX fragment responses retain their existing contracts.

## Validation

- `pnpm format:check`
- `./gradlew ktlintCheck`
- `./gradlew :apps:epistola:test`
- `./gradlew :apps:epistola:test --tests app.epistola.suite.handlers.UiNotFoundPageTest`
- local Spring Boot startup with the `local` profile
