### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-31
+
+Epistola Suite 1.0.0 is the first generally available release. It makes template editing and
+previews more reliable, adds wider and more resilient list pages, expands AI rendering diagnostics,
+and returns clearer API errors for preview and catalog failures.
+
 - **[user]** fix(editor): **Stencil parameters remain available after draft loading.** Text
   expression choices now follow the hydrated stencil's current node identity, so parameters such
   as `params.param1` no longer disappear when the original text editor mounted before draft

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # a release strips it, tags v<version>, then re-opens the next -SNAPSHOT (see the
 # `release` skill). CI validates the v* tag equals this value. A -PreleaseVersion
 # override (PR snapshot builds) still wins over this.
-version=1.0.0-RC7-SNAPSHOT
+version=1.0.0
 
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
## Summary

- set the application version to `1.0.0`
- finalize the `1.0.0` changelog section for the first generally available release
- leave a fresh empty `Unreleased` section for subsequent development

## Impact

After this PR is merged, its `main` merge commit can be tagged `v1.0.0`. The tag will trigger the release workflow, which validates the version and publishes the signed application image.

## Validation

- `env GRADLE_USER_HOME=/private/tmp/epistola-suite-gradle mise exec -- ./gradlew check`
- 357 actionable tasks completed successfully, including contract alignment, changelog parsing, migration preservation, backend tests, and UI tests