### PR TITLE
fix(catalogs): keep the update entry reachable and redesign it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+- **[user]** fix(catalogs): **Catalog update entry no longer clips out of reach.** In the
+  catalogs list, long version strings could push the "update available" button past the
+  fixed-width Version column's clipping edge, leaving the update unreachable except through
+  developer tools. The Version column is wider (at the expense of the Name and Actions
+  columns), and the update entry is redesigned: the installed version renders in the accent
+  color next to a gently pulsing button carrying an upgrade icon and the target version.
+- **[dev]** feat(design-system): **Motion utilities get a home.** New `animations.css` in the
+  design system holds shared motion utilities, starting with `ep-breathe` (slow opacity pulse
+  for passive attention). All utilities in it are disabled under `prefers-reduced-motion`.
 - **[dev]** fix(ci): **The scheduled security scan generates the editor SBOM with pnpm 11.**
   Invoke the editor's `sbom` package script explicitly so pnpm does not route the command to its
   built-in SBOM generator and fail because no format was supplied.

--- a/apps/epistola/src/main/resources/templates/catalogs/list.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/list.html
@@ -34,12 +34,12 @@
              data-testid="fixed-table-scroll">
         <table class="ep-table ep-table-fixed">
             <colgroup>
-                <col style="width: 21%" /><!-- Name -->
+                <col style="width: 18%" /><!-- Name -->
                 <col style="width: 15%" /><!-- ID -->
                 <col style="width: 13%" /><!-- Type -->
-                <col style="width: 12%" /><!-- Version -->
+                <col style="width: 20%" /><!-- Version -->
                 <col style="width: 17%" /><!-- Last Modified -->
-                <col style="width: 22%" /><!-- Actions -->
+                <col style="width: 17%" /><!-- Actions -->
             </colgroup>
             <thead>
                 <tr>
@@ -271,9 +271,10 @@
          "Check for updates" icon (actions cell) hx-gets `upgrade-check`, which
          returns this fragment swapped into that cell. `state` ∈ UNCHECKED |
          UP_TO_DATE | UPDATE_AVAILABLE | ZIP_MANAGED | CHECK_FAILED |
-         NOT_IN_SYNC | SOURCE_AHEAD. Up to date is green; an available update is
-         grey + the new version, which is the clickable entry to the Review
-         dialog. NOT_IN_SYNC (amber) means the source publishes an older catalog
+         NOT_IN_SYNC | SOURCE_AHEAD. Up to date is green; an available update
+         shows the installed version in the accent color next to a gently
+         pulsing (ep-breathe) icon+version button — the clickable entry to the
+         Review dialog. NOT_IN_SYNC (amber) means the source publishes an older catalog
          schema version than this Epistola and must republish it. CSP-safe
          (hx-get only). -->
     <th:block th:fragment="version-status" th:switch="${state}">
@@ -287,13 +288,17 @@
               th:text="${installedVersion != null ? 'v' + installedVersion : 'Up to date'}">v1.0.0</span>
 
         <span th:case="'UPDATE_AVAILABLE'"
-              style="display: inline-flex; align-items: baseline; gap: var(--ep-space-1);">
-            <span class="text-muted" th:text="${installedVersion != null ? 'v' + installedVersion : '—'}">v1.0.0</span>
-            <button type="button" class="ep-btn ep-btn-ghost ep-btn-sm" style="font-weight: 500;"
+              style="display: inline-flex; align-items: center; gap: var(--ep-space-2);">
+            <span style="color: var(--ep-primary-strong); font-weight: 500;"
+                  th:text="${installedVersion != null ? 'v' + installedVersion : '—'}">v1.0.0</span>
+            <button type="button" class="ep-btn ep-btn-ghost ep-btn-sm ep-breathe" style="font-weight: 500;"
                     th:title="${'Update available' + (availableVersion != null ? ' — v' + availableVersion : '') + '. Review the changes before applying.'}"
                     th:hx-get="@{/tenants/{tenantId}/catalogs/{catalogId}/upgrade-preview(tenantId=${tenantId},catalogId=${catalogId})}"
                     hx-target="#upgrade-dialog-container" hx-swap="innerHTML"
-                    th:text="${availableVersion != null ? '→ v' + availableVersion : '→ update available'}">→ v1.1.0</button>
+                    data-testid="catalog-upgrade-review">
+                <th:block th:replace="~{epistola-web/icon :: icon(name='circle-arrow-up', class='ep-icon ep-icon-sm')}" />
+                <span th:text="${availableVersion != null ? 'v' + availableVersion : 'update available'}">v1.1.0</span>
+            </button>
         </span>
 
         <span th:case="'ZIP_MANAGED'" class="text-muted"

--- a/apps/epistola/src/main/resources/templates/fragments/styles.html
+++ b/apps/epistola/src/main/resources/templates/fragments/styles.html
@@ -16,6 +16,7 @@
         <link rel="stylesheet" th:href="@{/design-system/tokens.css}">
         <link rel="stylesheet" th:href="@{/design-system/base.css}">
         <link rel="stylesheet" th:href="@{/design-system/components.css}">
+        <link rel="stylesheet" th:href="@{/design-system/animations.css}">
         <link rel="stylesheet" th:href="@{/css/main.css}">
     </th:block>
 </head>

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogUpgradeHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogUpgradeHandlerTest.kt
@@ -190,7 +190,55 @@ class CatalogUpgradeHandlerTest : BaseIntegrationTest() {
             val response = result<org.springframework.http.ResponseEntity<String>>()
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(response.body).contains("Up to date")
-            assertThat(response.body).doesNotContain("Update →")
+            assertThat(response.body).doesNotContain("catalog-upgrade-review")
+        }
+    }
+
+    @Test
+    fun `upgrade-check renders the review button when an update is available`() = fixture {
+        lateinit var testTenant: Tenant
+        given {
+            testTenant = tenant("Upgrade Check Available")
+            // Register + install from a file-based source, then advance the
+            // source's release so the next check reports UPDATE_AVAILABLE.
+            val dir = Files.createTempDirectory("update-catalog")
+            val manifest = dir.resolve("catalog.json")
+            Files.writeString(
+                manifest,
+                """{"schemaVersion":$CATALOG_SCHEMA_VERSION,"catalog":{"slug":"moving-source","name":"Moving Source"},""" +
+                    """"publisher":{"name":"P"},"release":{"version":"1.0.0"},"resources":[]}""",
+            )
+            withMediator {
+                RegisterCatalog(testTenant.id, sourceUrl = manifest.toUri().toString(), authType = AuthType.NONE).execute()
+                InstallFromCatalog(tenantKey = testTenant.id, catalogKey = CatalogKey.of("moving-source")).execute()
+            }
+            Files.writeString(
+                manifest,
+                """{"schemaVersion":$CATALOG_SCHEMA_VERSION,"catalog":{"slug":"moving-source","name":"Moving Source"},""" +
+                    """"publisher":{"name":"P"},"release":{"version":"1.1.0"},"resources":[]}""",
+            )
+        }
+
+        whenever {
+            restTemplate.exchange(
+                "/tenants/${testTenant.id}/catalogs/moving-source/upgrade-check",
+                org.springframework.http.HttpMethod.GET,
+                HttpEntity<Void>(htmxGet()),
+                String::class.java,
+            )
+        }
+
+        then {
+            val response = result<org.springframework.http.ResponseEntity<String>>()
+            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+            val body = response.body!!
+            // The review entry: icon + target version inside the button, full
+            // context in the tooltip, gentle pulse via ep-breathe.
+            assertThat(body).contains("catalog-upgrade-review")
+            assertThat(body).contains("upgrade-preview")
+            assertThat(body).contains("Update available — v1.1.0")
+            assertThat(body).contains("icon-circle-arrow-up")
+            assertThat(body).contains("ep-breathe")
         }
     }
 

--- a/modules/design-system/animations.css
+++ b/modules/design-system/animations.css
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Epistola Nederland B.V.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/*
+ * Epistola Design System — Animations
+ *
+ * Shared motion utilities. Keep this file small and deliberate: every
+ * animation must stay subtle, and every utility added here must be disabled
+ * under `prefers-reduced-motion` (extend the guard at the bottom).
+ */
+
+@layer components {
+  /* Slow opacity pulse for passive attention — content that should draw the
+     eye without moving (e.g. the catalog list's update-available button).
+     Stays well above legibility floor at its dimmest. */
+  .ep-breathe {
+    animation: ep-breathe 1.2s ease-in-out infinite;
+  }
+
+  @keyframes ep-breathe {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.6;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ep-breathe {
+      animation: none;
+    }
+  }
+}

--- a/modules/design-system/icons.svg
+++ b/modules/design-system/icons.svg
@@ -27,8 +27,8 @@
   <path d="M4.929 4.929 19.07 19.071" />
   </symbol>
   <symbol id="icon-book-open" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M12 7v14" />
-  <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+    <path d="M12 5v16" />
+  <path d="M20.001 19A2 2 0 0022 17V5a2 2 0 00-1.999-2L16 3.002A5 5 0 0012 5a5 5 0 00-4-2H4a2 2 0 00-2 2v12a2 2 0 001.999 2H8a5 5 0 014 2 5 5 0 014-2z" />
   </symbol>
   <symbol id="icon-building-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M10 12h4" />
@@ -49,6 +49,11 @@
   </symbol>
   <symbol id="icon-chevron-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="m18 15-6-6-6 6" />
+  </symbol>
+  <symbol id="icon-circle-arrow-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="10" />
+  <path d="m16 12-4-4-4 4" />
+  <path d="M12 16V8" />
   </symbol>
   <symbol id="icon-clock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="10" />

--- a/modules/design-system/icons/generate-sprite.js
+++ b/modules/design-system/icons/generate-sprite.js
@@ -40,6 +40,7 @@ const ICONS = [
   'chevron-down',
   'chevron-right',
   'chevron-up',
+  'circle-arrow-up',
   'clock',
   'columns-2',
   'copy',
@@ -118,7 +119,19 @@ function generateSprite() {
     }
   }
 
-  const sprite = `<svg xmlns="http://www.w3.org/2000/svg" style="display:none">\n${symbols.join('\n')}\n</svg>\n`;
+  // Assembled at runtime so license scanners don't read these literals as
+  // this file's own SPDX declaration.
+  const spdxTag = (name, value) => `  SPDX-${name}: ${value}`;
+  const header = [
+    '<!--',
+    spdxTag('FileCopyrightText', 'Epistola Nederland B.V.'),
+    '',
+    spdxTag('License-Identifier', 'AGPL-3.0-only'),
+    '-->',
+    '',
+    '',
+  ].join('\n');
+  const sprite = `${header}<svg xmlns="http://www.w3.org/2000/svg" style="display:none">\n${symbols.join('\n')}\n</svg>\n`;
 
   const outPath = join(ROOT, 'icons.svg');
   writeFileSync(outPath, sprite, 'utf-8');


### PR DESCRIPTION
## Description

The "update available" link in the catalogs list could no longer be clicked — the element was still findable in devtools but not on screen. Root cause: the fixed table layout introduced in #800 gives every cell `overflow: hidden` with a 12% Version column, and the update button rendered *after* the installed version inside that cell, so any longer version string (pre-release suffix, double-digit segments) pushed it past the clipping edge.

This PR fixes the reachability bug and redesigns the update entry:

- **Version column widened 12% → 20%** (Name 21% → 18%, Actions 22% → 17%); verified all action buttons still fit on one line and double-digit version pairs render with room to spare
- **Update entry redesigned**: the installed version renders in the accent color (weight 500, mirroring the green up-to-date state), next to a ghost button carrying a `circle-arrow-up` icon + the target version; full context stays in the tooltip
- **New `animations.css` in the design system** — a home for shared motion utilities, starting with `ep-breathe` (slow opacity pulse, 1.2s, 1 → 0.6) applied to the update button; disabled under `prefers-reduced-motion`
- **Sprite generator now emits its own SPDX header** so regenerating `icons.svg` no longer strips the REUSE metadata (tags assembled at runtime so `reuse lint` doesn't misread the JS source)

Known residual: an extreme *pre-release pair* (both versions with long suffixes) could still overflow — the structural fix (icon-only button, fixed-width content) was prototyped but deliberately not shipped here.

## Related Issue(s)

None — reported by a user via email.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

Reproduce locally: mark a subscribed catalog's install stale (`UPDATE catalogs SET installed_fingerprint = repeat('0', 64), installed_release_version = '10.10.10' WHERE …`) and click the row's "Check for updates" icon.

## Additional Notes

- New handler test covers the `UPDATE_AVAILABLE` fragment via a file-based source whose release is bumped after install — the previously untested state where this bug hid.
- `UP_TO_DATE` assertion now keys on the `catalog-upgrade-review` testid instead of stale button text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)