### PR TITLE
fix(fonts): normalize uploaded font media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+- **[user]** fix(fonts): **Font uploads work with incorrect browser MIME labels.** Font files
+  selected on corporate-managed devices are sent and stored as canonical `font/ttf` or
+  `font/otf`, while server-side byte validation accepts valid fonts even when the browser reports
+  a generic or misspelled binary type. Font-upload errors now mention only TTF and OTF rather than
+  the global asset allowlist.
 - **[user]** fix(catalog): **Catalogs with JSON Schema properties named `type` export normally.**
   Upgrade the backend and editor contract dependencies to 1.0.1, which prevents semantic
   fingerprinting from coercing nested schema objects to strings during catalog export.

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FontHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FontHandler.kt
@@ -244,7 +244,7 @@ class FontHandler(
             for (row in rows) {
                 try {
                     assetTypeCatalog.require(row.mediaType.mimeType)
-                } catch (e: UnsupportedAssetTypeException) {
+                } catch (_: UnsupportedAssetTypeException) {
                     faceError = "Unsupported font format. Use a .ttf or .otf file."
                     break
                 }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FontHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FontHandler.kt
@@ -201,7 +201,7 @@ class FontHandler(
             val weight: Int,
             val italic: Boolean,
             val filename: String,
-            val contentType: String?,
+            val mediaType: AssetMediaType,
             val bytes: ByteArray,
         )
         val rows = mutableListOf<FaceRow>()
@@ -219,12 +219,18 @@ class FontHandler(
             }
             val italic = italics.getOrNull(idx)?.equals("true", ignoreCase = true) == true
             val bytes = part.inputStream.use { it.readAllBytes() }
+            val filename = part.submittedFileName
+                ?: "${slug?.value ?: "font"}-$weight${if (italic) "i" else ""}"
+            val mediaType = fontMediaType(filename)
+            if (mediaType == null) {
+                faceError = "Unsupported font file: $filename. Use a .ttf or .otf file."
+                break
+            }
             rows += FaceRow(
                 weight = weight,
                 italic = italic,
-                filename = part.submittedFileName
-                    ?: "${slug?.value ?: "font"}-$weight${if (italic) "i" else ""}",
-                contentType = part.contentType,
+                filename = filename,
+                mediaType = mediaType,
                 bytes = bytes,
             )
         }
@@ -236,19 +242,10 @@ class FontHandler(
         }
         if (faceError == null) {
             for (row in rows) {
-                val contentType = row.contentType
-                if (contentType == null) {
-                    faceError = "No content type on uploaded face"
-                    break
-                }
-                val mediaType = try {
-                    assetTypeCatalog.require(contentType)
+                try {
+                    assetTypeCatalog.require(row.mediaType.mimeType)
                 } catch (e: UnsupportedAssetTypeException) {
-                    faceError = e.message ?: "Unsupported font format"
-                    break
-                }
-                if (mediaType !in FONT_MEDIA_TYPES) {
-                    faceError = "Unsupported font format: $contentType. Use TTF or OTF."
+                    faceError = "Unsupported font format. Use a .ttf or .otf file."
                     break
                 }
                 val reason = app.epistola.generation.pdf.FontBytesValidator.rejectionReason(row.bytes)
@@ -268,7 +265,7 @@ class FontHandler(
                     val asset = UploadAsset(
                         tenantId = tenantKey,
                         name = row.filename,
-                        mediaType = assetTypeCatalog.require(row.contentType!!),
+                        mediaType = row.mediaType,
                         content = row.bytes,
                         width = null,
                         height = null,
@@ -480,10 +477,19 @@ class FontHandler(
     }
 
     private companion object {
-        /** Asset media types accepted for font-face binaries. */
-        val FONT_MEDIA_TYPES = setOf(
-            AssetMediaType.TTF,
-            AssetMediaType.OTF,
-        )
+        /**
+         * Browser-supplied multipart media types are advisory: Chromium can
+         * source them from the host OS and enterprise-managed registries. Use
+         * the accepted filename extension for the canonical stored media type;
+         * [app.epistola.generation.pdf.FontBytesValidator] remains the content
+         * authority before anything is persisted.
+         */
+        fun fontMediaType(filename: String): AssetMediaType? = when (
+            filename.substringAfterLast('.', missingDelimiterValue = "").lowercase()
+        ) {
+            "ttf" -> AssetMediaType.TTF
+            "otf" -> AssetMediaType.OTF
+            else -> null
+        }
     }
 }

--- a/apps/epistola/src/main/resources/static/js/pages/asset-forms.js
+++ b/apps/epistola/src/main/resources/static/js/pages/asset-forms.js
@@ -157,6 +157,45 @@
     container.appendChild(clone);
   });
 
+  // ── Font files: canonicalize the browser-provided MIME type ─────────────────
+  // Chromium may source File.type from an OS-managed extension registry. Replace
+  // selected TTF/OTF files with equivalent File objects carrying the canonical
+  // IANA type so multipart submissions are stable across corporate endpoints.
+  // The server still validates the filename and bytes independently.
+  function canonicalFontMimeType(filename) {
+    const lowerName = filename.toLowerCase();
+    if (lowerName.endsWith('.ttf')) return 'font/ttf';
+    if (lowerName.endsWith('.otf')) return 'font/otf';
+    return null;
+  }
+
+  document.addEventListener('change', function (event) {
+    const input = event.target.closest && event.target.closest('input[data-font-file]');
+    if (!input || !input.files || input.files.length === 0) return;
+    if (typeof File !== 'function' || typeof DataTransfer !== 'function') return;
+
+    const normalizedFiles = Array.from(input.files).map(function (file) {
+      const canonicalType = canonicalFontMimeType(file.name);
+      if (!canonicalType || file.type === canonicalType) return file;
+      return new File([file], file.name, {
+        type: canonicalType,
+        lastModified: file.lastModified,
+      });
+    });
+    if (
+      normalizedFiles.every(function (file, index) {
+        return file === input.files[index];
+      })
+    )
+      return;
+
+    const transfer = new DataTransfer();
+    normalizedFiles.forEach(function (file) {
+      transfer.items.add(file);
+    });
+    input.files = transfer.files;
+  });
+
   // ── File input: show the selected file name ─────────────────────────────────
   // Usage: <input type="file" data-file-preview="preview-container-id">
   // The container holds a #file-name span; it is shown with the chosen file's

--- a/apps/epistola/src/main/resources/templates/fonts/new.html
+++ b/apps/epistola/src/main/resources/templates/fonts/new.html
@@ -76,6 +76,7 @@
                         <div style="flex:2;">
                             <label class="ep-label">File</label>
                             <input type="file" name="file"
+                                   data-font-file
                                    accept="font/ttf,font/otf,.ttf,.otf" />
                         </div>
                         <div style="flex:1;">

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/fonts/FontUploadHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/fonts/FontUploadHandlerTest.kt
@@ -14,6 +14,8 @@ import app.epistola.suite.mediator.query
 import app.epistola.suite.tenants.Tenant
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.resttestclient.TestRestTemplate
 import org.springframework.core.io.ByteArrayResource
@@ -49,11 +51,11 @@ class FontUploadHandlerTest : BaseIntegrationTest() {
         .getResource("classpath:epistola/fonts/inter/inter-Regular.ttf")
         .contentAsByteArray
 
-    private fun facePart(name: String) = HttpEntity(
+    private fun facePart(name: String, contentType: String = "font/ttf") = HttpEntity(
         object : ByteArrayResource(ttf()) {
             override fun getFilename(): String = name
         },
-        HttpHeaders().apply { contentType = MediaType.parseMediaType("font/ttf") },
+        HttpHeaders().apply { this.contentType = MediaType.parseMediaType(contentType) },
     )
 
     /** A face whose content type is font/ttf but whose bytes are not a valid font. */
@@ -111,6 +113,72 @@ class FontUploadHandlerTest : BaseIntegrationTest() {
             )
             val slugs = objectMapper.readTree(search.body).values().map { it["slug"].asString() }
             assertThat(slugs).contains("acme-sans")
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["application/octet-stream", "application/x-octect-stream"])
+    fun `valid TTF upload ignores advisory browser media type`(browserMediaType: String) = fixture {
+        lateinit var testTenant: Tenant
+
+        given { testTenant = tenant("Font Browser MIME ${browserMediaType.hashCode()}") }
+
+        whenever {
+            val payload = LinkedMultiValueMap<String, Any>()
+            payload.add("slug", "corporate-sans")
+            payload.add("name", "Corporate Sans")
+            payload.add("kind", "sans")
+            payload.add("catalog", "default")
+            payload.add("file", facePart("corporate-sans.ttf", browserMediaType))
+            payload.add("weight", "400")
+            payload.add("italic", "false")
+            restTemplate.postForEntity(
+                "/tenants/${testTenant.id}/fonts",
+                HttpEntity(payload, multipartHeaders()),
+                String::class.java,
+            )
+        }
+
+        then {
+            val response = result<ResponseEntity<String>>()
+            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+
+            val assets = withMediator { ListAssets(tenantId = testTenant.id).query() }
+            val asset = assets.single { it.name == "corporate-sans.ttf" }
+            assertThat(asset.name).isEqualTo("corporate-sans.ttf")
+            assertThat(asset.mediaType.mimeType).isEqualTo("font/ttf")
+        }
+    }
+
+    @Test
+    fun `PDF upload is rejected with a font-specific error`() = fixture {
+        lateinit var testTenant: Tenant
+
+        given { testTenant = tenant("Font PDF Reject Tenant") }
+
+        whenever {
+            val payload = LinkedMultiValueMap<String, Any>()
+            payload.add("slug", "not-a-font")
+            payload.add("name", "Not A Font")
+            payload.add("kind", "sans")
+            payload.add("catalog", "default")
+            payload.add("file", facePart("not-a-font.pdf", "application/pdf"))
+            payload.add("weight", "400")
+            payload.add("italic", "false")
+            restTemplate.postForEntity(
+                "/tenants/${testTenant.id}/fonts",
+                HttpEntity(payload, multipartHeaders()),
+                String::class.java,
+            )
+        }
+
+        then {
+            val response = result<ResponseEntity<String>>()
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body).contains("Use a .ttf or .otf file")
+            assertThat(response.body).doesNotContain("Supported:")
+            assertThat(withMediator { ListAssets(tenantId = testTenant.id).query() })
+                .noneMatch { it.name == "not-a-font.pdf" }
         }
     }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/FontUploadMimeUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/FontUploadMimeUiTest.kt
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.tenants.Tenant
+import app.epistola.suite.tenants.commands.CreateTenant
+import com.microsoft.playwright.options.FilePayload
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.io.ResourceLoader
+
+/** Browser coverage for canonicalizing OS-provided font MIME types before upload. */
+class FontUploadMimeUiTest : BasePlaywrightTest() {
+
+    @Autowired
+    private lateinit var resourceLoader: ResourceLoader
+
+    @Test
+    fun `corporate browser media type is normalized before font upload`() {
+        lateinit var tenant: Tenant
+        withMediator {
+            tenant = CreateTenant(
+                id = TenantKey.of("test-font-mime-${System.nanoTime()}"),
+                name = "Font MIME UI Test",
+            ).execute()
+        }
+
+        gotoAndReady("/tenants/${tenant.id}/fonts/new")
+        page.locator("#slug").fill("corporate-sans")
+        page.locator("#name").fill("Corporate Sans")
+
+        val bytes = resourceLoader
+            .getResource("classpath:epistola/fonts/inter/inter-Regular.ttf")
+            .contentAsByteArray
+        val fileInput = page.locator("input[data-font-file]")
+        fileInput.setInputFiles(
+            FilePayload("corporate-sans.ttf", "application/x-octect-stream", bytes),
+        )
+
+        assertThat(fileInput.evaluate("el => el.files[0].type"))
+            .isEqualTo("font/ttf")
+
+        page.locator("[data-testid='create-form-submit']").click()
+        page.htmxSettle()
+
+        com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat(page.locator("#font-grid-items"))
+            .containsText("Corporate Sans")
+    }
+}

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -31,6 +31,14 @@ is rejected at upload. Allowed media types live in the seeded `asset_types`
 lookup table (not an enum/CHECK); `AssetMediaType` is an open value class with
 an `AssetMediaCategory` (IMAGE/FONT) split.
 
+The multipart media type reported by a browser is advisory. Some browsers
+derive it from OS-managed extension mappings, which can be missing or changed
+on corporate devices. The web UI therefore canonicalizes `.ttf` and `.otf`
+selections to `font/ttf` and `font/otf` before submission, and the server derives
+the stored type from the accepted extension. Actual acceptance still depends on
+`FontBytesValidator`: changing a filename or request header cannot make invalid,
+corrupt, WOFF/WOFF2, or embedding-restricted bytes pass validation.
+
 ## The `fontFamily` style value
 
 `fontFamily` in document styles / block-style presets / inline node styles is


### PR DESCRIPTION
## What changed

- normalize `.ttf` and `.otf` selections to `font/ttf` and `font/otf` in the browser before multipart submission
- derive the canonical stored font media type from the accepted filename extension on the server
- retain byte-level font validation before persistence
- keep font-upload validation messages limited to TTF and OTF, without listing PDF or other globally supported asset types
- add integration and Playwright regression coverage and document the behavior

## Why

Some corporate-managed systems provide Chromium with incorrect OS MIME mappings, causing valid fonts to be submitted as `application/octet-stream` or the misspelled `application/x-octect-stream`. The upload flow treated that browser-provided value as authoritative and rejected otherwise valid font files.

The multipart media type is now advisory. The browser sends a canonical type when possible, while the server independently canonicalizes the type and validates the actual bytes.

## Impact

Valid TTF and OTF files upload consistently across managed environments. PDF remains unsupported by the font uploader and is only allowed in the appropriate image-upload flow.

## Validation

- `pnpm format:check`
- `./gradlew ktlintCheck`
- focused font upload integration tests
- focused Playwright MIME normalization test
- `./gradlew unitTest integrationTest`
- `./gradlew checkContractVersionAlignment`
- `git diff --check`
