### PR TITLE
fix(editor): align spacing and component rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **[user]** fix(editor): **Theme spacing and defaults now match generated documents.** The
   template editor receives the effective variant, template, or tenant theme and uses its spacing
   unit for canvas styles and every `sp` unit conversion, including borders and theme presets.
+- **[user]** fix(editor): **Margin and padding settings are no longer duplicated.** Template blocks
+  and theme presets now show one four-side Margin control and one four-side Padding control while
+  retaining the existing per-side values in stored documents.
 - **[user]** docs(legal): **Epistola's legal entity is now explicit.** Root documentation now
   identifies Epistola Nederland B.V. as the first-party copyright holder, publisher, support
   provider, and commercial SLA counterparty, while preserving third-party and contributor rights.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
   unit for canvas styles and every `sp` unit conversion, including borders and theme presets. Live
   PDF previews now use that same resolved editor theme so spacing conversions cannot drift. Unit
   switches on component properties such as image dimensions also use the theme's configured scale
-  instead of always falling back to 4pt.
+  instead of always falling back to 4pt, and image and QR-code dimensions render with that scale
+  on the editor canvas as well as in PDF previews.
 - **[user]** fix(editor): **Margin and padding settings are no longer duplicated.** Template blocks
   and theme presets now show one four-side Margin control and one four-side Padding control while
   retaining the existing per-side values in stored documents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   PDF previews now use that same resolved editor theme so spacing conversions cannot drift. Unit
   switches on component properties such as image dimensions also use the theme's configured scale
   instead of always falling back to 4pt, and image and QR-code dimensions render with that scale
-  on the editor canvas as well as in PDF previews.
+  on the editor canvas as well as in PDF previews. Locked image aspect ratios now remain correct
+  when either dimension uses `sp`, including mixed `pt`/`sp` dimensions.
 - **[user]** fix(editor): **Margin and padding settings are no longer duplicated.** Template blocks
   and theme presets now show one four-side Margin control, one four-side Padding control, and one
   four-side Border control while retaining the existing per-side values in stored documents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   now moves the caret into its rich-text surface so typed content appears immediately.
 - **[user]** fix(editor): **Theme spacing and defaults now match generated documents.** The
   template editor receives the effective variant, template, or tenant theme and uses its spacing
-  unit for canvas styles and every `sp` unit conversion, including borders and theme presets.
+  unit for canvas styles and every `sp` unit conversion, including borders and theme presets. Live
+  PDF previews now use that same resolved editor theme so spacing conversions cannot drift.
 - **[user]** fix(editor): **Margin and padding settings are no longer duplicated.** Template blocks
   and theme presets now show one four-side Margin control and one four-side Padding control while
   retaining the existing per-side values in stored documents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - **[user]** fix(editor): **Margin and padding settings are no longer duplicated.** Template blocks
   and theme presets now show one four-side Margin control and one four-side Padding control while
   retaining the existing per-side values in stored documents.
+- **[user]** fix(editor): **New datatables pass template validation.** The column-count prompt now
+  remains an editor-only creation detail instead of leaking `_columnCount` into the saved
+  datatable properties.
 - **[user]** docs(legal): **Epistola's legal entity is now explicit.** Root documentation now
   identifies Epistola Nederland B.V. as the first-party copyright holder, publisher, support
   provider, and commercial SLA counterparty, while preserving third-party and contributor rights.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- **[user]** fix(editor): **New text blocks are ready for typing.** Selecting an empty text block
+  now moves the caret into its rich-text surface so typed content appears immediately.
 - **[user]** fix(editor): **Theme spacing and defaults now match generated documents.** The
   template editor receives the effective variant, template, or tenant theme and uses its spacing
   unit for canvas styles and every `sp` unit conversion, including borders and theme presets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
   instead of always falling back to 4pt, and image and QR-code dimensions render with that scale
   on the editor canvas as well as in PDF previews.
 - **[user]** fix(editor): **Margin and padding settings are no longer duplicated.** Template blocks
-  and theme presets now show one four-side Margin control and one four-side Padding control while
-  retaining the existing per-side values in stored documents.
+  and theme presets now show one four-side Margin control, one four-side Padding control, and one
+  four-side Border control while retaining the existing per-side values in stored documents.
 - **[user]** fix(editor): **New datatables pass template validation.** The column-count prompt now
   remains an editor-only creation detail instead of leaking `_columnCount` into the saved
   datatable properties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- **[user]** fix(editor): **Theme spacing and defaults now match generated documents.** The
+  template editor receives the effective variant, template, or tenant theme and uses its spacing
+  unit for canvas styles and every `sp` unit conversion, including borders and theme presets.
 - **[user]** docs(legal): **Epistola's legal entity is now explicit.** Root documentation now
   identifies Epistola Nederland B.V. as the first-party copyright holder, publisher, support
   provider, and commercial SLA counterparty, while preserving third-party and contributor rights.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 - **[user]** fix(editor): **Theme spacing and defaults now match generated documents.** The
   template editor receives the effective variant, template, or tenant theme and uses its spacing
   unit for canvas styles and every `sp` unit conversion, including borders and theme presets. Live
-  PDF previews now use that same resolved editor theme so spacing conversions cannot drift.
+  PDF previews now use that same resolved editor theme so spacing conversions cannot drift. Unit
+  switches on component properties such as image dimensions also use the theme's configured scale
+  instead of always falling back to 4pt.
 - **[user]** fix(editor): **Margin and padding settings are no longer duplicated.** Template blocks
   and theme presets now show one four-side Margin control and one four-side Padding control while
   retaining the existing per-side values in stored documents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - **[user]** fix(editor): **New datatables pass template validation.** The column-count prompt now
   remains an editor-only creation detail instead of leaking `_columnCount` into the saved
   datatable properties.
+- **[user]** fix(pdf): **Keep with next now prevents orphaned blocks.** A block can stay with its
+  next visible sibling at any nesting level, including preset-driven chains inside containers and
+  stencils, while explicit page breaks and oversized groups continue to paginate safely.
 - **[user]** docs(legal): **Epistola's legal entity is now explicit.** Root documentation now
   identifies Epistola Nederland B.V. as the first-party copyright holder, publisher, support
   provider, and commercial SLA counterparty, while preserving third-party and contributor rights.

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
@@ -56,7 +56,11 @@ import app.epistola.suite.templates.validation.MigrationSuggestion
 import app.epistola.suite.templates.validation.SchemaCompatibilityResult
 import app.epistola.suite.templates.validation.ValidationError
 import app.epistola.suite.tenants.queries.GetTenant
+import app.epistola.suite.themes.BlockStylePresets
+import app.epistola.suite.themes.ThemeStyleResolver
 import app.epistola.suite.themes.queries.ListThemes
+import app.epistola.template.model.DocumentStyles
+import app.epistola.template.model.PageSettings
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.function.ServerRequest
@@ -116,6 +120,14 @@ data class ValidateSchemaResponse(
     }
 }
 
+/** Theme defaults needed by the browser editor, without persistence metadata. */
+data class EditorThemeConfig(
+    val documentStyles: DocumentStyles,
+    val pageSettings: PageSettings?,
+    val blockStylePresets: BlockStylePresets?,
+    val spacingUnit: Float?,
+)
+
 /**
  * Handles core template CRUD operations and template detail views.
  * Variant operations are handled by [VariantRouteHandler].
@@ -145,6 +157,7 @@ class DocumentTemplateHandler(
     private val jsonSchemaValidator: JsonSchemaValidator,
     private val detailHelper: TemplateDetailHelper,
     private val localeResolver: TenantLocaleResolver,
+    private val themeStyleResolver: ThemeStyleResolver,
 ) {
     private val logger = org.slf4j.LoggerFactory.getLogger(javaClass)
 
@@ -402,6 +415,21 @@ class DocumentTemplateHandler(
             ?: return ServerResponse.notFound().build()
         val resolvedLocale = localeResolver.resolve(tenant, context.variantAttributes)
         val featureToggles = ResolveFeatureToggles(tenantId.key).query()
+        val editorTheme = themeStyleResolver.resolveTheme(
+            tenantId = tenantId.key,
+            templateDefaultThemeId = context.templateThemeKey,
+            tenantDefaultThemeId = tenant.defaultThemeKey,
+            templateModel = context.templateModel,
+            templateCatalogKey = context.templateThemeCatalogKey,
+            tenantDefaultThemeCatalogKey = tenant.defaultThemeCatalogKey,
+        )?.let {
+            EditorThemeConfig(
+                documentStyles = it.documentStyles,
+                pageSettings = it.pageSettings,
+                blockStylePresets = it.blockStylePresets,
+                spacingUnit = it.spacingUnit,
+            )
+        }
 
         // Test-only seam (issue #418, Instance C): a `leaderTiming` query
         // param (JSON) lets UI tests shrink the editor's leader-hint TTLs so
@@ -419,6 +447,7 @@ class DocumentTemplateHandler(
                 "templateName" to context.templateName,
                 "variantAttributes" to context.variantAttributes,
                 "templateModel" to context.templateModel,
+                "editorTheme" to editorTheme,
                 "dataExamples" to context.dataExamples,
                 "dataModel" to context.dataModel,
                 "leaderTiming" to leaderTiming,

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/TemplatePreviewHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/TemplatePreviewHandler.kt
@@ -4,6 +4,8 @@
 
 package app.epistola.suite.templates
 
+import app.epistola.generation.pdf.ResolvedTheme
+import app.epistola.generation.pdf.SpacingScale
 import app.epistola.suite.common.ids.VersionKey
 import app.epistola.suite.documents.queries.PreviewDocument
 import app.epistola.suite.documents.queries.PreviewVariant
@@ -33,6 +35,7 @@ data class PreviewRequest(
     val data: ObjectNode? = null,
     val templateModel: Map<String, Any?>? = null,
     val versionId: Int? = null,
+    val theme: EditorThemeConfig? = null,
 )
 
 /**
@@ -89,6 +92,16 @@ class TemplatePreviewHandler(
                     variantId = variantId.key,
                     data = dataNode,
                     templateModel = liveTemplateModel,
+                    resolvedTheme = previewRequest.theme?.let { theme ->
+                        ResolvedTheme(
+                            documentStyles = theme.documentStyles,
+                            pageSettings = theme.pageSettings,
+                            blockStylePresets = theme.blockStylePresets
+                                ?.mapValues { (_, preset) -> preset.styles }
+                                .orEmpty(),
+                            spacingUnit = theme.spacingUnit ?: SpacingScale.DEFAULT_BASE_UNIT,
+                        )
+                    },
                 ).query()
             }
         } catch (e: ValidationException) {

--- a/apps/epistola/src/main/resources/static/js/editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/editor-boot.js
@@ -327,7 +327,11 @@ async function mount(container) {
             Accept: 'application/pdf',
             'X-XSRF-TOKEN': window.getCsrfToken(),
           },
-          body: JSON.stringify({ templateModel: doc, data: data?.data ?? data }),
+          body: JSON.stringify({
+            templateModel: doc,
+            data: data?.data ?? data,
+            theme: config.theme ?? null,
+          }),
           signal: signal,
         },
       );

--- a/apps/epistola/src/main/resources/static/js/editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/editor-boot.js
@@ -33,6 +33,7 @@ async function mount(container) {
   mountEditor({
     container: container,
     template: config.templateModel,
+    theme: config.theme ?? undefined,
     dataExamples: config.dataExamples,
     dataModel: config.dataModel,
     plugins: plugins,

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -81,6 +81,7 @@
     {
         "editorModuleUrl": [[@{/editor/template-editor.js}]],
         "templateModel": [[${templateModel}]],
+        "theme": [[${editorTheme}]],
         "templateId": [[${templateId}]],
         "tenantId": [[${tenantId}]],
         "catalogId": [[${catalogId}]],

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -11,6 +11,8 @@ import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TemplateId
 import app.epistola.suite.common.ids.TemplateKey
 import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.ThemeId
+import app.epistola.suite.common.ids.ThemeKey
 import app.epistola.suite.common.ids.VariantKey
 import app.epistola.suite.features.KnownFeatures
 import app.epistola.suite.features.commands.SaveFeatureToggle
@@ -22,6 +24,7 @@ import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.queries.ListDocumentTemplates
 import app.epistola.suite.templates.queries.ListDocumentTemplatesHandler
 import app.epistola.suite.tenants.Tenant
+import app.epistola.suite.themes.commands.CreateTheme
 import org.assertj.core.api.Assertions.assertThat
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.Nested
@@ -1372,6 +1375,49 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
                 assertThat(response.body).contains("\"moduleUrl\": \"/editor/walkthrough-plugin-")
                 assertThat(response.body).contains("\"stylesheetUrl\": \"/editor/ai-plugin-")
                 assertThat(response.body).doesNotContain("<link rel=\"stylesheet\" href=\"/editor/ai-plugin-")
+            }
+        }
+
+        @Test
+        fun `GET editor page includes effective theme defaults`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+            var variantId: VariantKey? = null
+
+            given {
+                testTenant = tenant("Themed Editor Tenant")
+                template = template(testTenant, "Themed Editor Template")
+                variantId = variant(testTenant, template, "Default").id
+                withMediator {
+                    val catalogId = CatalogId.default(TenantId(testTenant.id))
+                    val themeId = ThemeId(ThemeKey.of("editor-theme"), catalogId)
+                    CreateTheme(
+                        id = themeId,
+                        name = "Editor Theme",
+                        documentStyles = mapOf("fontSize" to "10pt"),
+                        spacingUnit = 6f,
+                    ).execute()
+                    UpdateDocumentTemplate(
+                        id = TemplateId(template.id, catalogId),
+                        themeId = themeId.key,
+                        themeCatalogKey = themeId.catalogKey,
+                    ).execute()
+                }
+            }
+
+            whenever {
+                restTemplate.getForEntity(
+                    "/tenants/${testTenant.id}/templates/default/${template.id}/variants/$variantId/editor",
+                    String::class.java,
+                )
+            }
+
+            then {
+                val response = result<org.springframework.http.ResponseEntity<String>>()
+                assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+                assertThat(response.body).contains("\"theme\": {")
+                assertThat(response.body).contains("\"documentStyles\":{\"fontSize\":\"10pt\"}")
+                assertThat(response.body).contains("\"spacingUnit\":6.0")
             }
         }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -78,6 +78,10 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
         }
     }
 
+    private fun pdfPageCount(pdfBytes: ByteArray): Int = Regex("""/Type\s*/Page\b""")
+        .findAll(pdfBytes.toString(Charsets.ISO_8859_1))
+        .count()
+
     @Test
     fun `GET templates returns list page with template data`() = fixture {
         lateinit var testTenant: Tenant
@@ -1758,6 +1762,73 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
                 val response = result<org.springframework.http.ResponseEntity<ByteArray>>()
                 assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
                 assertThat(response.headers.contentType).isEqualTo(MediaType.APPLICATION_PDF)
+            }
+        }
+
+        @Test
+        fun `POST live preview uses the editor theme spacing unit`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+            var variantId: VariantKey? = null
+
+            given {
+                testTenant = tenant("Preview Spacing Tenant")
+                template = template(testTenant, "Preview Spacing Template")
+                variantId = variant(testTenant, template, "Default").id
+            }
+
+            whenever {
+                fun preview(spacingUnit: Int): ByteArray {
+                    val headers = HttpHeaders()
+                    headers.contentType = MediaType.APPLICATION_JSON
+                    val textNodes = (1..5).joinToString(",") { index ->
+                        """"text-$index": {
+                            "id": "text-$index",
+                            "type": "text",
+                            "slots": [],
+                            "styles": {"marginBottom": "10sp"},
+                            "props": {"content": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "SPACING-$index"}]}]}}
+                        }"""
+                    }
+                    val textChildren = (1..5).joinToString(",") { index -> "\"text-$index\"" }
+                    val body = """{
+                        "data": {},
+                        "theme": {
+                            "documentStyles": {},
+                            "pageSettings": null,
+                            "blockStylePresets": null,
+                            "spacingUnit": $spacingUnit
+                        },
+                        "templateModel": {
+                            "modelVersion": 1,
+                            "root": "root-1",
+                            "nodes": {
+                                "root-1": {"id": "root-1", "type": "root", "slots": ["slot-1"]},
+                                $textNodes
+                            },
+                            "slots": {
+                                "slot-1": {"id": "slot-1", "nodeId": "root-1", "name": "children", "children": [$textChildren]}
+                            },
+                            "themeRef": {"type": "inherit"}
+                        }
+                    }"""
+                    return requireNotNull(
+                        restTemplate.postForEntity(
+                            "/tenants/${testTenant.id}/templates/default/${template.id}/variants/$variantId/preview",
+                            HttpEntity(body, headers),
+                            ByteArray::class.java,
+                        ).body,
+                    )
+                }
+
+                val defaultPdf = preview(spacingUnit = 4)
+                val largePdf = preview(spacingUnit = 20)
+                pdfPageCount(defaultPdf) to pdfPageCount(largePdf)
+            }
+
+            then {
+                val (defaultPages, largePages) = result<Pair<Int, Int>>()
+                assertThat(largePages).isGreaterThan(defaultPages)
             }
         }
 

--- a/modules/editor/src/main/typescript/components/datatable/datatable-registration.ts
+++ b/modules/editor/src/main/typescript/components/datatable/datatable-registration.ts
@@ -75,6 +75,12 @@ export function createDatatableDefinition(): ComponentDefinition {
     createSubtree: (nodeId: NodeId, props?: Record<string, unknown>) => {
       const columnCount = (props?._columnCount as number | undefined) ?? 3;
 
+      // The dialog value is factory input, not a contract-declared property.
+      // Remove it from the same merged object that createNode persists.
+      if (props) {
+        delete props._columnCount;
+      }
+
       const columnsSlotId = nanoid() as SlotId;
       const columnNodeIds: NodeId[] = [];
       const extraNodes: Node[] = [];

--- a/modules/editor/src/main/typescript/components/datatable/datatable.test.ts
+++ b/modules/editor/src/main/typescript/components/datatable/datatable.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { EditorEngine } from '../../engine/EditorEngine.js';
 import { createDefaultRegistry } from '../../engine/registry.js';
 import { createTestDocument, resetCounter } from '../../engine/test-helpers.js';
-import type { NodeId, SlotId } from '../../types/index.js';
+import type { NodeId } from '../../types/index.js';
 
 beforeEach(() => {
   resetCounter();
@@ -72,6 +72,14 @@ describe('Datatable createNode subtree', () => {
 
     // slots = 1 columns slot + 3 body slots = 4 total
     expect(slots).toHaveLength(4);
+  });
+
+  it('does not persist the transient column count factory input', () => {
+    const registry = createDefaultRegistry();
+    const { node, extraNodes } = registry.createNode('datatable', { _columnCount: 4 });
+
+    expect(extraNodes).toHaveLength(4);
+    expect(node.props).not.toHaveProperty('_columnCount');
   });
 
   it('columns slot has 3 child node IDs', () => {

--- a/modules/editor/src/main/typescript/components/image/image-registration.test.ts
+++ b/modules/editor/src/main/typescript/components/image/image-registration.test.ts
@@ -145,14 +145,46 @@ describe('image onPropChange aspect ratio lock', () => {
     expect(result.height).toBe('');
   });
 
-  it('does nothing when value uses non-pt unit', () => {
+  it('does nothing when value uses a percentage', () => {
     const def = imageDef();
     const props = { width: '100pt', height: '200pt', aspectRatioLocked: true };
 
     const result = def.onPropChange!('width', '50%', props);
 
-    // parsePt returns null for non-pt values, so height stays unchanged
     expect(result.height).toBe('200pt');
+  });
+
+  it('adjusts an sp dimension using the active theme spacing unit', () => {
+    const def = imageDef();
+    const props = { width: '1sp', height: '2sp', aspectRatioLocked: true };
+
+    const result = def.onPropChange!('width', '2sp', props, {
+      engine: { theme: { spacingUnit: 16 } },
+    });
+
+    expect(result.height).toBe('4sp');
+  });
+
+  it('adjusts a pt dimension when the changed dimension uses sp', () => {
+    const def = imageDef();
+    const props = { width: '16pt', height: '32pt', aspectRatioLocked: true };
+
+    const result = def.onPropChange!('width', '2sp', props, {
+      engine: { theme: { spacingUnit: 16 } },
+    });
+
+    expect(result.height).toBe('64pt');
+  });
+
+  it('keeps the linked dimension stable for an equivalent pt to sp switch', () => {
+    const def = imageDef();
+    const props = { width: '16pt', height: '32pt', aspectRatioLocked: true };
+
+    const result = def.onPropChange!('width', '1sp', props, {
+      engine: { theme: { spacingUnit: 16 } },
+    });
+
+    expect(result.height).toBe('32pt');
   });
 
   it('rounds the computed dimension', () => {

--- a/modules/editor/src/main/typescript/components/image/image-registration.test.ts
+++ b/modules/editor/src/main/typescript/components/image/image-registration.test.ts
@@ -3,7 +3,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { describe, it, expect } from 'vitest';
-import { createImageDefinition, resolveContentUrl, crossCatalogKey } from './image-registration.js';
+import {
+  createImageDefinition,
+  resolveContentUrl,
+  crossCatalogKey,
+  resolveCanvasDimension,
+} from './image-registration.js';
 import type { ComponentDefinition } from '../../engine/registry.js';
 
 /** Minimal stubs — the asset picker is unused in onPropChange tests. */
@@ -63,6 +68,17 @@ describe('crossCatalogKey', () => {
 
   it('returns the asset catalog when it differs from the template catalog', () => {
     expect(crossCatalogKey('system', 'epistola-demo')).toBe('system');
+  });
+});
+
+describe('resolveCanvasDimension', () => {
+  it('converts sp dimensions with the theme spacing unit', () => {
+    expect(resolveCanvasDimension('1sp', 16)).toBe('16pt');
+  });
+
+  it('preserves absolute and percentage dimensions', () => {
+    expect(resolveCanvasDimension('16pt', 16)).toBe('16pt');
+    expect(resolveCanvasDimension('50%', 16)).toBe('50%');
   });
 });
 

--- a/modules/editor/src/main/typescript/components/image/image-registration.ts
+++ b/modules/editor/src/main/typescript/components/image/image-registration.ts
@@ -13,6 +13,7 @@ import type { ComponentDefinition } from '../../engine/registry.js';
 import type { EditorEngine } from '../../engine/EditorEngine.js';
 import { openAssetPickerDialog, type AssetPickerCallbacks } from './asset-picker-dialog.js';
 import { html } from 'lit';
+import { convertSpToPt, DEFAULT_SPACING_UNIT_PT } from '../../ui/style-css.js';
 
 /** Layout-only style properties available on image nodes. */
 const IMAGE_STYLES = ['padding', 'margin'];
@@ -65,6 +66,14 @@ function parsePt(value: unknown): number | null {
 /** Convert image pixel dimensions to pt (1px = 0.75pt). */
 function pxToPt(px: number): number {
   return Math.round(px * 0.75);
+}
+
+/** Convert an image dimension to browser CSS using the active theme spacing scale. */
+export function resolveCanvasDimension(
+  value: string | undefined,
+  spacingUnitPt: number,
+): string | undefined {
+  return value ? convertSpToPt(value, spacingUnitPt) : undefined;
 }
 
 export function createImageDefinition(options?: ImageOptions): ComponentDefinition {
@@ -215,8 +224,9 @@ export function createImageDefinition(options?: ImageOptions): ComponentDefiniti
       const nodeCatalogKey = node.props?.catalogKey as string | undefined;
       const src = resolveContentUrl(contentUrlPattern, assetId, nodeCatalogKey, defaultCatalogKey);
       const alt = (node.props?.alt as string) || '';
-      const width = node.props?.width as string | undefined;
-      const height = node.props?.height as string | undefined;
+      const spacingUnit = engine.theme?.spacingUnit ?? DEFAULT_SPACING_UNIT_PT;
+      const width = resolveCanvasDimension(node.props?.width as string | undefined, spacingUnit);
+      const height = resolveCanvasDimension(node.props?.height as string | undefined, spacingUnit);
 
       const imgStyle =
         [width ? `width: ${width}` : '', height ? `height: ${height}` : '']

--- a/modules/editor/src/main/typescript/components/image/image-registration.ts
+++ b/modules/editor/src/main/typescript/components/image/image-registration.ts
@@ -54,13 +54,31 @@ export function crossCatalogKey(
   return assetCatalogKey === defaultCatalogKey ? null : assetCatalogKey;
 }
 
-/** Parse a pt value, returning the numeric part or null for non-pt / empty values. */
-function parsePt(value: unknown): number | null {
+interface ParsedDimension {
+  points: number;
+  unit: 'pt' | 'sp';
+}
+
+/** Resolve a physical image dimension to points while retaining its stored unit. */
+function parseDimension(value: unknown, spacingUnitPt: number): ParsedDimension | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
-  if (!trimmed.endsWith('pt')) return null;
   const num = parseFloat(trimmed);
-  return Number.isFinite(num) && num > 0 ? num : null;
+  if (!Number.isFinite(num) || num <= 0) return null;
+  if (trimmed.endsWith('pt')) return { points: num, unit: 'pt' };
+  if (trimmed.endsWith('sp')) return { points: num * spacingUnitPt, unit: 'sp' };
+  return null;
+}
+
+/** Format a computed physical dimension in the linked property's existing unit. */
+function formatDimension(
+  points: number,
+  unit: ParsedDimension['unit'],
+  spacingUnitPt: number,
+): string {
+  if (unit === 'pt') return `${Math.round(points)}pt`;
+  const multiplier = Number((points / spacingUnitPt).toFixed(3));
+  return `${multiplier}sp`;
 }
 
 /** Convert image pixel dimensions to pt (1px = 0.75pt). */
@@ -106,21 +124,25 @@ export function createImageDefinition(options?: ImageOptions): ComponentDefiniti
       aspectRatioLocked: true,
     },
 
-    onPropChange: (key, value, props) => {
+    onPropChange: (key, value, props, context) => {
       if (!props.aspectRatioLocked) return props;
 
-      const oldWidth = parsePt(props.width);
-      const oldHeight = parsePt(props.height);
+      const editorEngine = context?.engine as EditorEngine | undefined;
+      const spacingUnit = editorEngine?.theme?.spacingUnit ?? DEFAULT_SPACING_UNIT_PT;
+      const oldWidth = parseDimension(props.width, spacingUnit);
+      const oldHeight = parseDimension(props.height, spacingUnit);
 
       if (key === 'width' && oldHeight && oldWidth) {
-        const newWidth = parsePt(value);
+        const newWidth = parseDimension(value, spacingUnit);
         if (newWidth) {
-          props.height = `${Math.round(oldHeight * (newWidth / oldWidth))}pt`;
+          const heightPoints = oldHeight.points * (newWidth.points / oldWidth.points);
+          props.height = formatDimension(heightPoints, oldHeight.unit, spacingUnit);
         }
       } else if (key === 'height' && oldWidth && oldHeight) {
-        const newHeight = parsePt(value);
+        const newHeight = parseDimension(value, spacingUnit);
         if (newHeight) {
-          props.width = `${Math.round(oldWidth * (newHeight / oldHeight))}pt`;
+          const widthPoints = oldWidth.points * (newHeight.points / oldHeight.points);
+          props.width = formatDimension(widthPoints, oldWidth.unit, spacingUnit);
         }
       }
 

--- a/modules/editor/src/main/typescript/components/qrcode/EpistolaQrCodePreview.ts
+++ b/modules/editor/src/main/typescript/components/qrcode/EpistolaQrCodePreview.ts
@@ -9,13 +9,16 @@ import QRCode from 'qrcode';
 import type { EditorEngine } from '../../engine/EditorEngine.js';
 import type { NodeId } from '../../types/index.js';
 import { evaluateExpression } from '../../engine/resolve-expression.js';
+import { DEFAULT_SPACING_UNIT_PT } from '../../ui/style-css.js';
 
 const DEFAULT_SIZE_PT = 120;
 const PX_PER_PT = 96 / 72;
-const SPACING_UNIT_PT = 4;
 const MAX_VALUE_BYTES = 2500;
 
-function parseSizeToPt(value: unknown): number | null {
+export function parseSizeToPt(
+  value: unknown,
+  spacingUnitPt: number = DEFAULT_SPACING_UNIT_PT,
+): number | null {
   if (typeof value === 'number') {
     return Number.isFinite(value) && value > 0 ? value : null;
   }
@@ -27,7 +30,7 @@ function parseSizeToPt(value: unknown): number | null {
 
   if (trimmed.endsWith('sp')) {
     const sp = Number.parseFloat(trimmed.slice(0, -2));
-    return Number.isFinite(sp) && sp > 0 ? sp * SPACING_UNIT_PT : null;
+    return Number.isFinite(sp) && sp > 0 ? sp * spacingUnitPt : null;
   }
 
   if (trimmed.endsWith('pt')) {
@@ -39,13 +42,13 @@ function parseSizeToPt(value: unknown): number | null {
   return Number.isFinite(unitless) && unitless > 0 ? unitless : null;
 }
 
-function resolveCssSize(value: unknown): string {
-  const sizePt = parseSizeToPt(value) ?? DEFAULT_SIZE_PT;
+function resolveCssSize(value: unknown, spacingUnitPt: number): string {
+  const sizePt = parseSizeToPt(value, spacingUnitPt) ?? DEFAULT_SIZE_PT;
   return `${sizePt}pt`;
 }
 
-function resolveQrWidth(value: unknown): number {
-  const sizePt = parseSizeToPt(value) ?? DEFAULT_SIZE_PT;
+function resolveQrWidth(value: unknown, spacingUnitPt: number): number {
+  const sizePt = parseSizeToPt(value, spacingUnitPt) ?? DEFAULT_SIZE_PT;
   return Math.max(128, Math.round(sizePt * PX_PER_PT));
 }
 
@@ -108,7 +111,7 @@ export class EpistolaQrCodePreview extends LitElement {
   }
 
   override render() {
-    const size = resolveCssSize(this.size);
+    const size = resolveCssSize(this.size, this._spacingUnit);
 
     if (this._status === 'ready' && this._svgMarkup) {
       return html`
@@ -185,7 +188,7 @@ export class EpistolaQrCodePreview extends LitElement {
         type: 'svg',
         errorCorrectionLevel: 'M',
         margin: 1,
-        width: resolveQrWidth(this.size),
+        width: resolveQrWidth(this.size, this._spacingUnit),
         color: {
           dark: '#111827ff',
           light: '#ffffffff',
@@ -196,6 +199,10 @@ export class EpistolaQrCodePreview extends LitElement {
       this._svgMarkup = null;
       this._status = 'invalid';
     }
+  }
+
+  private get _spacingUnit(): number {
+    return this.engine?.theme?.spacingUnit ?? DEFAULT_SPACING_UNIT_PT;
   }
 }
 

--- a/modules/editor/src/main/typescript/components/qrcode/qrcode.test.ts
+++ b/modules/editor/src/main/typescript/components/qrcode/qrcode.test.ts
@@ -7,9 +7,20 @@ import { EditorEngine } from '../../engine/EditorEngine.js';
 import { createDefaultRegistry } from '../../engine/registry.js';
 import { createTestDocument, resetCounter } from '../../engine/test-helpers.js';
 import type { NodeId } from '../../types/index.js';
+import { parseSizeToPt } from './EpistolaQrCodePreview.js';
 
 beforeEach(() => {
   resetCounter();
+});
+
+describe('QR code canvas sizing', () => {
+  it('converts sp sizes with the theme spacing unit', () => {
+    expect(parseSizeToPt('1sp', 16)).toBe(16);
+  });
+
+  it('keeps pt sizes unchanged', () => {
+    expect(parseSizeToPt('16pt', 16)).toBe(16);
+  });
 });
 
 function setupQrCodeEngine(overrideProps?: Record<string, unknown>) {

--- a/modules/editor/src/main/typescript/engine/EditorEngine.ts
+++ b/modules/editor/src/main/typescript/engine/EditorEngine.ts
@@ -9,10 +9,16 @@
  * undo/redo, and change notification. Framework-agnostic.
  */
 
-import type { TemplateDocument, NodeId, SlotId, PageSettings } from '../types/index.js';
+import type {
+  TemplateDocument,
+  NodeId,
+  SlotId,
+  PageSettings,
+  EditorTheme,
+} from '../types/index.js';
 import { type FieldPath, extractFieldPaths } from './schema-paths.js';
 import { SYSTEM_PARAMETER_PATHS, SYSTEM_PARAM_MOCK_DATA } from './system-params.js';
-import type { StyleRegistry, Theme } from '@epistola.app/epistola-catalog';
+import type { StyleRegistry } from '@epistola.app/epistola-catalog';
 import { type DocumentIndexes, buildIndexes } from './indexes.js';
 import { type AnyCommand, type CommandResult, applyCommand } from './commands.js';
 import { UndoStack } from './undo.js';
@@ -46,7 +52,7 @@ export class EditorEngine {
   private _selectedNodeId: NodeId | null = null;
   readonly registry: ComponentRegistry;
   readonly styleRegistry: StyleRegistry;
-  private _theme: Theme | undefined;
+  private _theme: EditorTheme | undefined;
   private _resolvedDocStyles!: Record<string, unknown>;
   private _inheritableKeys: Set<string>;
   private _resolvedPageSettings!: PageSettings;
@@ -87,7 +93,7 @@ export class EditorEngine {
     doc: TemplateDocument,
     registry: ComponentRegistry,
     options?: {
-      theme?: Theme;
+      theme?: EditorTheme;
       styleRegistry?: StyleRegistry;
       undoDepth?: number;
       dataModel?: object;
@@ -178,7 +184,7 @@ export class EditorEngine {
     return this._doc.slots[id];
   }
 
-  get theme(): Theme | undefined {
+  get theme(): EditorTheme | undefined {
     return this._theme;
   }
 
@@ -347,7 +353,7 @@ export class EditorEngine {
   }
 
   /** Update the theme (e.g. when loading a different theme). */
-  setTheme(theme: Theme | undefined): void {
+  setTheme(theme: EditorTheme | undefined): void {
     this._theme = theme;
     this._recomputeStyles();
     this._notify(false);

--- a/modules/editor/src/main/typescript/engine/engine.test.ts
+++ b/modules/editor/src/main/typescript/engine/engine.test.ts
@@ -1400,6 +1400,38 @@ describe('UpdatePageSettings', () => {
   });
 });
 
+describe('Editor theme defaults', () => {
+  it('keeps theme defaults separate so clearing an override reveals the theme', () => {
+    const registry = testRegistry();
+    const doc = {
+      ...createTestDocument(),
+      documentStylesOverride: { color: '#abcdef' },
+    };
+    const engine = new EditorEngine(doc, registry, {
+      theme: {
+        documentStyles: { color: '#112233', fontSize: '10pt' },
+        pageSettings: {
+          format: 'Letter',
+          orientation: 'landscape',
+          margins: { top: 12, right: 13, bottom: 14, left: 15 },
+        },
+        blockStylePresets: {
+          heading: { label: 'Heading', styles: { fontWeight: 700 } },
+        },
+        spacingUnit: 6,
+      },
+    });
+
+    expect(engine.theme?.spacingUnit).toBe(6);
+    expect(engine.resolvedDocStyles).toMatchObject({ color: '#abcdef', fontSize: '10pt' });
+    expect(engine.resolvedPageSettings.format).toBe('Letter');
+
+    engine.dispatch({ type: 'UpdateDocumentStyles', styles: {} });
+
+    expect(engine.resolvedDocStyles).toMatchObject({ color: '#112233', fontSize: '10pt' });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Undo / Redo
 // ---------------------------------------------------------------------------

--- a/modules/editor/src/main/typescript/engine/registry.ts
+++ b/modules/editor/src/main/typescript/engine/registry.ts
@@ -283,6 +283,7 @@ export interface ComponentDefinition {
     key: string,
     value: unknown,
     currentProps: Record<string, unknown>,
+    context?: { engine: unknown },
   ) => Record<string, unknown>;
 
   /**

--- a/modules/editor/src/main/typescript/engine/style-registry.test.ts
+++ b/modules/editor/src/main/typescript/engine/style-registry.test.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import { styleRegistry } from '@epistola.app/epistola-catalog/registry';
+import type { StyleRegistry } from '@epistola.app/epistola-catalog';
+import {
+  createEditorStyleRegistry,
+  defaultStyleRegistry,
+  isEditorStyleApplicable,
+} from './style-registry.js';
+
+describe('editor style registry', () => {
+  it('replaces spacing longhands with the compound margin and padding controls', () => {
+    const spacing = defaultStyleRegistry.groups.find((group) => group.label === 'Spacing');
+    const keys = spacing?.properties.map((property) => property.key);
+
+    expect(keys).toEqual(['padding', 'margin']);
+  });
+
+  it('does not mutate the contract registry', () => {
+    createEditorStyleRegistry(styleRegistry);
+    const spacing = styleRegistry.groups.find((group) => group.label === 'Spacing');
+
+    expect(spacing?.properties.map((property) => property.key)).toContain('marginTop');
+    expect(spacing?.properties.map((property) => property.key)).toContain('paddingLeft');
+  });
+
+  it('keeps a longhand when a future registry omits its compound control', () => {
+    const source: StyleRegistry = {
+      schemaVersion: 1,
+      groups: [
+        {
+          name: 'spacing',
+          label: 'Spacing',
+          properties: [{ key: 'marginTop', label: 'Top Margin', type: 'unit' }],
+        },
+      ],
+    };
+
+    expect(createEditorStyleRegistry(source).groups[0].properties).toHaveLength(1);
+  });
+
+  it('maps component longhand allowlists to their compound control', () => {
+    expect(isEditorStyleApplicable('margin', ['marginBottom'])).toBe(true);
+    expect(isEditorStyleApplicable('padding', ['paddingLeft'])).toBe(true);
+    expect(isEditorStyleApplicable('margin', ['paddingTop'])).toBe(false);
+  });
+});

--- a/modules/editor/src/main/typescript/engine/style-registry.test.ts
+++ b/modules/editor/src/main/typescript/engine/style-registry.test.ts
@@ -19,12 +19,21 @@ describe('editor style registry', () => {
     expect(keys).toEqual(['padding', 'margin']);
   });
 
+  it('replaces border longhands with the compound border control', () => {
+    const borders = defaultStyleRegistry.groups.find((group) => group.label === 'Borders');
+    const keys = borders?.properties.map((property) => property.key);
+
+    expect(keys).toEqual(['border', 'borderRadius']);
+  });
+
   it('does not mutate the contract registry', () => {
     createEditorStyleRegistry(styleRegistry);
     const spacing = styleRegistry.groups.find((group) => group.label === 'Spacing');
 
     expect(spacing?.properties.map((property) => property.key)).toContain('marginTop');
     expect(spacing?.properties.map((property) => property.key)).toContain('paddingLeft');
+    const borders = styleRegistry.groups.find((group) => group.label === 'Borders');
+    expect(borders?.properties.map((property) => property.key)).toContain('borderTop');
   });
 
   it('keeps a longhand when a future registry omits its compound control', () => {
@@ -45,6 +54,7 @@ describe('editor style registry', () => {
   it('maps component longhand allowlists to their compound control', () => {
     expect(isEditorStyleApplicable('margin', ['marginBottom'])).toBe(true);
     expect(isEditorStyleApplicable('padding', ['paddingLeft'])).toBe(true);
+    expect(isEditorStyleApplicable('border', ['borderBottom'])).toBe(true);
     expect(isEditorStyleApplicable('margin', ['paddingTop'])).toBe(false);
   });
 });

--- a/modules/editor/src/main/typescript/engine/style-registry.ts
+++ b/modules/editor/src/main/typescript/engine/style-registry.ts
@@ -12,9 +12,10 @@
 import { styleRegistry } from '@epistola.app/epistola-catalog/registry';
 import type { StyleRegistry } from '@epistola.app/epistola-catalog';
 
-const COMPOUND_SPACING_LONGHANDS: Record<string, ReadonlySet<string>> = {
+const COMPOUND_STYLE_LONGHANDS: Record<string, ReadonlySet<string>> = {
   margin: new Set(['marginTop', 'marginRight', 'marginBottom', 'marginLeft']),
   padding: new Set(['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft']),
+  border: new Set(['borderTop', 'borderRight', 'borderBottom', 'borderLeft']),
 };
 
 /**
@@ -27,7 +28,7 @@ export function createEditorStyleRegistry(source: StyleRegistry): StyleRegistry 
   for (const group of registry.groups) {
     const keys = new Set(group.properties.map((property) => property.key));
     const hiddenLonghands = new Set<string>();
-    for (const [compound, longhands] of Object.entries(COMPOUND_SPACING_LONGHANDS)) {
+    for (const [compound, longhands] of Object.entries(COMPOUND_STYLE_LONGHANDS)) {
       if (keys.has(compound)) {
         longhands.forEach((key) => hiddenLonghands.add(key));
       }
@@ -40,7 +41,7 @@ export function createEditorStyleRegistry(source: StyleRegistry): StyleRegistry 
 /** Whether a component allowlist makes an editor property available. */
 export function isEditorStyleApplicable(propertyKey: string, applicableStyles: string[]): boolean {
   if (applicableStyles.includes(propertyKey)) return true;
-  const longhands = COMPOUND_SPACING_LONGHANDS[propertyKey];
+  const longhands = COMPOUND_STYLE_LONGHANDS[propertyKey];
   return longhands ? applicableStyles.some((key) => longhands.has(key)) : false;
 }
 

--- a/modules/editor/src/main/typescript/engine/style-registry.ts
+++ b/modules/editor/src/main/typescript/engine/style-registry.ts
@@ -12,4 +12,36 @@
 import { styleRegistry } from '@epistola.app/epistola-catalog/registry';
 import type { StyleRegistry } from '@epistola.app/epistola-catalog';
 
-export const defaultStyleRegistry: StyleRegistry = structuredClone(styleRegistry);
+const COMPOUND_SPACING_LONGHANDS: Record<string, ReadonlySet<string>> = {
+  margin: new Set(['marginTop', 'marginRight', 'marginBottom', 'marginLeft']),
+  padding: new Set(['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft']),
+};
+
+/**
+ * Build the registry presented by editor UIs. The contract keeps canonical
+ * longhand properties for validation and serialization, while the compound
+ * controls edit those same keys and therefore replace the duplicate rows.
+ */
+export function createEditorStyleRegistry(source: StyleRegistry): StyleRegistry {
+  const registry = structuredClone(source);
+  for (const group of registry.groups) {
+    const keys = new Set(group.properties.map((property) => property.key));
+    const hiddenLonghands = new Set<string>();
+    for (const [compound, longhands] of Object.entries(COMPOUND_SPACING_LONGHANDS)) {
+      if (keys.has(compound)) {
+        longhands.forEach((key) => hiddenLonghands.add(key));
+      }
+    }
+    group.properties = group.properties.filter((property) => !hiddenLonghands.has(property.key));
+  }
+  return registry;
+}
+
+/** Whether a component allowlist makes an editor property available. */
+export function isEditorStyleApplicable(propertyKey: string, applicableStyles: string[]): boolean {
+  if (applicableStyles.includes(propertyKey)) return true;
+  const longhands = COMPOUND_SPACING_LONGHANDS[propertyKey];
+  return longhands ? applicableStyles.some((key) => longhands.has(key)) : false;
+}
+
+export const defaultStyleRegistry: StyleRegistry = createEditorStyleRegistry(styleRegistry);

--- a/modules/editor/src/main/typescript/lib.ts
+++ b/modules/editor/src/main/typescript/lib.ts
@@ -14,7 +14,7 @@
 import './editor.css';
 import './ui/EpistolaEditor.js';
 import './ui/quality-plugin.js';
-import type { TemplateDocument, NodeId, SlotId } from './types/index.js';
+import type { TemplateDocument, NodeId, SlotId, EditorTheme } from './types/index.js';
 import type { FetchPreviewFn } from './ui/preview-service.js';
 import type { EditorPlugin } from './plugins/types.js';
 import { createDefaultRegistry } from './engine/registry.js';
@@ -31,7 +31,7 @@ import { nanoid } from 'nanoid';
 
 validateCoreShortcutRegistriesOnStartup();
 
-export type { TemplateDocument, Node, Slot, NodeId, SlotId } from './types/index.js';
+export type { TemplateDocument, Node, Slot, NodeId, SlotId, EditorTheme } from './types/index.js';
 export type { AssetInfo, CatalogInfo } from './components/image/asset-picker-dialog.js';
 export type { FontInfo } from './engine/font-catalog.js';
 export type {
@@ -88,6 +88,8 @@ export interface EditorOptions {
   container: HTMLElement;
   /** Initial template document (node/slot model) */
   template?: TemplateDocument;
+  /** Effective theme defaults selected by the host's variant/template/tenant cascade. */
+  theme?: EditorTheme;
   /** Callback when the template is saved */
   onSave?: (template: TemplateDocument) => Promise<void>;
   /** JSON Schema describing the data model (for expression autocomplete) */
@@ -258,6 +260,7 @@ export function mountEditor(options: EditorOptions): EditorInstance {
   editorEl.initEngine(doc, registry, {
     dataModel,
     dataExamples,
+    theme: options.theme,
     features: options.features,
     locale: options.locale,
   });

--- a/modules/editor/src/main/typescript/theme-editor/sections/DocumentStylesSection.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/DocumentStylesSection.ts
@@ -19,6 +19,7 @@ import {
   renderColorInput,
   renderSpacingInput,
   renderSelectInput,
+  DEFAULT_SPACING_UNIT,
 } from '../../ui/inputs/style-inputs.js';
 import type { ThemeEditorState } from '../ThemeEditorState.js';
 
@@ -41,6 +42,7 @@ export function renderDocumentStylesSection(state: ThemeEditorState, readOnly = 
                 prop,
                 docStyles[prop.key],
                 (value) => state.updateDocumentStyle(prop.key, value),
+                state.theme.spacingUnit ?? DEFAULT_SPACING_UNIT,
                 readOnly,
               ),
             )}
@@ -55,13 +57,14 @@ function renderStyleProperty(
   prop: StyleProperty,
   value: unknown,
   onChange: (value: unknown) => void,
+  spacingUnit: number,
   readOnly = false,
 ): unknown {
   const inputId = `theme-doc-style-${prop.key}`;
   return html`
     <div class="inspector-field">
       <label class="inspector-field-label" for=${inputId}>${prop.label}</label>
-      ${renderStyleInput(prop, value, onChange, inputId, readOnly)}
+      ${renderStyleInput(prop, value, onChange, spacingUnit, inputId, readOnly)}
     </div>
   `;
 }
@@ -70,6 +73,7 @@ function renderStyleInput(
   prop: StyleProperty,
   value: unknown,
   onChange: (value: unknown) => void,
+  spacingUnit: number,
   inputId: string,
   readOnly = false,
 ): unknown {
@@ -87,7 +91,7 @@ function renderStyleInput(
         value,
         prop.units ?? ['px'],
         (v) => onChange(v),
-        undefined,
+        spacingUnit,
         inputId,
         readOnly,
       );
@@ -98,7 +102,7 @@ function renderStyleInput(
         value,
         prop.units ?? ['px'],
         (v) => onChange(v),
-        undefined,
+        spacingUnit,
         inputId,
         readOnly,
       );

--- a/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.test.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import { ThemeEditorState } from '../ThemeEditorState.js';
+import { renderPresetItem } from './PresetItem.js';
+
+function templateToHtml(value: unknown): string {
+  if (value == null || value === false || typeof value === 'symbol') return '';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  if (Array.isArray(value)) return value.map(templateToHtml).join('');
+  if (typeof value === 'object' && 'strings' in value && 'values' in value) {
+    const result = value as { strings: ArrayLike<string>; values: unknown[] };
+    return Array.from(result.strings)
+      .map((part, index) => part + templateToHtml(result.values[index]))
+      .join('');
+  }
+  return '';
+}
+
+describe('PresetItem spacing controls', () => {
+  it('renders compound margin and padding controls without longhand duplicates', () => {
+    const state = new ThemeEditorState({
+      id: 'test',
+      name: 'Test',
+      documentStyles: {},
+      blockStylePresets: {
+        card: {
+          label: 'Card',
+          styles: { marginTop: '1sp', paddingLeft: '2sp' },
+        },
+      },
+      spacingUnit: 6,
+    });
+
+    const html = templateToHtml(
+      renderPresetItem(state, 'card', state.theme.blockStylePresets.card, () => undefined),
+    );
+
+    expect(html.match(/>Margin</g)).toHaveLength(1);
+    expect(html.match(/>Padding</g)).toHaveLength(1);
+    expect(html).not.toContain('Top Margin');
+    expect(html).not.toContain('Left Padding');
+  });
+});

--- a/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
+++ b/modules/editor/src/main/typescript/theme-editor/sections/PresetItem.ts
@@ -20,6 +20,7 @@ import {
   renderSpacingInput,
   renderSelectInput,
   COMPOUND_STYLE_TYPES,
+  DEFAULT_SPACING_UNIT,
   type BorderValue,
 } from '../../ui/inputs/style-inputs.js';
 import '../../ui/inputs/BorderInput.js';
@@ -169,6 +170,7 @@ function renderPresetBody(
                   value,
                   (v) => state.updatePresetStyle(name, prop.key, v, prop.type),
                   `preset-${name}-style-${prop.key}`,
+                  state.theme.spacingUnit ?? DEFAULT_SPACING_UNIT,
                   readOnly,
                 );
               })}
@@ -185,12 +187,13 @@ function renderPresetStyleProperty(
   value: unknown,
   onChange: (value: unknown) => void,
   inputId: string,
+  spacingUnit: number,
   readOnly = false,
 ): unknown {
   return html`
     <div class="inspector-field">
       <label class="inspector-field-label" for=${inputId}>${prop.label}</label>
-      ${renderPresetStyleInput(prop, value, onChange, inputId, readOnly)}
+      ${renderPresetStyleInput(prop, value, onChange, inputId, spacingUnit, readOnly)}
     </div>
   `;
 }
@@ -200,6 +203,7 @@ function renderPresetStyleInput(
   value: unknown,
   onChange: (value: unknown) => void,
   inputId: string,
+  spacingUnit: number,
   readOnly = false,
 ): unknown {
   switch (prop.type) {
@@ -216,7 +220,7 @@ function renderPresetStyleInput(
         value,
         prop.units ?? ['px'],
         (v) => onChange(v),
-        undefined,
+        spacingUnit,
         inputId,
         readOnly,
       );
@@ -227,7 +231,7 @@ function renderPresetStyleInput(
         value,
         prop.units ?? ['px'],
         (v) => onChange(v),
-        undefined,
+        spacingUnit,
         inputId,
         readOnly,
       );
@@ -236,6 +240,7 @@ function renderPresetStyleInput(
         <epistola-border-input
           .value=${value as BorderValue | undefined}
           .units=${prop.units ?? ['pt', 'sp']}
+          .baseUnit=${spacingUnit}
           ?readOnly=${readOnly}
           @change=${(e: CustomEvent) => onChange(e.detail)}
         ></epistola-border-input>

--- a/modules/editor/src/main/typescript/types/index.ts
+++ b/modules/editor/src/main/typescript/types/index.ts
@@ -23,3 +23,11 @@ export type {
   ExpressionLanguage,
   Expression,
 } from '@epistola.app/epistola-catalog';
+
+import type { Theme } from '@epistola.app/epistola-catalog';
+
+/** Theme defaults required by the template editor's style cascade. */
+export type EditorTheme = Pick<
+  Theme,
+  'documentStyles' | 'pageSettings' | 'blockStylePresets' | 'spacingUnit'
+>;

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.tabindex.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.tabindex.test.ts
@@ -134,6 +134,22 @@ describe('EpistolaCanvas — read-only blocks are not user-focusable', () => {
     expect(tabindexFor(container, 'stencil')).toBe('0');
   });
 
+  it('moves focus into an empty text editor when its block is selected', async () => {
+    const engine = setupEngine(true);
+    await renderCanvas(container, engine);
+
+    const block = container.querySelector<HTMLElement>(
+      '.canvas-block[data-node-id="text-toplevel"]',
+    );
+    expect(block).not.toBeNull();
+
+    block!.click();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(engine.selectedNodeId).toBe('text-toplevel');
+    expect(document.activeElement?.classList.contains('ProseMirror')).toBe(true);
+  });
+
   it('blocks inside the locked stencil children slot have no tabindex (out of tab cycle and click cycle)', async () => {
     const engine = setupEngine(true);
     await renderCanvas(container, engine);

--- a/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaEditor.ts
@@ -5,7 +5,7 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { keyed } from 'lit/directives/keyed.js';
-import type { TemplateDocument, NodeId, SlotId } from '../types/index.js';
+import type { TemplateDocument, NodeId, SlotId, EditorTheme } from '../types/index.js';
 import { EditorEngine } from '../engine/EditorEngine.js';
 import { wireParameterCache } from '../engine/parameter-evaluation-cache.js';
 import {
@@ -216,6 +216,7 @@ export class EpistolaEditor extends LitElement {
     options?: {
       dataModel?: object;
       dataExamples?: object[];
+      theme?: EditorTheme;
       features?: EditorFeatures;
       locale?: string;
     },
@@ -231,6 +232,7 @@ export class EpistolaEditor extends LitElement {
     this._engine = new EditorEngine(doc, reg, {
       dataModel: options?.dataModel,
       dataExamples: options?.dataExamples,
+      theme: options?.theme,
       features: options?.features,
       locale: options?.locale,
     });

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
@@ -176,9 +176,9 @@ describe('EpistolaInspector generic presentation hook', () => {
       documentStyles: {},
       pageSettings: undefined,
       blockStylePresets: {},
-      spacingUnit: 6,
+      spacingUnit: 16,
     });
-    engine.dispatch({ type: 'UpdateNodeProps', nodeId: textNodeId, props: { width: '12pt' } });
+    engine.dispatch({ type: 'UpdateNodeProps', nodeId: textNodeId, props: { width: '32pt' } });
     inspector.doc = engine.doc;
 
     const fieldTemplate = (

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
@@ -89,6 +89,16 @@ describe('EpistolaInspector generic presentation hook', () => {
     expect(html).not.toContain('Right Padding');
   });
 
+  it('renders one four-side border control without longhand duplicates', () => {
+    const { inspector } = setupInspector();
+
+    const html = templateToHtml(inspector.render());
+
+    expect(html.match(/>Border</g)).toHaveLength(1);
+    expect(html).not.toContain('Top Border');
+    expect(html).not.toContain('Right Border');
+  });
+
   it('renders the default component label and full generic sections when no presentation hook is provided', () => {
     const { inspector } = setupInspector();
 

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
@@ -78,6 +78,17 @@ function setupInspector(): SetupResult {
 }
 
 describe('EpistolaInspector generic presentation hook', () => {
+  it('renders one four-side margin and padding control without longhand duplicates', () => {
+    const { inspector } = setupInspector();
+
+    const html = templateToHtml(inspector.render());
+
+    expect(html.match(/>Margin</g)).toHaveLength(1);
+    expect(html.match(/>Padding</g)).toHaveLength(1);
+    expect(html).not.toContain('Top Margin');
+    expect(html).not.toContain('Right Padding');
+  });
+
   it('renders the default component label and full generic sections when no presentation hook is provided', () => {
     const { inspector } = setupInspector();
 

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.test.ts
@@ -168,4 +168,39 @@ describe('EpistolaInspector generic presentation hook', () => {
 
     expect(updateCount).toBe(2);
   });
+
+  it('uses the theme spacing unit when converting component unit properties', () => {
+    const { engine, inspector, textNodeId } = setupInspector();
+    const unitField = { key: 'width', label: 'Width', type: 'unit', units: ['pt', 'sp'] } as const;
+    engine.setTheme({
+      documentStyles: {},
+      pageSettings: undefined,
+      blockStylePresets: {},
+      spacingUnit: 6,
+    });
+    engine.dispatch({ type: 'UpdateNodeProps', nodeId: textNodeId, props: { width: '12pt' } });
+    inspector.doc = engine.doc;
+
+    const fieldTemplate = (
+      inspector as unknown as {
+        _renderField: (
+          node: NonNullable<ReturnType<EditorEngine['getNode']>>,
+          field: unknown,
+        ) => {
+          values: unknown[];
+        };
+      }
+    )._renderField(engine.getNode(textNodeId)!, unitField);
+    const unitTemplate = fieldTemplate.values.at(-1) as { values: unknown[] };
+    const selectTemplate = unitTemplate.values.find(
+      (value): value is { values: unknown[] } =>
+        typeof value === 'object' && value !== null && 'values' in value,
+    )!;
+    const handleUnitChange = selectTemplate.values.find(
+      (value): value is (event: Event) => void => typeof value === 'function',
+    )!;
+    handleUnitChange({ target: { value: 'sp' } } as unknown as Event);
+
+    expect(engine.getNode(textNodeId)?.props?.width).toBe('2sp');
+  });
 });

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -583,7 +583,7 @@ export class EpistolaInspector extends LitElement {
               value,
               field.units ?? ['pt'],
               (v) => this._handlePropChange(field.key, v),
-              undefined,
+              this.engine?.theme?.spacingUnit ?? DEFAULT_SPACING_UNIT,
               fieldId,
             )}
           </div>

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -659,7 +659,7 @@ export class EpistolaInspector extends LitElement {
 
     const def = this.engine.registry.get(node.type);
     if (def?.onPropChange) {
-      newProps = def.onPropChange(key, value, newProps);
+      newProps = def.onPropChange(key, value, newProps, { engine: this.engine });
     }
 
     setNestedValue(newProps, key, value);

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -14,6 +14,7 @@ import type {
 } from '../engine/registry.js';
 import type { BlockStylePreset, StyleProperty } from '@epistola.app/epistola-catalog';
 import { getNestedValue, setNestedValue } from '../engine/props.js';
+import { isEditorStyleApplicable } from '../engine/style-registry.js';
 import { EDITOR_UI_ANCHORS } from './editor-ui-anchors.js';
 import { normalizeFontFamilyValue, fontFamilyValueToSelectValue } from '../engine/font-ref.js';
 import {
@@ -403,7 +404,7 @@ export class EpistolaInspector extends LitElement {
   ): StyleProperty[] {
     if (!applicableStyles || applicableStyles === 'all') return properties;
     if (applicableStyles.length === 0) return [];
-    return properties.filter((p) => applicableStyles.includes(p.key));
+    return properties.filter((p) => isEditorStyleApplicable(p.key, applicableStyles));
   }
 
   private _renderStyleProperty(

--- a/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaInspector.ts
@@ -28,6 +28,7 @@ import {
   renderSpacingInput,
   renderSelectInput,
   COMPOUND_STYLE_TYPES,
+  DEFAULT_SPACING_UNIT,
   type BorderValue,
 } from './inputs/style-inputs.js';
 import './inputs/BorderInput.js';
@@ -427,6 +428,7 @@ export class EpistolaInspector extends LitElement {
     onChange: (value: unknown) => void,
     inputId: string,
   ): unknown {
+    const spacingUnit = this.engine?.theme?.spacingUnit ?? DEFAULT_SPACING_UNIT;
     switch (prop.type) {
       case 'select':
         return renderSelectInput(
@@ -436,7 +438,13 @@ export class EpistolaInspector extends LitElement {
           inputId,
         );
       case 'unit':
-        return renderUnitInput(value, prop.units ?? ['px'], (v) => onChange(v), undefined, inputId);
+        return renderUnitInput(
+          value,
+          prop.units ?? ['px'],
+          (v) => onChange(v),
+          spacingUnit,
+          inputId,
+        );
       case 'color':
         return renderColorInput(value, (v) => onChange(v || undefined), inputId);
       case 'spacing':
@@ -444,7 +452,7 @@ export class EpistolaInspector extends LitElement {
           value,
           prop.units ?? ['px'],
           (v) => onChange(v),
-          undefined,
+          spacingUnit,
           inputId,
         );
       case 'border':
@@ -452,6 +460,7 @@ export class EpistolaInspector extends LitElement {
           <epistola-border-input
             .value=${value as BorderValue | undefined}
             .units=${prop.units ?? ['pt', 'sp']}
+            .baseUnit=${spacingUnit}
             @change=${(e: CustomEvent) => onChange(e.detail)}
           ></epistola-border-input>
         `;

--- a/modules/editor/src/main/typescript/ui/EpistolaTextEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaTextEditor.ts
@@ -321,6 +321,11 @@ export class EpistolaTextEditor extends LitElement {
     this._pmView = null;
   }
 
+  /** Move keyboard focus into the rich-text surface after its block is selected. */
+  focusEditor(): void {
+    this._pmView?.focus();
+  }
+
   // ---------------------------------------------------------------------------
   // TextChange integration
   // ---------------------------------------------------------------------------

--- a/modules/editor/src/main/typescript/ui/inputs/BorderInput.ts
+++ b/modules/editor/src/main/typescript/ui/inputs/BorderInput.ts
@@ -43,6 +43,7 @@ export class BorderInput extends LitElement {
 
   @property({ type: Object }) value?: BorderValue;
   @property({ type: Array }) units: string[] = ['pt', 'sp'];
+  @property({ type: Number }) baseUnit = DEFAULT_SPACING_UNIT;
   @property({ type: Boolean }) readOnly = false;
 
   @state() private _linked = true;
@@ -191,10 +192,10 @@ export class BorderInput extends LitElement {
                           let newValue = widthParsed.value;
                           if (oldUnit === 'pt' && newUnit === 'sp') {
                             newValue = parseFloat(
-                              nearestSpacingStep(widthParsed.value, DEFAULT_SPACING_UNIT),
+                              nearestSpacingStep(widthParsed.value, this.baseUnit),
                             );
                           } else if (oldUnit === 'sp' && newUnit === 'pt') {
-                            newValue = widthParsed.value * DEFAULT_SPACING_UNIT;
+                            newValue = widthParsed.value * this.baseUnit;
                           }
                           this._handleSideChange(
                             side,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/documents/queries/PreviewVariant.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/documents/queries/PreviewVariant.kt
@@ -4,6 +4,7 @@
 
 package app.epistola.suite.documents.queries
 
+import app.epistola.generation.pdf.ResolvedTheme
 import app.epistola.suite.common.ids.CatalogId
 import app.epistola.suite.common.ids.TemplateId
 import app.epistola.suite.common.ids.TemplateKey
@@ -45,6 +46,7 @@ data class PreviewVariant(
     val variantId: VariantKey,
     val data: ObjectNode,
     val templateModel: TemplateDocument? = null,
+    val resolvedTheme: ResolvedTheme? = null,
 ) : Query<ByteArray>,
     RequiresPermission {
     override val permission get() = Permission.DOCUMENT_GENERATE
@@ -129,6 +131,7 @@ class PreviewVariantHandler(
             tenant = tenant,
             data = query.data,
             culture = culture,
+            resolvedThemeOverride = query.resolvedTheme,
         )
     }
 

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/DocumentPreviewRenderer.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/DocumentPreviewRenderer.kt
@@ -9,6 +9,7 @@ import app.epistola.generation.pdf.AssetResolution
 import app.epistola.generation.pdf.AssetResolver
 import app.epistola.generation.pdf.PdfMetadata
 import app.epistola.generation.pdf.RenderingDefaults
+import app.epistola.generation.pdf.ResolvedTheme
 import app.epistola.suite.assets.queries.GetAssetContent
 import app.epistola.suite.common.ids.AssetKey
 import app.epistola.suite.common.ids.CatalogKey
@@ -59,6 +60,7 @@ class DocumentPreviewRenderer(
         tenant: Tenant,
         data: ObjectNode,
         culture: RenderCulture = RenderCulture.DEFAULT,
+        resolvedThemeOverride: ResolvedTheme? = null,
     ): ByteArray {
         val outputStream = ByteArrayOutputStream()
 
@@ -120,6 +122,7 @@ class DocumentPreviewRenderer(
                 tenantDefaultThemeCatalogKey = tenant.defaultThemeCatalogKey,
                 culture = culture,
                 watermarkText = PREVIEW_WATERMARK,
+                resolvedThemeOverride = resolvedThemeOverride,
             )
         }
 

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/GenerationService.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/GenerationService.kt
@@ -84,29 +84,33 @@ class GenerationService(
         tenantDefaultThemeCatalogKey: CatalogKey? = null,
         culture: RenderCulture = RenderCulture.DEFAULT,
         watermarkText: String? = null,
+        resolvedThemeOverride: ResolvedTheme? = null,
     ) {
         templateDocumentValidator.validateTemplateGraphForRendering(templateModel)
 
-        // Resolve styles from theme (variant-level > template-level > tenant-level)
-        val resolvedStyles = themeStyleResolver.resolveStyles(
+        // Live editor previews can provide the exact theme snapshot used by
+        // the canvas; all other callers resolve the authoritative cascade.
+        val resolvedTheme = resolvedThemeOverride ?: themeStyleResolver.resolveStyles(
             tenantId,
             templateDefaultThemeId,
             tenantDefaultThemeId,
             templateModel,
             templateCatalogKey = templateCatalogKey,
             tenantDefaultThemeCatalogKey = tenantDefaultThemeCatalogKey,
-        )
+        ).let { resolvedStyles ->
+            ResolvedTheme(
+                documentStyles = resolvedStyles.documentStyles,
+                pageSettings = resolvedStyles.pageSettings,
+                blockStylePresets = resolvedStyles.blockStylePresets.mapValues { (_, preset) -> preset.styles },
+                spacingUnit = resolvedStyles.spacingUnit,
+            )
+        }
 
         pdfRenderer.render(
             document = templateModel,
             data = data,
             outputStream = outputStream,
-            resolvedTheme = ResolvedTheme(
-                documentStyles = resolvedStyles.documentStyles,
-                pageSettings = resolvedStyles.pageSettings,
-                blockStylePresets = resolvedStyles.blockStylePresets.mapValues { (_, preset) -> preset.styles },
-                spacingUnit = resolvedStyles.spacingUnit,
-            ),
+            resolvedTheme = resolvedTheme,
             metadata = metadata,
             pdfaCompliant = pdfaCompliant,
             assetResolver = assetResolver,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/GetEditorContext.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/queries/GetEditorContext.kt
@@ -4,7 +4,9 @@
 
 package app.epistola.suite.templates.queries
 
+import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.common.ids.ThemeKey
 import app.epistola.suite.common.ids.VariantId
 import app.epistola.suite.mediator.Query
 import app.epistola.suite.mediator.QueryHandler
@@ -22,6 +24,8 @@ import tools.jackson.databind.node.ObjectNode
  */
 data class EditorContext(
     val templateName: String,
+    val templateThemeKey: ThemeKey?,
+    val templateThemeCatalogKey: CatalogKey?,
     val variantAttributes: Map<String, String>,
     val templateModel: TemplateDocument,
     val dataExamples: List<DataExample>,
@@ -50,6 +54,8 @@ class GetEditorContextHandler(
             """
             SELECT
                 dt.name as template_name,
+                dt.theme_key,
+                dt.theme_catalog_key,
                 cv.data_model,
                 cv.data_examples,
                 tv.attributes as variant_attributes,
@@ -124,6 +130,8 @@ class GetEditorContextHandler(
 
         EditorContext(
             templateName = row["template_name"] as String,
+            templateThemeKey = (row["theme_key"] as String?)?.let(ThemeKey::of),
+            templateThemeCatalogKey = (row["theme_catalog_key"] as String?)?.let(CatalogKey::of),
             variantAttributes = variantAttributes,
             templateModel = templateModel,
             dataExamples = dataExamples,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/themes/ThemeStyleResolver.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/themes/ThemeStyleResolver.kt
@@ -91,6 +91,46 @@ class ThemeStyleResolver(
         templateCatalogKey: CatalogKey? = null,
         tenantDefaultThemeCatalogKey: CatalogKey? = null,
     ): ResolvedStyles {
+        val theme = resolveTheme(
+            tenantId = tenantId,
+            templateDefaultThemeId = templateDefaultThemeId,
+            tenantDefaultThemeId = tenantDefaultThemeId,
+            templateModel = templateModel,
+            templateCatalogKey = templateCatalogKey,
+            tenantDefaultThemeCatalogKey = tenantDefaultThemeCatalogKey,
+        )
+        val templateDocumentStyles = templateModel.documentStylesOverride ?: emptyMap()
+
+        return if (theme != null) {
+            ResolvedStyles(
+                documentStyles = mergeDocumentStyles(theme.documentStyles, templateDocumentStyles),
+                pageSettings = theme.pageSettings, // Theme page settings as fallback
+                blockStylePresets = theme.blockStylePresets ?: BlockStylePresets.EMPTY,
+                spacingUnit = theme.spacingUnit ?: SpacingScale.DEFAULT_BASE_UNIT,
+            )
+        } else {
+            ResolvedStyles(
+                documentStyles = templateDocumentStyles,
+                pageSettings = null,
+                blockStylePresets = BlockStylePresets.EMPTY,
+            )
+        }
+    }
+
+    /**
+     * Returns the unmerged effective theme selected by the same cascade used
+     * for generation. Callers that apply template overrides themselves (such
+     * as the editor) must use this rather than [resolveStyles], otherwise an
+     * override would be baked into the theme fallback and could not be cleared.
+     */
+    fun resolveTheme(
+        tenantId: TenantKey,
+        templateDefaultThemeId: ThemeKey?,
+        tenantDefaultThemeId: ThemeKey?,
+        templateModel: TemplateDocument,
+        templateCatalogKey: CatalogKey? = null,
+        tenantDefaultThemeCatalogKey: CatalogKey? = null,
+    ): Theme? {
         // Theme cascade: variant-level > template-level > tenant-level
         // The catalog key must follow the theme key through the cascade
         val (effectiveThemeId, effectiveCatalogKey) = when (val ref = templateModel.themeRef) {
@@ -108,23 +148,7 @@ class ThemeStyleResolver(
             }
         }
 
-        val theme = effectiveThemeId?.let { getTheme(tenantId, effectiveCatalogKey, it) }
-        val templateDocumentStyles = templateModel.documentStylesOverride ?: emptyMap()
-
-        return if (theme != null) {
-            ResolvedStyles(
-                documentStyles = mergeDocumentStyles(theme.documentStyles, templateDocumentStyles),
-                pageSettings = theme.pageSettings, // Theme page settings as fallback
-                blockStylePresets = theme.blockStylePresets ?: BlockStylePresets.EMPTY,
-                spacingUnit = theme.spacingUnit ?: SpacingScale.DEFAULT_BASE_UNIT,
-            )
-        } else {
-            ResolvedStyles(
-                documentStyles = templateDocumentStyles,
-                pageSettings = null,
-                blockStylePresets = BlockStylePresets.EMPTY,
-            )
-        }
+        return effectiveThemeId?.let { getTheme(tenantId, effectiveCatalogKey, it) }
     }
 
     /**

--- a/modules/epistola-core/src/main/resources/epistola/catalogs/demo/catalog.json
+++ b/modules/epistola-core/src/main/resources/epistola/catalogs/demo/catalog.json
@@ -10,9 +10,9 @@
     "url": "https://github.com/epistola-app"
   },
   "release": {
-    "version": "5.16.4",
-    "releasedAt": "2026-07-29T00:00:00Z",
-    "fingerprint": "3e69a550dbce0f08ac610b8f2156ed764e0beee452f5dbaf32a7183ca8efee90"
+    "version": "5.16.5",
+    "releasedAt": "2026-07-31T00:00:00Z",
+    "fingerprint": "a85079f7a7deb9ae98f776680f6fbb6dcf1e8c5d364a077acf4fc345af95b3e2"
   },
   "resources": [
     {

--- a/modules/epistola-core/src/main/resources/epistola/catalogs/demo/resources/templates/simple-letter.json
+++ b/modules/epistola-core/src/main/resources/epistola/catalogs/demo/resources/templates/simple-letter.json
@@ -303,7 +303,7 @@
           "id": "n-attachments",
           "type": "text",
           "slots": [],
-          "styles": { "marginTop": "4sp" },
+          "styles": { "marginTop": "4sp", "keepWithNext": true },
           "props": {
             "content": {
               "type": "doc",

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogIntegrationTest.kt
@@ -45,7 +45,7 @@ class CatalogIntegrationTest : IntegrationTestBase() {
             assertThat(catalog.name).isEqualTo("Epistola Demo Catalog")
             assertThat(catalog.type).isEqualTo(CatalogType.SUBSCRIBED)
             assertThat(catalog.sourceUrl).isEqualTo(DEMO_CATALOG_URL)
-            assertThat(catalog.installedReleaseVersion).isEqualTo("5.16.4")
+            assertThat(catalog.installedReleaseVersion).isEqualTo("5.16.5")
         }
     }
 

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/themes/ThemeQueriesTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/themes/ThemeQueriesTest.kt
@@ -35,8 +35,76 @@ import app.epistola.suite.themes.queries.GetThemeUsagePage
 import app.epistola.suite.themes.queries.ListThemes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 
 class ThemeQueriesTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var themeStyleResolver: ThemeStyleResolver
+
+    @Test
+    fun `effective theme follows cascade without merging template overrides`(): Unit = withMediator {
+        val tenant = createTenant("Theme Resolver Cascade")
+        val catalogId = CatalogId.default(TenantId(tenant.id))
+        val tenantTheme = ThemeId(ThemeKey.of("tenant-theme"), catalogId)
+        val templateTheme = ThemeId(ThemeKey.of("template-theme"), catalogId)
+        val variantTheme = ThemeId(ThemeKey.of("variant-theme"), catalogId)
+        CreateTheme(id = tenantTheme, name = "Tenant", spacingUnit = 4f).execute()
+        CreateTheme(id = templateTheme, name = "Template", spacingUnit = 5f).execute()
+        CreateTheme(
+            id = variantTheme,
+            name = "Variant",
+            documentStyles = mapOf("color" to "#112233", "fontSize" to "10pt"),
+            spacingUnit = 6f,
+        ).execute()
+
+        val inheritedModel = createDefaultTemplateModel(VariantKey.INITIAL)
+        assertThat(
+            themeStyleResolver.resolveTheme(
+                tenantId = tenant.id,
+                templateDefaultThemeId = null,
+                tenantDefaultThemeId = tenantTheme.key,
+                templateModel = inheritedModel,
+                tenantDefaultThemeCatalogKey = tenantTheme.catalogKey,
+            )?.name,
+        ).isEqualTo("Tenant")
+        assertThat(
+            themeStyleResolver.resolveTheme(
+                tenantId = tenant.id,
+                templateDefaultThemeId = templateTheme.key,
+                tenantDefaultThemeId = tenantTheme.key,
+                templateModel = inheritedModel,
+                templateCatalogKey = templateTheme.catalogKey,
+                tenantDefaultThemeCatalogKey = tenantTheme.catalogKey,
+            )?.name,
+        ).isEqualTo("Template")
+
+        val overriddenModel = inheritedModel.copy(
+            themeRef = ThemeRefOverride(variantTheme.key.value, variantTheme.catalogKey.value),
+            documentStylesOverride = mapOf("color" to "#abcdef"),
+        )
+        val rawTheme = themeStyleResolver.resolveTheme(
+            tenantId = tenant.id,
+            templateDefaultThemeId = templateTheme.key,
+            tenantDefaultThemeId = tenantTheme.key,
+            templateModel = overriddenModel,
+            templateCatalogKey = templateTheme.catalogKey,
+            tenantDefaultThemeCatalogKey = tenantTheme.catalogKey,
+        )
+        val mergedStyles = themeStyleResolver.resolveStyles(
+            tenantId = tenant.id,
+            templateDefaultThemeId = templateTheme.key,
+            tenantDefaultThemeId = tenantTheme.key,
+            templateModel = overriddenModel,
+            templateCatalogKey = templateTheme.catalogKey,
+            tenantDefaultThemeCatalogKey = tenantTheme.catalogKey,
+        )
+
+        assertThat(rawTheme?.name).isEqualTo("Variant")
+        assertThat(rawTheme?.spacingUnit).isEqualTo(6f)
+        assertThat(rawTheme?.documentStyles?.get("color")).isEqualTo("#112233")
+        assertThat(mergedStyles.documentStyles["color"]).isEqualTo("#abcdef")
+        assertThat(mergedStyles.documentStyles["fontSize"]).isEqualTo("10pt")
+    }
 
     @Test
     fun `GetTheme returns the theme`(): Unit = withMediator {

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/NodeRenderer.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/NodeRenderer.kt
@@ -6,7 +6,11 @@ package app.epistola.generation.pdf
 
 import app.epistola.template.model.Node
 import app.epistola.template.model.TemplateDocument
+import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.Div
+import com.itextpdf.layout.element.IBlockElement
 import com.itextpdf.layout.element.IElement
+import com.itextpdf.layout.element.Image
 
 /**
  * Interface for rendering template nodes to iText PDF elements.
@@ -83,7 +87,56 @@ class NodeRendererRegistry(
         context: RenderContext,
     ): List<IElement> {
         val slot = document.slots[slotId] ?: return emptyList()
-        return slot.children.flatMap { childNodeId -> renderNode(childNodeId, document, context) }
+        val result = mutableListOf<IElement>()
+        val pendingGroup = mutableListOf<IElement>()
+        var pendingHasFollower = false
+
+        fun flushPending(groupWithNext: Boolean) {
+            if (pendingGroup.isEmpty()) return
+            if (groupWithNext && pendingGroup.size > 1) {
+                result += keepTogether(pendingGroup)
+            } else {
+                result += pendingGroup
+            }
+            pendingGroup.clear()
+            pendingHasFollower = false
+        }
+
+        for (childNodeId in slot.children) {
+            val node = document.nodes[childNodeId]
+                ?: throw IllegalStateException("Node '$childNodeId' not found in template document")
+            val elements = renderNode(childNodeId, document, context)
+
+            // A condition or other structural node that emits nothing is
+            // transparent: the previous visible block keeps with the next
+            // visible sibling instead.
+            if (elements.isEmpty()) continue
+
+            // Never group across an explicit page break, including one emitted
+            // by a structural child such as a conditional.
+            if (elements.any { it is AreaBreak }) {
+                flushPending(groupWithNext = pendingHasFollower)
+                result += elements
+                continue
+            }
+
+            if (pendingGroup.isNotEmpty()) {
+                pendingHasFollower = true
+                pendingGroup += elements
+                if (!keepsWithNext(node, context)) {
+                    flushPending(groupWithNext = true)
+                }
+            } else if (keepsWithNext(node, context)) {
+                pendingGroup += elements
+            } else {
+                result += elements
+            }
+        }
+
+        // A final keepWithNext has no following rendered sibling, so it has no
+        // page-flow effect and is rendered normally.
+        flushPending(groupWithNext = pendingHasFollower)
+        return result
     }
 
     /**
@@ -99,4 +152,26 @@ class NodeRendererRegistry(
         document: TemplateDocument,
         context: RenderContext,
     ): List<IElement> = node.slots.flatMap { slotId -> renderSlot(slotId, document, context) }
+
+    private fun keepsWithNext(node: Node, context: RenderContext): Boolean {
+        val inline = node.styles?.filterNonNullValues()?.get("keepWithNext")
+        val preset = node.stylePreset?.let { context.blockStylePresets[it]?.get("keepWithNext") }
+        val componentDefault = context.renderingDefaults.componentDefaults(node.type)?.get("keepWithNext")
+        val effective = inline ?: preset ?: componentDefault
+        return effective == true || effective == "true"
+    }
+
+    private fun keepTogether(elements: List<IElement>): Div {
+        val group = Div().setKeepTogether(true)
+        for (element in elements) {
+            when (element) {
+                is IBlockElement -> group.add(element)
+                is Image -> group.add(element)
+                // AreaBreak is excluded by the caller; retain this branch as a
+                // defensive fallback for future element implementations.
+                is AreaBreak -> group.add(element)
+            }
+        }
+        return group
+    }
 }

--- a/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
+++ b/modules/generation/src/main/kotlin/app/epistola/generation/pdf/StyleApplicator.kt
@@ -260,12 +260,11 @@ object StyleApplicator {
             }
         }
 
-        // Page flow: prevent page breaks from splitting or separating blocks
+        // Page flow: prevent page breaks from splitting blocks. keepWithNext
+        // is coordinated between siblings by NodeRendererRegistry because
+        // iText only handles that property at a document root renderer.
         if (styles["keepTogether"] == true || styles["keepTogether"] == "true") {
             element.setKeepTogether(true)
-        }
-        if (styles["keepWithNext"] == true || styles["keepWithNext"] == "true") {
-            element.setKeepWithNext(true)
         }
     }
 

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DirectPdfRendererTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/DirectPdfRendererTest.kt
@@ -14,6 +14,7 @@ import app.epistola.template.model.Slot
 import app.epistola.template.model.TemplateDocument
 import com.itextpdf.kernel.pdf.PdfDocument
 import com.itextpdf.kernel.pdf.PdfReader
+import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.Locale
@@ -56,6 +57,24 @@ class DirectPdfRendererTest {
             pageSettingsOverride = pageSettingsOverride,
         )
     }
+
+    private fun renderedPageTexts(document: TemplateDocument): List<String> {
+        val output = ByteArrayOutputStream()
+        renderer.render(document, emptyMap(), output)
+        PdfDocument(PdfReader(ByteArrayInputStream(output.toByteArray()))).use { pdf ->
+            return (1..pdf.numberOfPages).map { page -> PdfTextExtractor.getTextFromPage(pdf.getPage(page)) }
+        }
+    }
+
+    private fun richTextContent(blocks: List<Map<String, Any>>): Map<String, Any> = mapOf(
+        "type" to "doc",
+        "content" to blocks,
+    )
+
+    private fun paragraph(text: String): Map<String, Any> = mapOf(
+        "type" to "paragraph",
+        "content" to listOf(mapOf("type" to "text", "text" to text)),
+    )
 
     @Test
     fun `renders empty template`() {
@@ -214,6 +233,104 @@ class DirectPdfRendererTest {
         val pdfBytes = output.toByteArray()
         assertTrue(pdfBytes.isNotEmpty())
         assertTrue(pdfBytes.decodeToString(0, 5).startsWith("%PDF"))
+    }
+
+    @Test
+    fun `keepWithNext moves nested siblings to the same page`() {
+        fun document(keepWithNext: Boolean): TemplateDocument {
+            val filler = Node(
+                id = "filler",
+                type = "text",
+                props = mapOf(
+                    "content" to richTextContent(
+                        (1..35).map { paragraph("Filler line $it") },
+                    ),
+                ),
+            )
+            val heading = Node(
+                id = "heading",
+                type = "text",
+                props = mapOf(
+                    "content" to richTextContent(
+                        listOf(
+                            mapOf(
+                                "type" to "heading",
+                                "attrs" to mapOf("level" to 1),
+                                "content" to listOf(mapOf("type" to "text", "text" to "KEEP HEADING")),
+                            ),
+                        ),
+                    ),
+                ),
+                styles = if (keepWithNext) mapOf("keepWithNext" to true) else emptyMap(),
+            )
+            val following = Node(
+                id = "following",
+                type = "text",
+                props = mapOf(
+                    "content" to richTextContent(
+                        listOf(paragraph("FOLLOWING CONTENT " + "must stay together ".repeat(80))),
+                    ),
+                ),
+                styles = mapOf("keepTogether" to true),
+            )
+            val container = Node(
+                id = "container",
+                type = "container",
+                slots = listOf("container-slot"),
+            )
+            val root = Node(id = "root", type = "root", slots = listOf("root-slot"))
+            return TemplateDocument(
+                root = root.id,
+                nodes = listOf(root, filler, container, heading, following).associateBy(Node::id),
+                slots = mapOf(
+                    "root-slot" to Slot("root-slot", root.id, "children", listOf(filler.id, container.id)),
+                    "container-slot" to Slot("container-slot", container.id, "children", listOf(heading.id, following.id)),
+                ),
+            )
+        }
+
+        val baseline = renderedPageTexts(document(keepWithNext = false))
+        val kept = renderedPageTexts(document(keepWithNext = true))
+        val baselineHeadingPage = baseline.indexOfFirst { "KEEP HEADING" in it }
+        val baselineFollowingPage = baseline.indexOfFirst { "FOLLOWING CONTENT" in it }
+        val keptHeadingPage = kept.indexOfFirst { "KEEP HEADING" in it }
+        val keptFollowingPage = kept.indexOfFirst { "FOLLOWING CONTENT" in it }
+
+        assertTrue(baselineHeadingPage >= 0)
+        assertTrue(baselineFollowingPage > baselineHeadingPage)
+        assertEquals(keptFollowingPage, keptHeadingPage)
+        assertTrue(keptHeadingPage > baselineHeadingPage)
+    }
+
+    @Test
+    fun `oversized keepWithNext group degrades to normal page splitting`() {
+        val heading = Node(
+            id = "heading",
+            type = "text",
+            props = mapOf(
+                "content" to richTextContent(listOf(paragraph("OVERSIZED HEADING"))),
+            ),
+            styles = mapOf("keepWithNext" to true),
+        )
+        val following = Node(
+            id = "following",
+            type = "text",
+            props = mapOf(
+                "content" to richTextContent(
+                    (1..100).map { paragraph("Oversized content line $it") },
+                ),
+            ),
+        )
+        val document = documentWithChildren(
+            childNodes = mapOf(heading.id to heading, following.id to following),
+            childNodeIds = listOf(heading.id, following.id),
+        )
+
+        val pages = renderedPageTexts(document)
+
+        assertTrue(pages.size > 1)
+        assertTrue("OVERSIZED HEADING" in pages.first())
+        assertTrue(pages.any { "Oversized content line 100" in it })
     }
 
     @Test

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/NodeRendererRegistryTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/NodeRendererRegistryTest.kt
@@ -10,9 +10,17 @@ import app.epistola.template.model.Node
 import app.epistola.template.model.Slot
 import app.epistola.template.model.TemplateDocument
 import app.epistola.template.model.ThemeRef
+import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.Div
+import com.itextpdf.layout.element.IElement
+import com.itextpdf.layout.properties.Property
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NodeRendererRegistryTest {
 
@@ -20,18 +28,47 @@ class NodeRendererRegistryTest {
         mapOf(
             "root" to ContainerNodeRenderer(),
             "text" to TextNodeRenderer(),
+            "pagebreak" to PageBreakNodeRenderer(),
+            "empty" to object : NodeRenderer {
+                override fun render(
+                    node: Node,
+                    document: TemplateDocument,
+                    context: RenderContext,
+                    registry: NodeRendererRegistry,
+                ): List<IElement> = emptyList()
+            },
         ),
     )
     private val evaluator = CompositeExpressionEvaluator()
     private val fontCache = FontCache(pdfaCompliant = false)
     private val proseMirrorConverter = ProseMirrorConverter(evaluator)
 
-    private fun contextFor(doc: TemplateDocument) = RenderContext(
+    private fun contextFor(
+        doc: TemplateDocument,
+        presets: Map<String, Map<String, Any>> = emptyMap(),
+    ) = RenderContext(
         data = emptyMap(),
         expressionEvaluator = evaluator,
         proseMirrorConverter = proseMirrorConverter,
         fontCache = fontCache,
         document = doc,
+        blockStylePresets = presets,
+    )
+
+    private fun siblingDocument(vararg children: Node): TemplateDocument = TemplateDocument(
+        modelVersion = 1,
+        root = "n-root",
+        nodes = mapOf("n-root" to Node(id = "n-root", type = "root", slots = listOf("s-main"))) +
+            children.associateBy(Node::id),
+        slots = mapOf(
+            "s-main" to Slot(
+                id = "s-main",
+                nodeId = "n-root",
+                name = "children",
+                children = children.map(Node::id),
+            ),
+        ),
+        themeRef = ThemeRef.Inherit,
     )
 
     @Test
@@ -73,5 +110,129 @@ class NodeRendererRegistryTest {
         }
         assertContains(error.message!!, "n-does-not-exist")
         assertContains(error.message!!, "not found")
+    }
+
+    @Test
+    fun `keepWithNext groups a node with its following sibling`() {
+        val doc = siblingDocument(
+            Node(id = "a", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+            Node(id = "b", type = "text", slots = emptyList()),
+            Node(id = "c", type = "text", slots = emptyList()),
+        )
+
+        val elements = registry.renderSlot("s-main", doc, contextFor(doc))
+
+        assertEquals(2, elements.size)
+        val group = assertIs<Div>(elements.first())
+        assertTrue(group.getProperty<Boolean>(Property.KEEP_TOGETHER) == true)
+        assertEquals(2, group.children.size)
+    }
+
+    @Test
+    fun `keepWithNext chain remains grouped when its final node also requests a follower`() {
+        val doc = siblingDocument(
+            Node(id = "a", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+            Node(id = "b", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+        )
+
+        val elements = registry.renderSlot("s-main", doc, contextFor(doc))
+
+        val group = assertIs<Div>(elements.single())
+        assertEquals(2, group.children.size)
+    }
+
+    @Test
+    fun `inline false overrides preset keepWithNext`() {
+        val doc = siblingDocument(
+            Node(
+                id = "a",
+                type = "text",
+                slots = emptyList(),
+                stylePreset = "heading",
+                styles = mapOf("keepWithNext" to false),
+            ),
+            Node(id = "b", type = "text", slots = emptyList()),
+        )
+
+        val elements = registry.renderSlot(
+            "s-main",
+            doc,
+            contextFor(doc, presets = mapOf("heading" to mapOf("keepWithNext" to true))),
+        )
+
+        assertEquals(2, elements.size)
+        elements.forEach { assertNull(it.getProperty<Boolean>(Property.KEEP_TOGETHER)) }
+    }
+
+    @Test
+    fun `preset keepWithNext groups siblings`() {
+        val doc = siblingDocument(
+            Node(id = "a", type = "text", slots = emptyList(), stylePreset = "heading"),
+            Node(id = "b", type = "text", slots = emptyList()),
+        )
+
+        val elements = registry.renderSlot(
+            "s-main",
+            doc,
+            contextFor(doc, presets = mapOf("heading" to mapOf("keepWithNext" to true))),
+        )
+
+        assertIs<Div>(elements.single())
+    }
+
+    @Test
+    fun `final keepWithNext node renders without a wrapper`() {
+        val doc = siblingDocument(
+            Node(id = "a", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+        )
+
+        val elements = registry.renderSlot("s-main", doc, contextFor(doc))
+
+        assertEquals(1, elements.size)
+        assertNull(elements.single().getProperty<Boolean>(Property.KEEP_TOGETHER))
+    }
+
+    @Test
+    fun `non-rendering siblings are transparent to keepWithNext`() {
+        val doc = siblingDocument(
+            Node(id = "a", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+            Node(id = "hidden", type = "empty", slots = emptyList()),
+            Node(id = "b", type = "text", slots = emptyList()),
+        )
+
+        val elements = registry.renderSlot("s-main", doc, contextFor(doc))
+
+        val group = assertIs<Div>(elements.single())
+        assertEquals(2, group.children.size)
+    }
+
+    @Test
+    fun `page breaks terminate keepWithNext groups`() {
+        val doc = siblingDocument(
+            Node(id = "a", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+            Node(id = "break", type = "pagebreak", slots = emptyList()),
+            Node(id = "b", type = "text", slots = emptyList()),
+        )
+
+        val elements = registry.renderSlot("s-main", doc, contextFor(doc))
+
+        assertEquals(3, elements.size)
+        assertNull(elements.first().getProperty<Boolean>(Property.KEEP_TOGETHER))
+        assertIs<AreaBreak>(elements[1])
+    }
+
+    @Test
+    fun `page break preserves completed links within a keepWithNext chain`() {
+        val doc = siblingDocument(
+            Node(id = "a", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+            Node(id = "b", type = "text", slots = emptyList(), styles = mapOf("keepWithNext" to true)),
+            Node(id = "break", type = "pagebreak", slots = emptyList()),
+        )
+
+        val elements = registry.renderSlot("s-main", doc, contextFor(doc))
+
+        assertEquals(2, elements.size)
+        assertIs<Div>(elements.first())
+        assertIs<AreaBreak>(elements[1])
     }
 }

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -238,7 +238,7 @@ class StyleApplicatorTest {
     }
 
     // -----------------------------------------------------------------------
-    // keepTogether / keepWithNext
+    // keepTogether
     // -----------------------------------------------------------------------
 
     @Test
@@ -267,20 +267,6 @@ class StyleApplicatorTest {
             fontCache = fontCache,
         )
         assertTrue(div.getProperty<Boolean>(Property.KEEP_TOGETHER) == true)
-    }
-
-    @Test
-    fun `keepWithNext true sets property on element`() {
-        val div = Div()
-        StyleApplicator.applyStylesWithPreset(
-            div,
-            blockInlineStyles = mapOf("keepWithNext" to true),
-            blockStylePreset = null,
-            blockStylePresets = emptyMap(),
-            inheritedStyles = emptyMap(),
-            fontCache = fontCache,
-        )
-        assertTrue(div.getProperty<Boolean>(Property.KEEP_WITH_NEXT) == true)
     }
 
     @Test

--- a/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
+++ b/modules/generation/src/test/kotlin/app/epistola/generation/pdf/StyleApplicatorTest.kt
@@ -8,6 +8,7 @@ import app.epistola.catalog.protocol.FontRef
 import com.itextpdf.layout.borders.Border
 import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.properties.Property
+import com.itextpdf.layout.properties.UnitValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -222,6 +223,8 @@ class StyleApplicatorTest {
             fontCache = fontCache,
             spacingUnit = 6f, // 2sp = 12pt
         )
+
+        assertEquals(12f, div.getProperty<UnitValue>(Property.MARGIN_BOTTOM).value)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Align editor controls, canvas rendering, live PDF preview, and generated PDFs around the effective theme spacing scale. This PR also resolves the related editor insertion/control issues found during the same rendering-consistency pass and implements reliable PDF keep-with-next behavior.

## What changed

### Theme spacing and rendering parity

- Resolve the effective variant → template → tenant theme when the editor page is loaded.
- Keep raw theme defaults separate from template overrides so clearing an override reveals the theme value again.
- Pass the loaded editor theme snapshot to live preview, ensuring the canvas and preview use the same spacing scale for the editing session.
- Interpret `sp` values using the active theme scale in editor canvas styles, component property controls, borders, presets, images, QR codes, live preview, and PDF generation.

The live preview already accepts the editor's live template document. Supplying the corresponding loaded theme snapshot follows the same model and prevents an external theme change during an editing session from making the canvas and preview disagree.

### Editor behavior and controls

- Replace duplicate margin, padding, and border longhand rows with one four-side control while preserving canonical per-side values in stored documents.
- Keep physical `pt` values physical when switching units and convert `sp` values using the configured theme scale rather than the former 4pt fallback.
- Preserve locked image aspect ratios for `pt`, `sp`, and mixed-unit dimensions.
- Focus the ProseMirror surface when a text block receives focus so newly inserted text blocks are immediately editable.
- Remove the transient datatable `_columnCount` factory input before the node is persisted and validated.

### PDF pagination

- Implement keep-with-next at the sibling traversal level so it works inside nested containers and stencils, not only at the document root.
- Support preset-driven and inline keep-with-next chains.
- Treat non-rendering structural siblings as transparent.
- Stop grouping at explicit page breaks and allow oversized groups to paginate normally.

### Demo and compatibility

- Demonstrate keep-with-next in the bundled simple-letter template.
- Bump and regenerate the bundled demo catalog release metadata.
- No database migration, REST contract, or `epistola-contract` dependency upgrade is required.

## User impact

- `1sp` now has the same physical meaning in the editor, live preview, and generated PDF.
- A theme configured with a 16pt spacing unit renders `1sp` as 16pt instead of silently falling back to 4pt.
- Images no longer distort when their linked dimensions use theme-relative units.
- Text and datatable insertion work without invalid persisted state or an apparently unresponsive text block.
- Keep-with-next prevents headings and similar blocks from being orphaned from their following content.

## Test coverage

- Editor engine coverage for raw theme defaults, template override precedence, and clearing overrides.
- Unit-conversion coverage using a 16pt theme scale for component controls, images, QR codes, borders, and presets.
- Inspector and theme-editor coverage for consolidated margin, padding, and border controls.
- Datatable regression coverage proving `_columnCount` is not persisted.
- DOM focus coverage proving an empty text block transfers focus into ProseMirror.
- Theme-cascade integration coverage across tenant, template, and variant selection.
- Handler integration coverage proving the editor receives effective theme defaults and live PDF preview uses the supplied spacing scale.
- PDF renderer coverage for inline and preset keep-with-next, chains, nested siblings, invisible siblings, page breaks, oversized groups, and actual page placement.
- Bundled catalog fingerprint verification.

## Validation

- `pnpm test` — 103 files / 1,999 tests passed
- `pnpm build`
- scoped `oxfmt --check` for every file changed from `main`
- `pnpm lint:check`
- `pnpm license:check`
- `./gradlew check` — 357 tasks completed successfully, including integration and Playwright coverage
- `./gradlew checkContractVersionAlignment`
- `git diff --check origin/main...HEAD`
- GitHub build, CodeQL, and secret-scanning checks pass

## Deliberate follow-up

The timing-dependent stencil parameter scope bug is intentionally excluded and tracked in #803. It requires a focused Lit component-identity and ProseMirror callback lifecycle fix rather than being folded into this rendering PR.
