### PR TITLE
fix(editor): preserve stencil parameter scope after hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- **[user]** fix(editor): **Stencil parameters remain available after draft loading.** Text
+  expression choices now follow the hydrated stencil's current node identity, so parameters such
+  as `params.param1` no longer disappear when the original text editor mounted before draft
+  hydration completed.
 - **[user]** fix(editor): **New text blocks are ready for typing.** Selecting an empty text block
   now moves the caret into its rich-text surface so typed content appears immediately.
 - **[user]** fix(editor): **Theme spacing and defaults now match generated documents.** The

--- a/modules/editor/src/main/typescript/components/stencil/draft-hydration.integration.test.ts
+++ b/modules/editor/src/main/typescript/components/stencil/draft-hydration.integration.test.ts
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mountEditor, type EditorInstance } from '../../lib.js';
+import type { EpistolaEditor } from '../../ui/EpistolaEditor.js';
+import type { EpExpressionDialog } from '../../ui/EpExpressionDialog.js';
+import type { NodeId, SlotId, TemplateDocument } from '../../types/index.js';
+import type { StencilVersionInfo } from './types.js';
+import { createMockCallbacks } from './stencil-test-helpers.js';
+
+const EMPTY_EXPRESSION_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'expression', attrs: { expression: '' } }],
+    },
+  ],
+};
+
+const PARAMETER_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    param1: { type: 'string' as const, default: 'Hydrated value' },
+  },
+};
+
+function embeddedDraftDocument(): TemplateDocument {
+  return {
+    modelVersion: 1,
+    root: 'root' as NodeId,
+    nodes: {
+      root: { id: 'root' as NodeId, type: 'root', slots: ['root-slot' as SlotId] },
+      'stencil-instance': {
+        id: 'stencil-instance' as NodeId,
+        type: 'stencil',
+        slots: ['stencil-slot' as SlotId],
+        props: {
+          stencilId: 'repro',
+          catalogKey: 'default',
+          draftVersion: 2,
+          parameterSchemaSnapshot: PARAMETER_SCHEMA,
+        },
+      },
+      'embedded-text': {
+        id: 'embedded-text' as NodeId,
+        type: 'text',
+        slots: [],
+        props: { content: EMPTY_EXPRESSION_CONTENT },
+      },
+    },
+    slots: {
+      'root-slot': {
+        id: 'root-slot' as SlotId,
+        nodeId: 'root' as NodeId,
+        name: 'children',
+        children: ['stencil-instance' as NodeId],
+      },
+      'stencil-slot': {
+        id: 'stencil-slot' as SlotId,
+        nodeId: 'stencil-instance' as NodeId,
+        name: 'children',
+        children: ['embedded-text' as NodeId],
+      },
+    },
+    themeRef: { type: 'inherit' },
+  };
+}
+
+function fetchedDraft(): StencilVersionInfo {
+  return {
+    ref: { stencilId: 'repro', catalogKey: 'default' },
+    stencilName: 'Reproduction',
+    version: 2,
+    status: 'draft',
+    parameterSchema: PARAMETER_SCHEMA,
+    content: {
+      modelVersion: 1,
+      root: 'draft-root' as NodeId,
+      nodes: {
+        'draft-root': {
+          id: 'draft-root' as NodeId,
+          type: 'root',
+          slots: ['draft-root-slot' as SlotId],
+        },
+        'draft-text': {
+          id: 'draft-text' as NodeId,
+          type: 'text',
+          slots: [],
+          props: { content: EMPTY_EXPRESSION_CONTENT },
+        },
+      },
+      slots: {
+        'draft-root-slot': {
+          id: 'draft-root-slot' as SlotId,
+          nodeId: 'draft-root' as NodeId,
+          name: 'children',
+          children: ['draft-text' as NodeId],
+        },
+      },
+      themeRef: { type: 'inherit' },
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function mountWithVersionLoader(getStencilVersion: () => Promise<StencilVersionInfo | null>): {
+  container: HTMLElement;
+  editor: EpistolaEditor;
+  instance: EditorInstance;
+} {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const instance = mountEditor({
+    container,
+    template: embeddedDraftDocument(),
+    stencilOptions: createMockCallbacks({ getStencilVersion }),
+  });
+  const editor = container.querySelector<EpistolaEditor>('epistola-editor')!;
+  return { container, editor, instance };
+}
+
+function hydratedTextId(editor: EpistolaEditor): NodeId {
+  const stencil = editor.engine!.doc.nodes['stencil-instance'];
+  return editor.engine!.doc.slots[stencil.slots[0]].children[0];
+}
+
+async function openHydratedExpressionDialog(
+  container: HTMLElement,
+  textNodeId: NodeId,
+): Promise<EpExpressionDialog> {
+  await vi.waitFor(() => {
+    expect(
+      container.querySelector(`.canvas-block[data-node-id="${textNodeId}"] .expression-chip`),
+    ).not.toBeNull();
+  });
+  container
+    .querySelector<HTMLElement>(`.canvas-block[data-node-id="${textNodeId}"] .expression-chip`)!
+    .click();
+  await vi.waitFor(() => {
+    expect(document.querySelector('ep-expression-dialog')).not.toBeNull();
+  });
+  return document.querySelector<EpExpressionDialog>('ep-expression-dialog')!;
+}
+
+const mountedInstances: EditorInstance[] = [];
+
+afterEach(() => {
+  for (const instance of mountedInstances.splice(0)) instance.unmount();
+  document.body.replaceChildren();
+});
+
+describe('mounted editor stencil draft hydration', () => {
+  it('exposes hydrated parameters when the version request resolves immediately', async () => {
+    const { container, editor, instance } = mountWithVersionLoader(() =>
+      Promise.resolve(fetchedDraft()),
+    );
+    mountedInstances.push(instance);
+
+    await vi.waitFor(() => {
+      expect(editor.engine!.doc.nodes['embedded-text']).toBeUndefined();
+    });
+    const dialog = await openHydratedExpressionDialog(container, hydratedTextId(editor));
+
+    expect(dialog.fieldPaths).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: 'params.param1' })]),
+    );
+    dialog.close(null);
+  });
+
+  it('replaces the mounted text editor and resolves manually entered parameters after delayed hydration', async () => {
+    const versionGate = deferred<StencilVersionInfo | null>();
+    const { container, editor, instance } = mountWithVersionLoader(() => versionGate.promise);
+    mountedInstances.push(instance);
+
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('.canvas-block[data-node-id="embedded-text"] epistola-text-editor'),
+      ).not.toBeNull();
+    });
+    const embeddedEditor = container.querySelector(
+      '.canvas-block[data-node-id="embedded-text"] epistola-text-editor',
+    );
+
+    versionGate.resolve(fetchedDraft());
+    await vi.waitFor(() => {
+      expect(editor.engine!.doc.nodes['embedded-text']).toBeUndefined();
+    });
+    const hydratedId = hydratedTextId(editor);
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector(`.canvas-block[data-node-id="${hydratedId}"] epistola-text-editor`),
+      ).not.toBeNull();
+    });
+    const hydratedEditor = container.querySelector(
+      `.canvas-block[data-node-id="${hydratedId}"] epistola-text-editor`,
+    );
+    expect(hydratedEditor).not.toBe(embeddedEditor);
+    expect((embeddedEditor as HTMLElement).isConnected).toBe(false);
+
+    const dialog = await openHydratedExpressionDialog(container, hydratedId);
+    expect(dialog.fieldPaths).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: 'params.param1' })]),
+    );
+
+    dialog.querySelector<HTMLButtonElement>('.mode-btn[data-mode="code"]')!.click();
+    await dialog.updateComplete;
+    const input = dialog.querySelector<HTMLTextAreaElement>('.expression-dialog-input')!;
+    input.value = 'params.param1';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    dialog.querySelector<HTMLButtonElement>('.expression-dialog-btn.save')!.click();
+
+    await vi.waitFor(() => {
+      const value = container.querySelector<HTMLElement>(
+        `.canvas-block[data-node-id="${hydratedId}"] .expression-chip-content`,
+      )?.textContent;
+      expect(value).toBe('Hydrated value');
+    });
+  });
+});

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.tabindex.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.tabindex.test.ts
@@ -217,4 +217,64 @@ describe('EpistolaCanvas — read-only blocks are not user-focusable', () => {
 
     expect(engine.selectedNodeId).toBe('stencil');
   });
+
+  it('recreates a text editor when a child node is replaced with a different ID', async () => {
+    const engine = setupEngine(true);
+    await renderCanvas(container, engine);
+
+    const initialEditor = container.querySelector<HTMLElement>(
+      '.canvas-block[data-node-id="text-toplevel"] epistola-text-editor',
+    );
+    expect(initialEditor).not.toBeNull();
+
+    const replacement = structuredClone(engine.doc);
+    const initialNode = replacement.nodes['text-toplevel'];
+    delete replacement.nodes['text-toplevel'];
+    replacement.nodes['text-hydrated'] = {
+      ...initialNode,
+      id: 'text-hydrated' as NodeId,
+    };
+    const rootSlot = replacement.slots['root-slot'];
+    replacement.slots['root-slot'] = {
+      ...rootSlot,
+      children: rootSlot.children.map((childId) =>
+        childId === 'text-toplevel' ? ('text-hydrated' as NodeId) : childId,
+      ),
+    };
+
+    engine.replaceDocument(replacement);
+    await renderCanvas(container, engine);
+
+    const hydratedEditor = container.querySelector<HTMLElement>(
+      '.canvas-block[data-node-id="text-hydrated"] epistola-text-editor',
+    );
+    expect(hydratedEditor).not.toBeNull();
+    expect(hydratedEditor).not.toBe(initialEditor);
+    expect(initialEditor!.isConnected).toBe(false);
+  });
+
+  it('preserves a text editor when its node ID is reordered within a slot', async () => {
+    const engine = setupEngine(true);
+    await renderCanvas(container, engine);
+
+    const initialEditor = container.querySelector<HTMLElement>(
+      '.canvas-block[data-node-id="text-toplevel"] epistola-text-editor',
+    );
+    expect(initialEditor).not.toBeNull();
+
+    const reordered = structuredClone(engine.doc);
+    const rootSlot = reordered.slots['root-slot'];
+    reordered.slots['root-slot'] = {
+      ...rootSlot,
+      children: rootSlot.children.toReversed(),
+    };
+
+    engine.replaceDocument(reordered);
+    await renderCanvas(container, engine);
+
+    const reorderedEditor = container.querySelector<HTMLElement>(
+      '.canvas-block[data-node-id="text-toplevel"] epistola-text-editor',
+    );
+    expect(reorderedEditor).toBe(initialEditor);
+  });
 });

--- a/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaCanvas.ts
@@ -4,6 +4,7 @@
 
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import {
   draggable,
@@ -387,7 +388,11 @@ export class EpistolaCanvas extends LitElement {
           ? html`<span class="canvas-slot-hint"
               >${isMultiSlot ? slot.name : 'Drop blocks here'}</span
             >`
-          : slot.children.map((childId) => this._renderBlock(childId))}
+          : repeat(
+              slot.children,
+              (childId) => childId,
+              (childId) => this._renderBlock(childId),
+            )}
       </div>
     `;
   }

--- a/modules/editor/src/main/typescript/ui/EpistolaTextEditor.test.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaTextEditor.test.ts
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EditorEngine } from '../engine/EditorEngine.js';
+import { createDefaultRegistry } from '../engine/registry.js';
+import { createStencilDefinition } from '../components/stencil/stencil-registration.js';
+import type { NodeId, SlotId, TemplateDocument } from '../types/index.js';
+import type { EpExpressionDialog } from './EpExpressionDialog.js';
+import { EpistolaTextEditor } from './EpistolaTextEditor.js';
+
+const EXPRESSION_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'expression', attrs: { expression: 'params.param1' } }],
+    },
+  ],
+};
+
+function initialDocument(): TemplateDocument {
+  return {
+    modelVersion: 1,
+    root: 'root' as NodeId,
+    nodes: {
+      root: { id: 'root' as NodeId, type: 'root', slots: ['root-slot' as SlotId] },
+      'initial-text': {
+        id: 'initial-text' as NodeId,
+        type: 'text',
+        slots: [],
+        props: { content: EXPRESSION_CONTENT },
+      },
+    },
+    slots: {
+      'root-slot': {
+        id: 'root-slot' as SlotId,
+        nodeId: 'root' as NodeId,
+        name: 'children',
+        children: ['initial-text' as NodeId],
+      },
+    },
+    themeRef: { type: 'inherit' },
+  };
+}
+
+function hydratedDocument(): TemplateDocument {
+  return {
+    modelVersion: 1,
+    root: 'root' as NodeId,
+    nodes: {
+      root: { id: 'root' as NodeId, type: 'root', slots: ['root-slot' as SlotId] },
+      stencil: {
+        id: 'stencil' as NodeId,
+        type: 'stencil',
+        slots: ['stencil-slot' as SlotId],
+        props: {
+          stencilId: 'repro',
+          catalogKey: 'default',
+          draftVersion: 2,
+          parameterSchemaSnapshot: {
+            type: 'object',
+            properties: { param1: { type: 'string', default: 'Hydrated value' } },
+          },
+        },
+      },
+      'hydrated-text': {
+        id: 'hydrated-text' as NodeId,
+        type: 'text',
+        slots: [],
+        props: { content: EXPRESSION_CONTENT },
+      },
+    },
+    slots: {
+      'root-slot': {
+        id: 'root-slot' as SlotId,
+        nodeId: 'root' as NodeId,
+        name: 'children',
+        children: ['stencil' as NodeId],
+      },
+      'stencil-slot': {
+        id: 'stencil-slot' as SlotId,
+        nodeId: 'stencil' as NodeId,
+        name: 'children',
+        children: ['hydrated-text' as NodeId],
+      },
+    },
+    themeRef: { type: 'inherit' },
+  };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('EpistolaTextEditor expression scope callbacks', () => {
+  it('dereferences the current node after its initial ProseMirror mount', async () => {
+    const registry = createDefaultRegistry();
+    registry.register(createStencilDefinition({ callbacks: null }));
+    const engine = new EditorEngine(initialDocument(), registry);
+    const editor = new EpistolaTextEditor();
+    editor.engine = engine;
+    editor.nodeId = 'initial-text' as NodeId;
+    editor.content = EXPRESSION_CONTENT;
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+
+    engine.replaceDocument(hydratedDocument(), 'HydrateStencilDrafts');
+    editor.nodeId = 'hydrated-text' as NodeId;
+    editor.content = EXPRESSION_CONTENT;
+    await editor.updateComplete;
+
+    editor.querySelector<HTMLElement>('.expression-chip')!.click();
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('ep-expression-dialog')).not.toBeNull();
+    });
+    const dialog = document.querySelector<EpExpressionDialog>('ep-expression-dialog')!;
+    expect(dialog.fieldPaths).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'params.param1',
+          scopeKind: 'stencil-parameter',
+        }),
+      ]),
+    );
+    expect(dialog.getExampleData?.()).toMatchObject({
+      params: { param1: 'Hydrated value' },
+    });
+    dialog.close(null);
+  });
+});

--- a/modules/editor/src/main/typescript/ui/EpistolaTextEditor.ts
+++ b/modules/editor/src/main/typescript/ui/EpistolaTextEditor.ts
@@ -43,6 +43,7 @@ import type { TextChangeOps } from '../engine/undo.js';
 import type { NodeId } from '../types/index.js';
 import { type DocumentIndexes, isAncestor } from '../engine/indexes.js';
 import { rewriteExpressionsInContent } from '../engine/alias-rewrite.js';
+import { DEFAULT_LOCALE } from '../engine/locale.js';
 
 const DEBOUNCE_MS = 300;
 
@@ -200,19 +201,27 @@ export class EpistolaTextEditor extends LitElement {
   private _createProseMirror(): void {
     if (!this._pmContainer) return;
 
-    const engine = this.engine;
-    const nodeId = this.nodeId;
-
-    // Getters that resolve fresh on each call — so alias changes take effect immediately
-    const getFieldPaths = () =>
-      engine && nodeId ? engine.getAvailableVariablesAt(nodeId) : (engine?.fieldPaths ?? []);
-    const getExampleData = engine
-      ? () => (nodeId ? engine.getEvaluationContextAt(nodeId) : engine.getExampleData())
-      : undefined;
+    // Resolve component inputs on every call. Canvas nodes are normally keyed
+    // by node ID, but these callbacks must also remain safe if a host updates a
+    // mounted editor's engine or node identity through another lifecycle path.
+    const getFieldPaths = () => {
+      const engine = this.engine;
+      const nodeId = this.nodeId;
+      return engine && nodeId ? engine.getAvailableVariablesAt(nodeId) : (engine?.fieldPaths ?? []);
+    };
+    const getExampleData = () => {
+      const engine = this.engine;
+      const nodeId = this.nodeId;
+      return engine
+        ? nodeId
+          ? engine.getEvaluationContextAt(nodeId)
+          : engine.getExampleData()
+        : undefined;
+    };
     // Effective BCP-47 locale the host resolved (variant attribute → tenant
     // default → app default). Read fresh per call so a future locale change
     // mid-session would re-format on the next refresh.
-    const getLocale = engine ? () => engine.locale : undefined;
+    const getLocale = () => this.engine?.locale ?? DEFAULT_LOCALE;
 
     const plugins = createPlugins(epistolaSchema, {
       expressionNodeViewOptions: { getFieldPaths, getExampleData, getLocale },


### PR DESCRIPTION
## Description

Fixes a timing-dependent editor bug where stencil parameters disappeared from text expression choices after draft hydration.

Draft hydration rekeys the stencil's child nodes. The canvas previously rendered slot children by array position, which allowed Lit to reuse a mounted rich-text editor for a replacement text node. Its ProseMirror expression callbacks had also captured the original node ID, so scope lookups continued against a node that no longer existed.

This change:

- keys canvas slot children by node ID, recreating component state only when block identity changes;
- preserves component instances when blocks with the same IDs are reordered;
- resolves expression field paths, evaluation data, and locale from the text editor's current engine and node ID;
- adds fast and delayed hydration regression coverage, including manual expression evaluation;
- records the user-visible fix in the changelog.

## Related Issue(s)

Fixes #803

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing editor tests pass locally (`pnpm --filter @epistola/editor test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

Not applicable; this fixes component identity and expression scope without changing the intended UI.

## Additional Notes

Validation completed locally:

- 105 editor test files / 2,004 tests passed
- `pnpm build`
- scoped `oxfmt --check`
- `pnpm lint:check` (successful with the repository's existing warnings)
- `pnpm license:check`

No API, database, catalog contract, backend, PDF, or stored-document changes are included.
