### PR TITLE
chore: add publiccode.yml software metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- **[dev]** chore(repo): **Machine-readable software metadata added.** A `publiccode.yml`
+  (publiccode.yml standard v0.5) at the repository root describes the suite for public-sector
+  OSS catalogue crawlers: identity, licensing, features, maintenance contacts, and dependencies.
 - **[dev]** build(deps): **Upgrade Epistola contract dependencies to 1.0.0.** Backend artifacts,
   the editor catalog package, and the pnpm lockfile now consume the GA contract release together.
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,106 @@
+# Standard: https://yml.publiccode.tools/
+# Declares 0.5 rather than the newer 0.7: the reference validator
+# (italia/publiccode-parser-go, used by the EU OSS Catalogue and
+# developer.overheid.nl crawlers) supports up to 0.5. Nothing here uses a
+# 0.7-only key, so bump this once the parser catches up.
+publiccodeYmlVersion: "0.5"
+
+name: Epistola Suite
+url: "https://github.com/epistola-app/epistola-suite"
+softwareVersion: "1.0.0"
+releaseDate: "2026-07-31"
+logo: modules/design-system/epistola-logo.svg
+
+platforms:
+  - web
+  - linux
+
+categories:
+  - document-management
+  - content-management
+
+developmentStatus: stable
+
+softwareType: standalone/web
+
+description:
+  en:
+    shortDescription: >-
+      Multi-tenant platform for generating PDF documents from visually designed
+      templates bound to structured data.
+
+    longDescription: |
+      Epistola Suite turns document generation into a product capability instead
+      of a code change. Business users design templates in a block-based visual
+      editor — text, tables, columns, conditionals, loops, page headers and
+      footers — and bind them to a data contract expressed as a JSON Schema
+      (Draft 2020-12). Developers then call a versioned REST API with real data
+      to produce PDFs, single or in batch.
+
+      Every template carries variants (per language, brand or audience) and
+      immutable numbered versions with a `DRAFT` → `PUBLISHED` → `ARCHIVED`
+      lifecycle, so a document layout can be changed, reviewed and promoted
+      without touching the systems that consume it. Environments (for example
+      `staging` and `production`) each activate their own version of a variant,
+      making rollout and rollback a configuration action rather than a
+      redeployment.
+
+      Rendering is server-side and direct-to-PDF, with no intermediate HTML
+      step, and the same rendering path feeds both the editor's live preview and
+      the produced document, so what the designer sees is what the API returns.
+      Data binding uses JSONata by default, with sandboxed JavaScript and a
+      simple dot-path evaluator as alternatives.
+
+      The suite is multi-tenant by construction — all data is isolated per
+      tenant — and runs equally as a shared SaaS deployment or a single-tenant
+      self-hosted installation on Kubernetes via the bundled Helm chart.
+
+    features:
+      - Block-based visual template editor with live PDF preview
+      - JSON Schema (Draft 2020-12) data contracts with named data examples
+      - Template variants per language, brand or audience
+      - Immutable template versions with draft/published/archived lifecycle
+      - Environment-scoped version activation for staged rollout and rollback
+      - Reusable themes with a document, template and block style cascade
+      - Expression binding via JSONata, sandboxed JavaScript or dot paths
+      - Server-side PDF rendering, including PDF/A output
+      - Per-document locale resolution for dates, numbers and formatting
+      - Bundled and custom fonts with deterministic resolution
+      - Versioned REST API with RFC 9457 problem details
+      - Batch document generation with job tracking
+      - Catalog import and export for moving resources between installations
+      - Multi-tenancy with per-tenant isolation, roles and API keys
+      - Model Context Protocol server exposing read-only discovery to AI assistants
+      - OpenID Connect single sign-on
+
+    documentation: "https://github.com/epistola-app/epistola-suite/tree/main/docs"
+
+legal:
+  license: AGPL-3.0-only
+  mainCopyrightOwner: Epistola Nederland B.V.
+
+maintenance:
+  type: internal
+  contacts:
+    - name: Sander de Groot
+      affiliation: Epistola Nederland B.V.
+
+localisation:
+  # The application UI is English-only; document *output* is locale-aware
+  # per render (see docs/locale.md), which is a product feature rather than
+  # UI localisation.
+  localisationReady: false
+  availableLanguages:
+    - en
+
+dependsOn:
+  open:
+    - name: PostgreSQL
+      versionMin: "18"
+      optional: false
+    - name: Keycloak
+      optional: true
+
+organisation:
+  name: Epistola Nederland B.V.
+  uri: "https://github.com/epistola-app"


### PR DESCRIPTION
## Description

Adds a `publiccode.yml` (v0.5 of the [publiccode.yml standard](https://yml.publiccode.tools/)) at the repository root so public-sector OSS catalogue crawlers (EU OSS Catalogue, developer.overheid.nl, developers.italia.it) can index the suite. It declares identity (name, URL, logo, 1.0.0 / 2026-07-31), AGPL-3.0-only licensing with Epistola Nederland B.V. as copyright owner, platform/category classification, an English feature list, maintenance contact, localisation status, and runtime dependencies (PostgreSQL required, Keycloak optional).

The file declares standard version 0.5 rather than 0.7 because the reference validator (`italia/publiccode-parser-go`, used by the catalogue crawlers) supports up to 0.5; no 0.7-only keys are used, so bumping later is a one-line change. Validated with `italia/publiccode-parser-go`.

Every factual claim was verified against the repository: release version/date against `CHANGELOG.md`, licensing against `LICENSE`/`LICENSES/`/SPDX headers, and each feature bullet against its implementing code and docs (PDF/A in `DirectPdfRenderer`, RFC 9457 via `ProblemDetailsTest`, sandboxed GraalJS binding, read-only MCP scope per `docs/mcp.md`, etc.).

## Related Issue(s)

—

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [ ] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

—

## Additional Notes

- Metadata-only change: no application code is touched, so no tests were added or run beyond `pnpm format:check` and `pnpm license:check` (REUSE compliant, 2170/2170 files).
- Open question for review: `dependsOn` declares PostgreSQL `versionMin: "18"` to match the dev compose and cluster scripts, but Testcontainers still runs integration tests on `postgres:17` (`TestRuntimeLifecycle.kt`). Either the declared floor should drop to 17 or the test image should move to 18 — reviewer input welcome.
- `maintenance.contacts` currently lists Sander de Groot only; extend as needed.