### PR TITLE
build(graphify): add scoped AI impact analysis

### DIFF
--- a/.aiignore
+++ b/.aiignore
@@ -11,6 +11,7 @@ target/
 .gradle/
 .kotlin/
 coverage/
+graphify-out/
 **/build/
 **/dist/
 **/out/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify Graphify scope coverage
+        run: scripts/graphify.sh verify-scopes
+
       - name: Check contract version
         if: github.event_name == 'pull_request'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ dist/
 ### Test Coverage ###
 coverage/
 plan.md
+graphify-out/
 
 ### pnpm ###
 # pnpm falls back to an in-project store when the repo and the global store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,9 @@ Update the shared `epistola-contract` version in `gradle/libs.versions.toml`,
 `@epistola.app/epistola-catalog` in `modules/editor/package.json`, and
 `pnpm-lock.yaml` together. Run `./gradlew checkContractVersionAlignment` before
 committing.
+
+For impact analysis on an unfamiliar or cross-cutting change, consult the
+appropriate local Graphify scope before broad source inspection. Follow the
+workflow and verification rules in [`docs/graphify.md`](docs/graphify.md);
+Graphify results identify candidates and never replace source, build, or test
+verification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- **[dev]** build(graphify): **Scoped AI impact graphs stay local and current.** A pinned,
+  production-only Graphify workflow now builds and lazily refreshes separate backend, editor,
+  support, and migration graphs so assistants can find candidate impact without committing large
+  generated artifacts or treating the repository-wide graph as an architecture score.
 - **[dev]** fix(ci): **The scheduled security scan generates the editor SBOM with pnpm 11.**
   Invoke the editor's `sbom` package script explicitly so pnpm does not route the command to its
   built-in SBOM generator and fail because no format was supplied.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,28 @@ Spring profile (datasource `127.0.0.1:4001`), so don't run them alongside a loca
 | `docs/github.md`                 | GitHub workflows documentation |
 | `.github/labels.yml`             | Issue label definitions        |
 
+## Graphify impact analysis
+
+Use the repository's local Graphify workflow for impact analysis when a change
+is unfamiliar, cross-cutting, or asks about callers, dependencies, or a path
+between symbols. Do not run it for every small edit.
+
+1. Select the narrowest scope: `backend`, `editor`, `support`, or `migrations`.
+2. Start with `scripts/graphify.sh affected`, `explain`, or `path`; use `query`
+   only when the structural command does not fit.
+3. Treat every result as a candidate set. Verify the relevant definitions and
+   references in source, check Gradle module dependencies for cross-module
+   claims, and search tests separately because production graphs exclude tests.
+4. Fall back to `rg` and direct source reading when a symbol is ambiguous, a
+   path is noisy, or the graph cannot represent the relationship.
+
+The graphs are structural reference maps, not coupling metrics. A large
+connected component is expected in an application and does not by itself mean
+the modules are poorly decoupled. Generated corpora, graphs, reports, and HTML
+visualizations stay under the ignored `graphify-out/` directory. See
+[`docs/graphify.md`](docs/graphify.md) for commands, scope boundaries, refresh
+behavior, and limitations.
+
 ## When Making Changes
 
 1. **Read existing code first** - Understand patterns before modifying

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -1,0 +1,135 @@
+# Graphify impact analysis
+
+Epistola uses [Graphify](https://github.com/Graphify-Labs/graphify) as a local,
+structural index for code-impact investigation. It can quickly suggest callers,
+related definitions, and paths worth inspecting before an assistant opens broad
+parts of the repository. It is a navigation aid, not an authority on architecture
+or a substitute for source and tests.
+
+## What is generated
+
+The wrapper creates four production-only graphs:
+
+| Scope        | Content                                                                  |
+| ------------ | ------------------------------------------------------------------------ |
+| `backend`    | Host applications, core, generation, web, REST API, crypto, and MCP code |
+| `editor`     | Production editor TypeScript/JavaScript and icon sprite generation       |
+| `support`    | Audit, quality, load-test, version-check, and commercial feature code    |
+| `migrations` | Production Flyway SQL from the application and modules                   |
+
+All generated data is local and ignored by both Git and AI context collection:
+
+```text
+graphify-out/
+├── corpora/<scope>/             # scoped source mirror used for extraction
+├── scoped/<scope>/graph.json    # query input
+├── scoped/<scope>/graph.html    # interactive visualization
+├── scoped/<scope>/GRAPH_REPORT.md
+└── tooling/                     # local uv/Graphify cache
+```
+
+Open `graphify-out/scoped/<scope>/graph.html` in a browser to inspect a graph.
+The full visualization can still be dense; the command-line queries are usually
+more useful for impact work.
+
+## Commands
+
+`mise` is the only prerequisite. The wrapper pins uv and Graphify, installs them
+into the ignored local tooling directory on first use, and sends no source to an
+LLM. Extraction and clustering are code/SQL-only and local.
+
+```bash
+# Build a scope if missing, or incrementally refresh it when tracked or
+# non-ignored untracked production source changes.
+scripts/graphify.sh ensure backend
+
+# Candidate impact around a symbol. Depth 1 is the default and best starting point.
+scripts/graphify.sh affected backend SpringMediator 1
+
+# Explain one symbol or find a structural path between two symbols.
+scripts/graphify.sh explain editor EditorEngine
+scripts/graphify.sh path support TenantBackupService TenantBackupStore
+
+# Ask a bounded natural-language structural question.
+scripts/graphify.sh query migrations "which tables refer to tenants"
+
+# Inspect local graph state, force rebuilds, or measure context reduction.
+scripts/graphify.sh status
+scripts/graphify.sh build all
+scripts/graphify.sh benchmark all
+
+# Validate that supported production files are assigned to a scope.
+scripts/graphify.sh verify-scopes
+```
+
+`ensure`, `affected`, `explain`, `path`, `query`, and `benchmark` compare a
+content fingerprint before starting Graphify. When inputs have not changed they
+reuse the graph immediately. When files changed, extraction is incremental and
+also removes deleted files. `build` deliberately forces a full rebuild.
+
+The CI workflow runs only `verify-scopes`; it neither downloads Graphify nor
+commits generated artifacts. This keeps new supported production sources from
+silently falling outside the index while avoiding a large binary-like graph in
+version control.
+
+## AI workflow
+
+Use Graphify when an issue is cross-cutting, the code area is unfamiliar, or a
+change asks for impact, callers, dependencies, or a route between symbols:
+
+1. Choose the narrowest applicable scope and run `affected`, `explain`, or
+   `path`. Start at depth 1; increase depth only for a specific reason.
+2. Use the output to select candidate files and symbols, then open those source
+   locations directly.
+3. Confirm references with `rg`. Confirm cross-module boundaries in Gradle build
+   files. Search tests separately because the graphs intentionally exclude test
+   code.
+4. Report verified impact as fact and label unverified graph relationships as
+   candidates. If matching is ambiguous or noisy, discard the result and use
+   direct source inspection.
+
+Do not consult Graphify for a self-contained edit whose impact is already clear.
+Do not infer runtime frequency, ownership, module coupling, correctness, or test
+coverage from graph connectivity. Calls, imports, inheritance, shared framework
+types, generated references, and SQL relationships naturally produce a large
+connected component even when module boundaries are sound. Decoupling is better
+evaluated from dependency direction, public interfaces, ownership, and the ease
+of changing a module independently.
+
+Graphify's language support is not equally precise for every construct. Dynamic
+dispatch, dependency injection, reflection, framework wiring, string-based
+routes, templating, generated code, and cross-scope relationships may be absent
+or approximate. A short or missing path is therefore not proof that no impact
+exists, and a returned path is not proof of a runtime call chain.
+
+## Current baseline
+
+On 2 August 2026, the four scopes contained 1,091 production files and produced
+the following local graphs. Graphify's benchmark uses generic questions and a
+naive token estimate, so these figures are directional rather than a performance
+guarantee:
+
+| Scope        | Files | Nodes |  Edges | Estimated average context reduction |
+| ------------ | ----: | ----: | -----: | ----------------------------------: |
+| `backend`    |   721 | 4,993 | 10,670 |                               23.0x |
+| `editor`     |   173 | 2,117 |  5,233 |                                7.1x |
+| `support`    |   156 | 1,310 |  2,061 |                               28.7x |
+| `migrations` |    41 |   112 |    167 |                                2.9x |
+
+The practical benefit is faster candidate selection, especially for backend and
+support questions. It does not reduce the verification required before changing
+code.
+
+## Maintenance
+
+- Add or adjust mappings in `scripts/graphify.sh` when production source moves
+  or a supported language is introduced. `verify-scopes` will flag unassigned
+  production candidates in CI.
+- Bump `SCOPE_SCHEMA_VERSION` when scope semantics change so existing local
+  graphs rebuild instead of being incrementally reused.
+- uv and Graphify versions are pinned in the wrapper. Renovate proposes grouped,
+  non-automerge upgrades. Review release notes, force-build all scopes, repeat
+  representative `affected`/`explain`/`path` checks, and update this baseline
+  before accepting an upgrade.
+- Never commit `graphify-out/`. Delete that directory if a completely clean
+  local rebuild is needed; the next command will recreate it.

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,19 @@
     "groupName": "all non-major dependencies",
     "groupSlug": "non-major"
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update pinned Graphify tooling used by scripts/graphify.sh",
+      "managerFilePatterns": ["/^scripts\\/graphify\\.sh$/"],
+      "matchStrings": [
+        "UV_VERSION=\\\"(?<currentValue>[^\\\"]+)\\\" # renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)",
+        "GRAPHIFY_VERSION=\\\"(?<currentValue>[^\\\"]+)\\\" # renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "versioningTemplate": "loose"
+    }
+  ],
   "packageRules": [
     {
       "description": "Default group for major updates (specific groups below override)",
@@ -26,6 +39,13 @@
       "groupSlug": "non-major",
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "description": "Keep Graphify upgrades reviewable because extraction semantics can change",
+      "matchPackageNames": ["graphifyy", "astral-sh/uv"],
+      "groupName": "graphify tooling",
+      "groupSlug": "graphify-tooling",
+      "automerge": false
     },
     {
       "description": "Group epistola-contract packages (server SDK + editor model) together",

--- a/scripts/graphify.sh
+++ b/scripts/graphify.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env sh
+# SPDX-FileCopyrightText: Epistola Nederland B.V.
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -eu
+
+UV_VERSION="0.11.29" # renovate: datasource=github-releases depName=astral-sh/uv
+GRAPHIFY_VERSION="0.9.32" # renovate: datasource=pypi depName=graphifyy
+SCOPE_SCHEMA_VERSION="1"
+DEFAULT_QUERY_BUDGET="1500"
+DEFAULT_AFFECTED_DEPTH="1"
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+graphify_root="$repo_root/graphify-out"
+corpora_root="$graphify_root/corpora"
+scoped_root="$graphify_root/scoped"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/graphify.sh <command> [arguments]
+
+Commands:
+  build [all|backend|editor|support|migrations]
+  ensure <backend|editor|support|migrations>
+  query <scope> "<question>" [graphify query options]
+  affected <scope> "<symbol>" [depth]
+  explain <scope> "<symbol>"
+  path <scope> "<from>" "<to>"
+  benchmark [all|backend|editor|support|migrations]
+  status
+  verify-scopes
+EOF
+}
+
+die() {
+    printf 'graphify: %s\n' "$*" >&2
+    exit 1
+}
+
+is_scope() {
+    case "$1" in
+        backend | editor | support | migrations) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_scope() {
+    [ "$#" -ge 1 ] || die "a scope is required"
+    is_scope "$1" || die "unknown scope '$1' (expected backend, editor, support, or migrations)"
+}
+
+all_source_files() {
+    git -C "$repo_root" ls-files --cached --others --exclude-standard | LC_ALL=C sort -u
+}
+
+is_editor_test_file() {
+    case "$1" in
+        *.test.ts | *.test.js | *.spec.ts | *.spec.js | *-test-helpers.ts | */test-helpers.ts) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+scope_for_file() {
+    path=$1
+
+    case "$path" in
+        */src/test/* | modules/testing/*) return 1 ;;
+    esac
+
+    case "$path" in
+        apps/*/src/main/resources/db/migration/*.sql | modules/*/src/main/resources/db/migration/*.sql)
+            printf '%s\n' migrations
+            return 0
+            ;;
+    esac
+
+    case "$path" in
+        modules/editor/src/main/typescript/*.ts | modules/editor/src/main/typescript/*.js)
+            if ! is_editor_test_file "$path"; then
+                printf '%s\n' editor
+                return 0
+            fi
+            return 1
+            ;;
+        modules/design-system/icons/generate-sprite.js)
+            printf '%s\n' editor
+            return 0
+            ;;
+    esac
+
+    case "$path" in
+        apps/epistola/src/main/kotlin/*.kt | \
+            apps/epistola/src/main/resources/static/*.js | \
+            apps/pdfrender/src/main/kotlin/*.kt | \
+            modules/epistola-core/src/main/kotlin/*.kt | \
+            modules/epistola-crypto/src/main/kotlin/*.kt | \
+            modules/epistola-mcp/src/main/kotlin/*.kt | \
+            modules/epistola-web/src/main/kotlin/*.kt | \
+            modules/generation/src/main/kotlin/*.kt | \
+            modules/rest-api/src/main/kotlin/*.kt)
+            printf '%s\n' backend
+            return 0
+            ;;
+    esac
+
+    case "$path" in
+        modules/epistola-audit/src/main/kotlin/*.kt | \
+            modules/epistola-audit/src/main/resources/static/*.js | \
+            modules/epistola-quality/src/main/kotlin/*.kt | \
+            modules/epistola-quality/src/main/resources/static/*.js | \
+            modules/epistola-support/src/main/kotlin/*.kt | \
+            modules/epistola-support/src/main/resources/static/*.js | \
+            modules/epistola-support-*/src/main/kotlin/*.kt | \
+            modules/epistola-support-*/src/main/resources/static/*.js | \
+            modules/epistola-version-check/src/main/kotlin/*.kt | \
+            modules/loadtest/src/main/kotlin/*.kt | \
+            modules/loadtest/src/main/resources/static/*.js)
+            printf '%s\n' support
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+is_supported_candidate() {
+    case "$1" in
+        apps/*/src/main/*.kt | apps/*/src/main/*.ts | apps/*/src/main/*.js | apps/*/src/main/*.sql | \
+            modules/*/src/main/*.kt | modules/*/src/main/*.ts | modules/*/src/main/*.js | modules/*/src/main/*.sql | \
+            modules/design-system/icons/generate-sprite.js)
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+is_explicitly_excluded() {
+    case "$1" in
+        modules/testing/*) return 0 ;;
+    esac
+    is_editor_test_file "$1"
+}
+
+list_scope() {
+    scope=$1
+    require_scope "$scope"
+    all_source_files | while IFS= read -r path; do
+        assigned=$(scope_for_file "$path" || true)
+        if [ "$assigned" = "$scope" ]; then
+            printf '%s\n' "$path"
+        fi
+    done
+}
+
+verify_scopes() {
+    failures=0
+    candidates=0
+
+    while IFS= read -r path; do
+        if ! is_supported_candidate "$path"; then
+            continue
+        fi
+        candidates=$((candidates + 1))
+        assigned=$(scope_for_file "$path" || true)
+        if [ -n "$assigned" ]; then
+            continue
+        fi
+        if is_explicitly_excluded "$path"; then
+            continue
+        fi
+        printf 'Unassigned Graphify source: %s\n' "$path" >&2
+        failures=$((failures + 1))
+    done <<EOF
+$(all_source_files)
+EOF
+
+    [ "$failures" -eq 0 ] || die "$failures supported production source file(s) are not assigned to a scope"
+
+    for scope in backend editor support migrations; do
+        count=$(list_scope "$scope" | wc -l | tr -d ' ')
+        [ "$count" -gt 0 ] || die "scope '$scope' is empty"
+        printf '%-10s %s files\n' "$scope" "$count"
+    done
+    printf 'Scope verification passed (%s supported candidates inspected).\n' "$candidates"
+}
+
+run_graphify() {
+    command -v mise >/dev/null 2>&1 || die "mise is required; install it and retry"
+    mkdir -p "$graphify_root/tooling/uv-cache" "$graphify_root/tooling/uv-tools"
+    env \
+        UV_CACHE_DIR="$graphify_root/tooling/uv-cache" \
+        UV_TOOL_DIR="$graphify_root/tooling/uv-tools" \
+        mise x "github:astral-sh/uv@$UV_VERSION" -- \
+        uvx --from "graphifyy[sql]==$GRAPHIFY_VERSION" graphify "$@"
+}
+
+materialize_scope() {
+    scope=$1
+    corpus_dir="$corpora_root/$scope"
+    temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/epistola-graphify-$scope.XXXXXX")
+    temp_corpus="$temp_dir/corpus"
+    file_list="$temp_dir/files.txt"
+    mkdir -p "$temp_corpus" "$corpus_dir"
+    list_scope "$scope" >"$file_list"
+    rsync -a --files-from="$file_list" "$repo_root/" "$temp_corpus/"
+    rsync -a --delete "$temp_corpus/" "$corpus_dir/"
+    rm -rf "$temp_dir"
+}
+
+scope_fingerprint() {
+    scope=$1
+    temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/epistola-graphify-fingerprint-$scope.XXXXXX")
+    paths_file="$temp_dir/paths.txt"
+    hashes_file="$temp_dir/hashes.txt"
+    list_scope "$scope" >"$paths_file"
+    git -C "$repo_root" hash-object --stdin-paths <"$paths_file" >"$hashes_file"
+    paste "$paths_file" "$hashes_file" | git hash-object --stdin
+    rm -rf "$temp_dir"
+}
+
+state_compatible() {
+    state_file=$1
+    [ -f "$state_file" ] || return 1
+    grep -qx "graphify_version=$GRAPHIFY_VERSION" "$state_file" && \
+        grep -qx "scope_schema_version=$SCOPE_SCHEMA_VERSION" "$state_file"
+}
+
+state_matches() {
+    state_file=$1
+    source_fingerprint=$2
+    state_compatible "$state_file" && grep -qx "source_fingerprint=$source_fingerprint" "$state_file"
+}
+
+write_state() {
+    scope=$1
+    state_file=$2
+    source_fingerprint=$3
+    ensured_commit=$(git -C "$repo_root" rev-parse HEAD)
+    ensured_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    cat >"$state_file" <<EOF
+graphify_version=$GRAPHIFY_VERSION
+scope_schema_version=$SCOPE_SCHEMA_VERSION
+scope=$scope
+source_fingerprint=$source_fingerprint
+ensured_commit=$ensured_commit
+ensured_at=$ensured_at
+EOF
+}
+
+refresh_scope() {
+    scope=$1
+    force=${2:-false}
+    require_scope "$scope"
+
+    corpus_dir="$corpora_root/$scope"
+    output_dir="$scoped_root/$scope"
+    graph_path="$output_dir/graph.json"
+    state_file="$output_dir/.epistola-state"
+    source_fingerprint=$(scope_fingerprint "$scope")
+
+    if [ "$force" != true ] && [ -f "$graph_path" ] && state_matches "$state_file" "$source_fingerprint"; then
+        printf 'Graphify scope %s is up to date.\n' "$scope"
+        return
+    fi
+
+    materialize_scope "$scope"
+    mkdir -p "$output_dir"
+
+    full_rebuild=$force
+    if [ ! -f "$graph_path" ] || ! state_compatible "$state_file"; then
+        full_rebuild=true
+    fi
+
+    if [ "$full_rebuild" = true ]; then
+        printf 'Building Graphify scope %s...\n' "$scope"
+        GRAPHIFY_OUT="$output_dir" run_graphify extract "$corpus_dir" \
+            --code-only \
+            --force \
+            --no-gitignore \
+            --max-workers "${GRAPHIFY_MAX_WORKERS:-6}"
+    else
+        printf 'Refreshing Graphify scope %s...\n' "$scope"
+        GRAPHIFY_OUT="$output_dir" run_graphify extract "$corpus_dir" \
+            --code-only \
+            --no-gitignore \
+            --max-workers "${GRAPHIFY_MAX_WORKERS:-6}"
+    fi
+
+    GRAPHIFY_OUT="$output_dir" GRAPHIFY_VIZ_NODE_LIMIT="${GRAPHIFY_VIZ_NODE_LIMIT:-10000}" \
+        run_graphify cluster-only "$corpus_dir" --graph "$graph_path" --no-label
+    write_state "$scope" "$state_file" "$source_fingerprint"
+}
+
+for_requested_scopes() {
+    requested=$1
+    operation=$2
+    if [ "$requested" = all ]; then
+        for scope in backend editor support migrations; do
+            "$operation" "$scope"
+        done
+    else
+        require_scope "$requested"
+        "$operation" "$requested"
+    fi
+}
+
+build_one() {
+    refresh_scope "$1" true
+}
+
+benchmark_one() {
+    scope=$1
+    refresh_scope "$scope" false
+    run_graphify benchmark "$scoped_root/$scope/graph.json"
+}
+
+status() {
+    printf 'Pinned Graphify %s via uv %s (scope schema %s)\n' \
+        "$GRAPHIFY_VERSION" "$UV_VERSION" "$SCOPE_SCHEMA_VERSION"
+    for scope in backend editor support migrations; do
+        graph_path="$scoped_root/$scope/graph.json"
+        state_file="$scoped_root/$scope/.epistola-state"
+        if [ -f "$graph_path" ]; then
+            size=$(du -h "$graph_path" | awk '{print $1}')
+            ensured_at=$(sed -n 's/^ensured_at=//p' "$state_file" 2>/dev/null || true)
+            printf '%-10s ready (%s, ensured %s)\n' "$scope" "$size" "${ensured_at:-unknown}"
+        else
+            printf '%-10s missing (run scripts/graphify.sh ensure %s)\n' "$scope" "$scope"
+        fi
+    done
+}
+
+command_name=${1:-}
+if [ -z "$command_name" ]; then
+    usage
+    exit 1
+fi
+shift
+
+case "$command_name" in
+    build)
+        requested=${1:-all}
+        for_requested_scopes "$requested" build_one
+        ;;
+    ensure)
+        [ "$#" -eq 1 ] || die "usage: scripts/graphify.sh ensure <scope>"
+        refresh_scope "$1" false
+        ;;
+    query)
+        [ "$#" -ge 2 ] || die "usage: scripts/graphify.sh query <scope> \"<question>\" [options]"
+        scope=$1
+        question=$2
+        shift 2
+        refresh_scope "$scope" false
+        run_graphify query "$question" --budget "${GRAPHIFY_QUERY_BUDGET:-$DEFAULT_QUERY_BUDGET}" \
+            --graph "$scoped_root/$scope/graph.json" "$@"
+        ;;
+    affected)
+        [ "$#" -ge 2 ] && [ "$#" -le 3 ] || die "usage: scripts/graphify.sh affected <scope> \"<symbol>\" [depth]"
+        scope=$1
+        symbol=$2
+        depth=${3:-$DEFAULT_AFFECTED_DEPTH}
+        refresh_scope "$scope" false
+        run_graphify affected "$symbol" --depth "$depth" --graph "$scoped_root/$scope/graph.json"
+        ;;
+    explain)
+        [ "$#" -eq 2 ] || die "usage: scripts/graphify.sh explain <scope> \"<symbol>\""
+        scope=$1
+        symbol=$2
+        refresh_scope "$scope" false
+        run_graphify explain "$symbol" --graph "$scoped_root/$scope/graph.json"
+        ;;
+    path)
+        [ "$#" -eq 3 ] || die "usage: scripts/graphify.sh path <scope> \"<from>\" \"<to>\""
+        scope=$1
+        from=$2
+        to=$3
+        refresh_scope "$scope" false
+        run_graphify path "$from" "$to" --graph "$scoped_root/$scope/graph.json"
+        ;;
+    benchmark)
+        requested=${1:-all}
+        for_requested_scopes "$requested" benchmark_one
+        ;;
+    status)
+        [ "$#" -eq 0 ] || die "usage: scripts/graphify.sh status"
+        status
+        ;;
+    verify-scopes)
+        [ "$#" -eq 0 ] || die "usage: scripts/graphify.sh verify-scopes"
+        verify_scopes
+        ;;
+    -h | --help | help)
+        usage
+        ;;
+    *)
+        usage >&2
+        die "unknown command '$command_name'"
+        ;;
+esac


### PR DESCRIPTION
## What changed

- add a pinned `scripts/graphify.sh` workflow for backend, editor, support, and migration graphs
- lazily refresh local graphs using content fingerprints and incremental extraction
- keep generated corpora, reports, graphs, and HTML visualizations out of Git and AI context
- verify production source scope coverage in CI and maintain tool pins through Renovate
- document how assistants should use Graphify for candidate impact analysis and verify its output

## Why

The repository-wide graph is too large and visually connected to be useful as a coupling score. Scoped structural graphs provide a faster way for assistants and developers to identify likely impact without confusing framework/reference connectivity with architectural coupling.

Generated output remains local. Graphify is used as a navigation aid; source inspection, module dependencies, and tests remain authoritative.

## Validation

- `./gradlew unitTest integrationTest`
- `CI=true pnpm format:check`
- `CI=true pnpm license:check`
- `scripts/graphify.sh verify-scopes`
- `sh -n scripts/graphify.sh`
- incremental add/delete freshness checks
- representative `affected`, `explain`, and `path` queries
- `scripts/graphify.sh benchmark all`
- `git diff --check`
