### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-04
+
+This patch release makes font uploads more resilient on managed devices, restores reliable catalog
+exports for JSON Schemas with `type` properties, and keeps catalog upgrades reachable when version
+labels are long.
+
 - **[user]** fix(fonts): **Font uploads work with incorrect browser MIME labels.** Font files
   selected on corporate-managed devices are sent and stored as canonical `font/ttf` or
   `font/otf`, while server-side byte validation accepts valid fonts even when the browser reports

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # a release strips it, tags v<version>, then re-opens the next -SNAPSHOT (see the
 # `release` skill). CI validates the v* tag equals this value. A -PreleaseVersion
 # override (PR snapshot builds) still wins over this.
-version=1.0.1-SNAPSHOT
+version=1.0.1
 
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
## Summary

- finalize the application version as `1.0.1`
- move the Unreleased changelog entries into the dated `1.0.1` release section
- add an end-user release summary covering font uploads, catalog exports, and catalog upgrade visibility

## Why

The `1.0.1-SNAPSHOT` development cycle contains patch-level fixes and maintenance changes since `v1.0.0`. This commit aligns the application version and changelog for the matching `v1.0.1` release tag.

## Impact

After this PR is merged, the merge commit is ready to be tagged `v1.0.1`. The tag-triggered build workflow will validate the tag against `gradle.properties` and publish the signed application image.

## Validation

- `node_modules/.bin/oxfmt --check`
- `./gradlew checkContractVersionAlignment ktlintCheck`
- `./gradlew unitTest integrationTest`
- `python3 scripts/license-headers.py --check`
- `reuse --no-multiprocessing lint`