### PR TITLE
fix(audit): exclude consumer housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+- **[user]** fix(audit): **Consumer polling no longer floods the audit log.** Consumer node
+  heartbeat/assignment updates and generation-result acknowledgement cursor advances are excluded
+  from auditing, and a scoped migration removes their existing success and failure entries while
+  preserving genuine audit history.
+
 ## [1.0.1] - 2026-08-04
 
 This patch release makes font uploads more resilient on managed devices, restores reliable catalog

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/migration/DataPreservationMigrationIT.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/migration/DataPreservationMigrationIT.kt
@@ -114,6 +114,27 @@ class DataPreservationMigrationIT {
                 INSERT INTO feature_toggles (tenant_key, feature_key, enabled)
                 VALUES ('$TENANT', 'stencil-parameters', true),
                        ('$TENANT', 'support-feedback', false);
+
+                -- audit_log is partitioned, while this migration-only fixture does not start the
+                -- partition scheduler. Create the historical partition explicitly so the scoped
+                -- consumer-housekeeping cleanup can be exercised against pre-existing rows.
+                CREATE TABLE audit_log_202606
+                    PARTITION OF audit_log
+                    FOR VALUES FROM ('2026-06-01 00:00:00+00') TO ('2026-07-01 00:00:00+00');
+
+                INSERT INTO audit_log
+                    (id, occurred_at, tenant_key, action, operation, outcome, instance_id)
+                VALUES
+                    ('00000000-0000-0000-0000-000000000101', '2026-06-23 10:00:00+00', '$TENANT',
+                     'TouchConsumerNode', 'WRITE', 'SUCCESS', 'migration-test'),
+                    ('00000000-0000-0000-0000-000000000102', '2026-06-23 10:00:01+00', '$TENANT',
+                     'TouchConsumerNode', 'WRITE', 'FAILURE', 'migration-test'),
+                    ('00000000-0000-0000-0000-000000000103', '2026-06-23 10:00:02+00', '$TENANT',
+                     'AcknowledgeGenerationResults', 'WRITE', 'SUCCESS', 'migration-test'),
+                    ('00000000-0000-0000-0000-000000000104', '2026-06-23 10:00:03+00', '$TENANT',
+                     'AcknowledgeGenerationResults', 'WRITE', 'FAILURE', 'migration-test'),
+                    ('00000000-0000-0000-0000-000000000105', '2026-06-23 10:00:04+00', '$TENANT',
+                     'CreateTheme', 'WRITE', 'SUCCESS', 'migration-test');
                 """.trimIndent(),
             )
         }
@@ -161,6 +182,18 @@ class DataPreservationMigrationIT {
                 .isEqualTo("0")
             assertThat(one("SELECT count(*) FROM feature_toggles WHERE tenant_key = '$TENANT' AND feature_key = 'support-feedback'"))
                 .describedAs("unrelated feature-toggle rows must survive the scoped delete")
+                .isEqualTo("1")
+
+            // Consumer transport housekeeping is intentionally removed from historical audit
+            // partitions, including failures; unrelated audit history remains untouched.
+            assertThat(one("SELECT count(*) FROM audit_log WHERE action = 'TouchConsumerNode'"))
+                .describedAs("historical consumer heartbeat audit rows must be deleted")
+                .isEqualTo("0")
+            assertThat(one("SELECT count(*) FROM audit_log WHERE action = 'AcknowledgeGenerationResults'"))
+                .describedAs("historical consumer acknowledgement audit rows must be deleted")
+                .isEqualTo("0")
+            assertThat(one("SELECT count(*) FROM audit_log WHERE action = 'CreateTheme'"))
+                .describedAs("unrelated audit rows must survive the scoped delete")
                 .isEqualTo("1")
         }
     }

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -103,7 +103,10 @@ Commands and queries have **opposite default polarity**:
   (the high-frequency opt-out). `NotAudited` covers `RecordApiKeyUsage` /
   `RecordUserLogin` (housekeeping) and `GenerateDocument` /
   `GenerateDocumentBatch` (high-volume, and already tracked in full by the
-  generation subsystem — they would bury the trail without adding much).
+  generation subsystem — they would bury the trail without adding much). It also
+  covers the consumer protocol's `TouchConsumerNode` heartbeat/assignment update
+  and `AcknowledgeGenerationResults` cursor advance: both are high-frequency
+  transport housekeeping, not operator actions.
 - **Queries → opt-in** (`operation = READ`). Queries are recorded _only_ when
   marked `AuditedRead`, because they are overwhelmingly high-volume internal
   reads (nav, feature toggles, list pages — several per page render). Only the
@@ -115,6 +118,11 @@ The mediator notifies cross-cutting listeners for _every_ command and query; the
 audit listener applies the polarity above. So adding a read to the trail is a
 one-line `AuditedRead` marker on the query, and removing command noise is a
 one-line `NotAudited` marker.
+
+Rows created for the consumer housekeeping commands before they were classified
+as `NotAudited` are removed by a scoped forward data migration. Genuine audit
+events remain append-only and forever-retained; this cleanup corrects historical
+scope rather than introducing general retention or deletion.
 
 If a genuinely useful **system** action should be audited despite being
 `SystemInternal`, introduce a small opt-in marker (e.g. `AlwaysAudited`) and

--- a/modules/epistola-audit/src/main/resources/db/migration/audit/V20260805074531__audit_remove_consumer_housekeeping.sql
+++ b/modules/epistola-audit/src/main/resources/db/migration/audit/V20260805074531__audit_remove_consumer_housekeeping.sql
@@ -1,0 +1,9 @@
+-- backup-restore-compatibility: backward=true forward=true
+-- reason: Data-only cleanup of audit_log, which is excluded from tenant backup/restore. No
+-- backed-up table changes, so a backup restores cleanly across this migration in either direction.
+--
+-- Consumer heartbeat/partition-assignment touches and acknowledgement cursor advances are
+-- high-frequency transport housekeeping, not operator actions. They are now NotAudited; remove
+-- the historical success and failure rows that were recorded before that classification.
+DELETE FROM audit_log
+WHERE action IN ('TouchConsumerNode', 'AcknowledgeGenerationResults');

--- a/modules/epistola-audit/src/test/kotlin/app/epistola/suite/audit/AuditMarkersTest.kt
+++ b/modules/epistola-audit/src/test/kotlin/app/epistola/suite/audit/AuditMarkersTest.kt
@@ -9,6 +9,8 @@ import app.epistola.suite.common.NotAudited
 import app.epistola.suite.documents.commands.GenerateDocument
 import app.epistola.suite.documents.commands.GenerateDocumentBatch
 import app.epistola.suite.documents.queries.GetDocument
+import app.epistola.suite.generation.collect.commands.AcknowledgeGenerationResults
+import app.epistola.suite.generation.collect.commands.TouchConsumerNode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test
  * Fast guard for the deliberate audit-scope decisions, so a marker can't be
  * dropped silently:
  * - high-volume document generation is excluded from the audit log ([NotAudited]);
+ * - consumer heartbeat/cursor housekeeping is excluded from the audit log;
  * - retrieving a stored document is an audited data-access read ([AuditedRead]).
  */
 class AuditMarkersTest {
@@ -24,6 +27,12 @@ class AuditMarkersTest {
     fun `high-volume generation commands are excluded from audit`() {
         assertThat(NotAudited::class.java.isAssignableFrom(GenerateDocument::class.java)).isTrue()
         assertThat(NotAudited::class.java.isAssignableFrom(GenerateDocumentBatch::class.java)).isTrue()
+    }
+
+    @Test
+    fun `consumer transport housekeeping commands are excluded from audit`() {
+        assertThat(NotAudited::class.java.isAssignableFrom(TouchConsumerNode::class.java)).isTrue()
+        assertThat(NotAudited::class.java.isAssignableFrom(AcknowledgeGenerationResults::class.java)).isTrue()
     }
 
     @Test

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/collect/commands/AcknowledgeGenerationResults.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/collect/commands/AcknowledgeGenerationResults.kt
@@ -4,6 +4,7 @@
 
 package app.epistola.suite.generation.collect.commands
 
+import app.epistola.suite.common.NotAudited
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.mediator.Command
 import app.epistola.suite.mediator.CommandHandler
@@ -23,6 +24,9 @@ import org.springframework.stereotype.Component
  *
  * Empty [partitions] or non-positive [acknowledgeUpTo] are no-ops — useful so
  * the collect endpoint can call this unconditionally without branching.
+ *
+ * This is high-frequency transport housekeeping rather than a user/domain action,
+ * so it is excluded from the audit trail via [NotAudited].
  */
 data class AcknowledgeGenerationResults(
     val tenantId: TenantKey,
@@ -30,7 +34,8 @@ data class AcknowledgeGenerationResults(
     val partitions: Set<Int>,
     val acknowledgeUpTo: Long,
 ) : Command<Unit>,
-    RequiresPermission {
+    RequiresPermission,
+    NotAudited {
     override val permission get() = Permission.DOCUMENT_GENERATE
     override val tenantKey get() = tenantId
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/collect/commands/TouchConsumerNode.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/generation/collect/commands/TouchConsumerNode.kt
@@ -4,6 +4,7 @@
 
 package app.epistola.suite.generation.collect.commands
 
+import app.epistola.suite.common.NotAudited
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.generation.collect.domain.Partition
 import app.epistola.suite.generation.collect.domain.PartitionAssignment
@@ -33,13 +34,17 @@ import org.springframework.stereotype.Component
  *     storing the freshly-computed partition list and `last_seen_at = now`.
  *  5. Returns this node's [PartitionAssignment] (the `mine` field of the wire
  *     `_meta` line).
+ *
+ * This is high-frequency transport housekeeping rather than a user/domain action,
+ * so it is excluded from the audit trail via [NotAudited].
  */
 data class TouchConsumerNode(
     val tenantId: TenantKey,
     val consumerId: String,
     val nodeId: String,
 ) : Command<PartitionAssignment>,
-    RequiresPermission {
+    RequiresPermission,
+    NotAudited {
     override val permission get() = Permission.DOCUMENT_GENERATE
     override val tenantKey get() = tenantId
 }


### PR DESCRIPTION
## Description

Excludes consumer transport housekeeping from the audit trail and removes the historical noise:

- marks `TouchConsumerNode` and `AcknowledgeGenerationResults` as `NotAudited`;
- adds a forward Flyway migration that deletes existing success and failure rows for those actions;
- extends marker and RC1-to-head migration coverage;
- updates the audit-log documentation and changelog.

Commands are audited by default. The consumer heartbeat/partition-assignment and acknowledgement-cursor commands were missing the existing high-frequency opt-out marker, so authenticated pings and collection polling continuously created forever-retained audit entries. This change preserves the consumer protocol behavior while keeping transport housekeeping out of the operator audit trail.

## Related Issue(s)

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [ ] Frontend (Editor/TypeScript)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The migration performs a scoped indexed delete. Normal PostgreSQL vacuuming can reuse the freed space; it deliberately avoids an exclusive `VACUUM FULL` or partition rewrite during deployment.

Validation performed:

- `pnpm format:check`
- `./gradlew checkMigrationVersions`
- `./gradlew ktlintCheck unitTest integrationTest`
