### PR TITLE
fix(api): return problem details for expected domain failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- **[user]** fix(api): **Preview failures return actionable problem details.** Document previews
+  now report missing active, published, or explicitly requested versions and other missing
+  resources through the API's typed error responses instead of returning an internal server error.
+
 ## [1.0.0-RC6] - 2026-07-30
 
 This release gives missing pages and unknown tenant URLs a consistent Epistola recovery experience,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - **[user]** fix(api): **Preview failures return actionable problem details.** Document previews
   now report missing active, published, or explicitly requested versions and other missing
   resources through the API's typed error responses instead of returning an internal server error.
+  Catalog release and upgrade endpoints likewise return specific problem details for missing or
+  incompatible catalogs, invalid release versions, and upgrade conflicts.
 
 ## [1.0.0-RC6] - 2026-07-30
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/api/v1/EpistolaCatalogApiIT.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/api/v1/EpistolaCatalogApiIT.kt
@@ -10,6 +10,7 @@ import app.epistola.suite.catalog.AuthType
 import app.epistola.suite.catalog.commands.CreateCatalog
 import app.epistola.suite.catalog.commands.InstallFromCatalog
 import app.epistola.suite.catalog.commands.RegisterCatalog
+import app.epistola.suite.catalog.commands.ReleaseCatalogVersion
 import app.epistola.suite.common.ids.CatalogId
 import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TenantId
@@ -81,6 +82,70 @@ class EpistolaCatalogApiIT : IntegrationTestBase() {
     }
 
     @Test
+    fun `release missing catalog returns catalog not found problem details`() {
+        val (tenantKey, apiKey) = seedTenantAndKey()
+
+        val response = restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/missing-catalog/release",
+            HttpMethod.POST,
+            HttpEntity("""{"releaseVersion":"1.0.0"}""", baseHeaders(apiKey)),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.headers.contentType?.includes(MediaType.APPLICATION_PROBLEM_JSON)).isTrue()
+        val body = response.body!!
+        assertThat(JsonPath.read<String>(body, "$.type")).isEqualTo("https://epistola.app/errors/catalog-not-found")
+        assertThat(JsonPath.read<String>(body, "$.catalogId")).isEqualTo("missing-catalog")
+    }
+
+    @Test
+    fun `release rejects a non-advancing version with actionable problem details`() {
+        val (tenantKey, apiKey) = seedTenantAndKey()
+        val catalogSlug = "rel-${UUID.randomUUID().toString().take(8)}"
+        seedAuthoredCatalog(tenantKey, catalogSlug)
+        withMediator {
+            ReleaseCatalogVersion(
+                tenantKey = tenantKey,
+                catalogKey = CatalogKey.of(catalogSlug),
+                version = "1.0.0",
+            ).execute()
+        }
+
+        val response = restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/$catalogSlug/release",
+            HttpMethod.POST,
+            HttpEntity("""{"releaseVersion":"1.0.0"}""", baseHeaders(apiKey)),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.headers.contentType?.includes(MediaType.APPLICATION_PROBLEM_JSON)).isTrue()
+        val body = response.body!!
+        assertThat(JsonPath.read<String>(body, "$.type")).isEqualTo("https://epistola.app/errors/catalog-release-version-invalid")
+        assertThat(JsonPath.read<String>(body, "$.detail")).contains("greater than")
+    }
+
+    @Test
+    fun `release rejects a subscribed catalog with read only problem details`() {
+        val (tenantKey, apiKey) = seedTenantAndKey()
+        withMediator {
+            RegisterCatalog(tenantKey = tenantKey, sourceUrl = DEMO_CATALOG_URL, authType = AuthType.NONE).execute()
+        }
+
+        val response = restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/epistola-demo/release",
+            HttpMethod.POST,
+            HttpEntity("""{"releaseVersion":"1.0.0"}""", baseHeaders(apiKey)),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+        assertThat(response.headers.contentType?.includes(MediaType.APPLICATION_PROBLEM_JSON)).isTrue()
+        assertThat(JsonPath.read<String>(response.body!!, "$.type")).isEqualTo("https://epistola.app/errors/catalog-read-only")
+    }
+
+    @Test
     fun `upgrade catalog applies subscribed catalog upgrade request`() {
         val (tenantKey, apiKey) = seedTenantAndKey()
         withMediator {
@@ -101,6 +166,26 @@ class EpistolaCatalogApiIT : IntegrationTestBase() {
         assertThat(JsonPath.read<Boolean>(body, "$.aborted")).isFalse
         assertThat(JsonPath.read<List<Any>>(body, "$.installResults")).isNotNull
         assertThat(JsonPath.read<List<Any>>(body, "$.removedResources")).isNotNull
+    }
+
+    @Test
+    fun `upgrade rejects an authored catalog with not upgradeable problem details`() {
+        val (tenantKey, apiKey) = seedTenantAndKey()
+        val catalogSlug = "upg-${UUID.randomUUID().toString().take(8)}"
+        seedAuthoredCatalog(tenantKey, catalogSlug)
+
+        val response = restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/$catalogSlug/upgrade",
+            HttpMethod.POST,
+            HttpEntity("{}", baseHeaders(apiKey)),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+        assertThat(response.headers.contentType?.includes(MediaType.APPLICATION_PROBLEM_JSON)).isTrue()
+        val body = response.body!!
+        assertThat(JsonPath.read<String>(body, "$.type")).isEqualTo("https://epistola.app/errors/catalog-not-upgradeable")
+        assertThat(JsonPath.read<String>(body, "$.catalogId")).isEqualTo(catalogSlug)
     }
 
     private fun seedAuthoredCatalog(tenantKey: TenantKey, slug: String) = withMediator {

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ReleaseCatalogVersion.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ReleaseCatalogVersion.kt
@@ -8,6 +8,8 @@ import app.epistola.catalog.protocol.ReleaseInfo
 import app.epistola.suite.catalog.CatalogContentBuilder
 import app.epistola.suite.catalog.CatalogFingerprintService
 import app.epistola.suite.catalog.CatalogKey
+import app.epistola.suite.catalog.CatalogNotFoundException
+import app.epistola.suite.catalog.CatalogReadOnlyException
 import app.epistola.suite.catalog.CatalogType
 import app.epistola.suite.catalog.SemVer
 import app.epistola.suite.catalog.queries.GetCatalog
@@ -65,9 +67,9 @@ class ReleaseCatalogVersionHandler(
 
     override fun handle(command: ReleaseCatalogVersion): ReleaseCatalogVersionResult {
         val catalog = GetCatalog(command.tenantKey, command.catalogKey).query()
-            ?: throw IllegalArgumentException("Catalog not found: ${command.catalogKey}")
-        check(catalog.type == CatalogType.AUTHORED) {
-            "Only AUTHORED catalogs can be released — '${command.catalogKey.value}' is ${catalog.type}"
+            ?: throw CatalogNotFoundException(command.catalogKey)
+        if (catalog.type != CatalogType.AUTHORED) {
+            throw CatalogReadOnlyException(command.catalogKey)
         }
 
         val newVersion = try {

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/UpgradeCatalog.kt
@@ -8,6 +8,8 @@ import app.epistola.suite.catalog.CatalogClient
 import app.epistola.suite.catalog.CatalogFingerprintService
 import app.epistola.suite.catalog.CatalogImportContext
 import app.epistola.suite.catalog.CatalogKey
+import app.epistola.suite.catalog.CatalogNotFoundException
+import app.epistola.suite.catalog.CatalogNotUpgradeableException
 import app.epistola.suite.catalog.CatalogUpgradeAnalyzer
 import app.epistola.suite.catalog.RemovedResource
 import app.epistola.suite.catalog.queries.GetCatalog
@@ -93,10 +95,13 @@ class UpgradeCatalogHandler(
 
     override fun handle(command: UpgradeCatalog): UpgradeCatalogResult = CatalogImportContext.runAsImport {
         val catalog = GetCatalog(command.tenantKey, command.catalogKey).query()
-            ?: throw IllegalArgumentException("Catalog not found: ${command.catalogKey}")
+            ?: throw CatalogNotFoundException(command.catalogKey)
 
         val sourceUrl = catalog.sourceUrl
-            ?: throw IllegalStateException("Catalog '${command.catalogKey}' has no source URL — only subscribed catalogs can be upgraded")
+            ?: throw CatalogNotUpgradeableException(
+                command.catalogKey,
+                "only subscribed catalogs with a source URL can be upgraded",
+            )
 
         val previousVersion = catalog.installedReleaseVersion
 

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/documents/queries/PreviewDocument.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/documents/queries/PreviewDocument.kt
@@ -15,6 +15,9 @@ import app.epistola.suite.common.ids.VariantId
 import app.epistola.suite.common.ids.VariantKey
 import app.epistola.suite.common.ids.VersionId
 import app.epistola.suite.common.ids.VersionKey
+import app.epistola.suite.documents.DefaultVariantNotFoundException
+import app.epistola.suite.documents.NoPublishedVersionException
+import app.epistola.suite.documents.VersionNotFoundException
 import app.epistola.suite.generation.DocumentPreviewRenderer
 import app.epistola.suite.i18n.TenantLocaleResolver
 import app.epistola.suite.mediator.Mediator
@@ -22,6 +25,8 @@ import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
+import app.epistola.suite.templates.NoActiveVersionException
+import app.epistola.suite.templates.TemplateNotFoundException
 import app.epistola.suite.templates.queries.GetDocumentTemplate
 import app.epistola.suite.templates.queries.activations.GetActiveVersion
 import app.epistola.suite.templates.queries.versions.GetLatestPublishedVersion
@@ -29,6 +34,7 @@ import app.epistola.suite.templates.queries.versions.GetVersion
 import app.epistola.suite.templates.services.VariantResolver
 import app.epistola.suite.templates.services.VariantSelectionCriteria
 import app.epistola.suite.templates.validation.JsonSchemaValidator
+import app.epistola.suite.tenants.TenantNotFoundException
 import app.epistola.suite.tenants.queries.GetTenant
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
@@ -113,22 +119,22 @@ class PreviewDocumentHandler(
         val version = if (query.versionId != null) {
             val vid = VersionId(query.versionId, variantId)
             mediator.query(GetVersion(vid))
-                ?: throw IllegalStateException("Version ${query.versionId} not found")
+                ?: throw VersionNotFoundException(query.tenantId, query.templateId, resolvedVariantKey, query.versionId)
         } else if (query.environmentId != null) {
             val envId = EnvironmentId(query.environmentId, tenantId)
             mediator.query(GetActiveVersion(variantId, envId))
-                ?: throw IllegalStateException("No active version for environment ${query.environmentId}")
+                ?: throw NoActiveVersionException(query.tenantId, resolvedVariantKey, query.environmentId)
         } else {
             // Fallback: latest published version
             mediator.query(GetLatestPublishedVersion(variantId))
-                ?: throw IllegalStateException("No published version found for variant $resolvedVariantKey")
+                ?: throw NoPublishedVersionException(query.tenantId, query.templateId, resolvedVariantKey)
         }
 
         // 3. Fetch template and tenant for theme resolution
         val template = mediator.query(GetDocumentTemplate(templateId))
-            ?: throw IllegalStateException("Template ${query.templateId} not found")
+            ?: throw TemplateNotFoundException(query.tenantId, query.templateId)
         val tenant = mediator.query(GetTenant(id = query.tenantId))
-            ?: throw IllegalStateException("Tenant ${query.tenantId} not found")
+            ?: throw TenantNotFoundException(query.tenantId)
 
         // 4. Resolve data: use provided data, or fall back to first example from version's contract
         val contractVersion = version.contractVersion?.let { cv ->
@@ -186,9 +192,7 @@ class PreviewDocumentHandler(
                 .findOne()
                 .orElse(null)
         }
-        requireNotNull(variantId) {
-            "No default variant found for template $templateId in tenant $tenantId"
-        }
+        variantId ?: throw DefaultVariantNotFoundException(tenantId, templateId)
         return VariantKey.of(variantId)
     }
 }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/documents/PreviewDocumentIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/documents/PreviewDocumentIntegrationTest.kt
@@ -6,6 +6,7 @@ package app.epistola.suite.documents
 
 import app.epistola.suite.common.ids.CatalogId
 import app.epistola.suite.common.ids.CatalogKey
+import app.epistola.suite.common.ids.EnvironmentKey
 import app.epistola.suite.common.ids.TemplateId
 import app.epistola.suite.common.ids.TenantId
 import app.epistola.suite.common.ids.VariantId
@@ -13,6 +14,7 @@ import app.epistola.suite.documents.queries.PreviewDocument
 import app.epistola.suite.documents.queries.PreviewVariant
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
+import app.epistola.suite.templates.NoActiveVersionException
 import app.epistola.suite.testing.DocumentSetup
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestTemplateBuilder
@@ -23,6 +25,7 @@ import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.node.ObjectNode
@@ -570,9 +573,45 @@ class PreviewDocumentIntegrationTest : IntegrationTestBase() {
                             data = emptyData(),
                         ),
                     )
-                }.isInstanceOf(IllegalStateException::class.java)
+                }.isInstanceOf(VersionNotFoundException::class.java)
                     .hasMessageContaining("Version")
                     .hasMessageContaining("not found")
+            }
+        }
+
+        @Test
+        fun `preview reports no active version as a client-facing domain error`() = scenario {
+            given {
+                val tenant = tenant("Test Tenant")
+                val tenantId = TenantId(tenant.id)
+                val template = template(tenant.id, "Test Template")
+                val compositeTemplateId = TemplateId(template.id, CatalogId.default(tenantId))
+                val variant = variant(compositeTemplateId, "Default")
+                val compositeVariantId = VariantId(variant.id, compositeTemplateId)
+                val templateModel = TestTemplateBuilder.buildMinimal(name = "Test Template")
+                val version = version(compositeVariantId, templateModel)
+                DocumentSetup(tenant, template, variant, version)
+            }.whenever { setup ->
+                setup
+            }.then { setup, _ ->
+                val production = EnvironmentKey.of("production")
+
+                val error = assertThrows<NoActiveVersionException> {
+                    query(
+                        PreviewDocument(
+                            tenantId = setup.tenant.id,
+                            catalogKey = CatalogKey.DEFAULT,
+                            templateId = setup.template.id,
+                            variantId = setup.variant.id,
+                            environmentId = production,
+                            data = emptyData(),
+                        ),
+                    )
+                }
+
+                assertThat(error.tenantId).isEqualTo(setup.tenant.id)
+                assertThat(error.variantId).isEqualTo(setup.variant.id)
+                assertThat(error.environmentId).isEqualTo(production)
             }
         }
 

--- a/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/ApiExceptionHandler.kt
+++ b/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/ApiExceptionHandler.kt
@@ -20,6 +20,8 @@ import app.epistola.suite.attributes.commands.AttributeInUseException
 import app.epistola.suite.catalog.CatalogNotFoundException
 import app.epistola.suite.catalog.CatalogNotUpgradeableException
 import app.epistola.suite.catalog.CatalogReadOnlyException
+import app.epistola.suite.catalog.commands.CatalogReleaseVersionException
+import app.epistola.suite.catalog.commands.CatalogUpgradeConflictException
 import app.epistola.suite.catalog.migrations.CatalogSchemaTooNewException
 import app.epistola.suite.catalog.migrations.CatalogSchemaTooOldException
 import app.epistola.suite.catalog.migrations.CatalogSchemaUnknownException
@@ -280,6 +282,8 @@ class ApiExceptionHandler : ResponseEntityExceptionHandler() {
         CatalogReadOnlyException::class,
         CatalogNotFoundException::class,
         CatalogNotUpgradeableException::class,
+        CatalogReleaseVersionException::class,
+        CatalogUpgradeConflictException::class,
         CatalogSchemaTooNewException::class,
         CatalogSchemaTooOldException::class,
         CatalogSchemaUnknownException::class,

--- a/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/ApiExceptionMappings.kt
+++ b/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/ApiExceptionMappings.kt
@@ -19,6 +19,8 @@ import app.epistola.suite.attributes.commands.AttributeInUseException
 import app.epistola.suite.catalog.CatalogNotFoundException
 import app.epistola.suite.catalog.CatalogNotUpgradeableException
 import app.epistola.suite.catalog.CatalogReadOnlyException
+import app.epistola.suite.catalog.commands.CatalogReleaseVersionException
+import app.epistola.suite.catalog.commands.CatalogUpgradeConflictException
 import app.epistola.suite.catalog.migrations.CatalogSchemaTooNewException
 import app.epistola.suite.catalog.migrations.CatalogSchemaTooOldException
 import app.epistola.suite.catalog.migrations.CatalogSchemaUnknownException
@@ -541,6 +543,20 @@ object ApiExceptionMappings {
             defaultDetail = "Catalog cannot be upgraded",
             extensions = { mapOf("catalogId" to it.catalogKey.value) },
             logMessage = { "Catalog not upgradeable: ${it.message}" },
+        )
+
+        builder.register<CatalogReleaseVersionException>(
+            problemType = ApiProblemTypes.CATALOG_RELEASE_VERSION_INVALID,
+            defaultDetail = "Catalog release version is invalid",
+            extensions = { emptyMap() },
+            logMessage = { "Catalog release version rejected: ${it.message}" },
+        )
+
+        builder.register<CatalogUpgradeConflictException>(
+            problemType = ApiProblemTypes.CATALOG_UPGRADE_CONFLICT,
+            defaultDetail = "Catalog upgrade is blocked by resources that are still in use",
+            extensions = { mapOf("conflicts" to it.conflicts) },
+            logMessage = { "Catalog upgrade blocked by ${it.conflicts.size} conflict(s)" },
         )
 
         builder.register<CatalogSchemaTooNewException>(

--- a/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/ProblemDetails.kt
+++ b/modules/rest-api/src/main/kotlin/app/epistola/suite/api/v1/ProblemDetails.kt
@@ -83,6 +83,8 @@ object ApiProblemTypes {
     val CATALOG_READ_ONLY = problem("CATALOG_READ_ONLY", "Catalog Read Only", HttpStatus.CONFLICT, "The catalog is subscribed/read-only and cannot be modified through this API.", emptyList())
     val CATALOG_NOT_FOUND = problem("CATALOG_NOT_FOUND", "Catalog Not Found", HttpStatus.NOT_FOUND, "The requested catalog does not exist or is not visible to the caller.", listOf("catalogId"))
     val CATALOG_NOT_UPGRADEABLE = problem("CATALOG_NOT_UPGRADEABLE", "Catalog Not Upgradeable", HttpStatus.CONFLICT, "The requested catalog is not in a state that supports upgrade operations.", listOf("catalogId"))
+    val CATALOG_RELEASE_VERSION_INVALID = problem("CATALOG_RELEASE_VERSION_INVALID", "Invalid Catalog Release Version", HttpStatus.BAD_REQUEST, "The requested catalog release version is invalid or does not advance the current version.", emptyList())
+    val CATALOG_UPGRADE_CONFLICT = problem("CATALOG_UPGRADE_CONFLICT", "Catalog Upgrade Conflict", HttpStatus.CONFLICT, "The catalog upgrade would remove resources that are still in use.", listOf("conflicts"))
     val CATALOG_SCHEMA_TOO_NEW = problem("CATALOG_SCHEMA_TOO_NEW", "Catalog Wire Schema Too New", HttpStatus.BAD_REQUEST, "The catalog was exported by a newer Epistola than this instance can read; upgrade this instance.", listOf("version", "supportedVersion"))
     val CATALOG_SCHEMA_TOO_OLD = problem("CATALOG_SCHEMA_TOO_OLD", "Catalog Wire Schema Too Old", HttpStatus.BAD_REQUEST, "The catalog's wire format predates the oldest version this instance can upgrade; re-export from a current source.", listOf("version", "baselineVersion"))
     val CATALOG_SCHEMA_UNKNOWN = problem("CATALOG_SCHEMA_UNKNOWN", "Catalog Wire Schema Unrecognised", HttpStatus.BAD_REQUEST, "The uploaded payload is not a recognised catalog wire format (not valid JSON, or a missing or non-integer schemaVersion).", emptyList())
@@ -151,6 +153,8 @@ object ApiProblemTypes {
         CATALOG_READ_ONLY,
         CATALOG_NOT_FOUND,
         CATALOG_NOT_UPGRADEABLE,
+        CATALOG_RELEASE_VERSION_INVALID,
+        CATALOG_UPGRADE_CONFLICT,
         CATALOG_SCHEMA_TOO_NEW,
         CATALOG_SCHEMA_TOO_OLD,
         CATALOG_SCHEMA_UNKNOWN,

--- a/modules/rest-api/src/test/kotlin/app/epistola/suite/api/v1/CatalogOperationProblemMappingTest.kt
+++ b/modules/rest-api/src/test/kotlin/app/epistola/suite/api/v1/CatalogOperationProblemMappingTest.kt
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.api.v1
+
+import app.epistola.suite.catalog.commands.CatalogReleaseVersionException
+import app.epistola.suite.catalog.commands.CatalogUpgradeConflictException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class CatalogOperationProblemMappingTest {
+
+    @Test
+    fun `invalid release versions map to a client error`() {
+        val mapping = ApiExceptionMappings.forException(
+            CatalogReleaseVersionException("Version not-semver is invalid"),
+        )!!
+
+        assertThat(mapping.problemType.code).isEqualTo("CATALOG_RELEASE_VERSION_INVALID")
+        assertThat(mapping.problemType.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(mapping.detail(CatalogReleaseVersionException("Version not-semver is invalid")))
+            .contains("not-semver")
+    }
+
+    @Test
+    fun `upgrade conflicts expose the blocking resources`() {
+        val exception = CatalogUpgradeConflictException(listOf("theme/default", "stencil/header"))
+        val mapping = ApiExceptionMappings.forException(exception)!!
+
+        assertThat(mapping.problemType.code).isEqualTo("CATALOG_UPGRADE_CONFLICT")
+        assertThat(mapping.problemType.status).isEqualTo(HttpStatus.CONFLICT)
+        assertThat(mapping.extensions(exception)["conflicts"])
+            .isEqualTo(listOf("theme/default", "stencil/header"))
+    }
+}


### PR DESCRIPTION
## Summary

- return typed RFC problem details when document preview resolution cannot find a requested version, active environment version, published version, template, tenant, or default variant
- map expected catalog release and upgrade failures to clear 400, 404, and 409 API responses
- add integration and mapping coverage for the new responses
- document the behavior in the changelog

## Root cause

Expected domain and lookup failures were raised as generic `IllegalStateException` values. The global API handler consequently treated them as unexpected failures and returned HTTP 500 responses.

## Impact

API clients now receive stable problem types, useful details, and relevant extension fields that can be presented to users instead of a generic internal-server-error response.

## Validation

- `./gradlew ktlintCheck unitTest integrationTest`
- `pnpm format -- CHANGELOG.md`
- `pnpm format:check`
- `git diff --check`