### PR TITLE
feat(ui): convert save confirmations to corner notices (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
   suite: the corner-notice subsystem (23 tests), paired with `NoticeModalPlacementUiTest` for
   the top-layer half (hoist, modal stacking, unmount rescue, server-OOB delivery). Runs via
   `pnpm test`, not Gradle — see `docs/testing.md`. (#477)
+- **[user]** feat(ui): **Saves confirm with corner notices instead of page banners.** The
+  feature-toggles, defaults, and site-banner forms now save in place and confirm with a
+  corner notice (previously a full-page redirect showing a green banner), catalog mutations
+  (create, register, release, upgrade, delete) and on-demand backups confirm with notices
+  too, and installing from a catalog reports honestly: success closes the preview dialog
+  with a notice, while a failure now keeps the dialog open with an error notice and a real
+  error status (previously the dialog closed as if it had succeeded). Restore-from-backup
+  and error reports keep their persistent banners deliberately. (#477)
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer
   processes can emit newline-delimited Logstash, ECS, or GELF output through
   `LOGGING_STRUCTURED_FORMAT_CONSOLE`, including tenant context when available and bounded stack

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
@@ -58,15 +58,10 @@ class CatalogHandler {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun list(request: ServerRequest): ServerResponse {
-        val saved = request.param("saved").isPresent
-
-        return ServerResponse.ok().page("catalogs/list") {
-            "pageTitle" to "Catalogs - Epistola"
-            "activeNavSection" to "catalogs"
-            catalogListModel(request)
-            if (saved) "saved" to true
-        }
+    fun list(request: ServerRequest): ServerResponse = ServerResponse.ok().page("catalogs/list") {
+        "pageTitle" to "Catalogs - Epistola"
+        "activeNavSection" to "catalogs"
+        catalogListModel(request)
     }
 
     fun newForm(request: ServerRequest): ServerResponse {
@@ -151,7 +146,8 @@ class CatalogHandler {
             dialogSuccess("catalogs/list", "catalog-list", "/tenants/${tenantId.key}/catalogs") {
                 catalogListModel(request)
             }
-            onNonHtmx { redirect("/tenants/${tenantId.key}/catalogs?saved=true") }
+            successNotice("Catalog created.")
+            onNonHtmx { redirect("/tenants/${tenantId.key}/catalogs") }
         }
     }
 
@@ -212,7 +208,8 @@ class CatalogHandler {
                 dialogSuccess("catalogs/list", "catalog-list", "/tenants/${tenantId.key}/catalogs") {
                     catalogListModel(request)
                 }
-                onNonHtmx { redirect("/tenants/${tenantId.key}/catalogs?saved=true") }
+                successNotice("Catalog registered.")
+                onNonHtmx { redirect("/tenants/${tenantId.key}/catalogs") }
             }
         } catch (e: Exception) {
             logger.warn("Failed to register catalog: ${e.message}", e)
@@ -256,6 +253,7 @@ class CatalogHandler {
                 fragment("catalogs/list", "catalog-list") {
                     catalogListModel(request)
                 }
+                successNotice("Catalog deleted.")
                 onNonHtmx {
                     ServerResponse.status(303)
                         .header("Location", "/tenants/${tenantId.key}/catalogs")
@@ -340,8 +338,9 @@ class CatalogHandler {
                     catalogListModel(request)
                     "oob" to true
                 }
+                successNotice("Catalog released.")
                 onNonHtmx {
-                    redirect("/tenants/${tenantId.key}/catalogs?saved=true")
+                    redirect("/tenants/${tenantId.key}/catalogs")
                 }
             }
         } catch (e: CatalogReleaseVersionException) {
@@ -448,8 +447,9 @@ class CatalogHandler {
                     catalogListModel(request)
                     "oob" to true
                 }
+                successNotice("Catalog upgraded.")
                 onNonHtmx {
-                    redirect("/tenants/${tenantId.key}/catalogs?saved=true")
+                    redirect("/tenants/${tenantId.key}/catalogs")
                 }
             }
         } catch (e: CatalogUpgradeConflictException) {

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
@@ -37,6 +37,7 @@ import app.epistola.suite.catalog.queries.GetCatalogReleaseStatus
 import app.epistola.suite.catalog.queries.ListCatalogsForManagement
 import app.epistola.suite.catalog.queries.PreviewCatalogUpgrade
 import app.epistola.suite.catalog.queries.PreviewInstall
+import app.epistola.suite.htmx.HxSwap
 import app.epistola.suite.htmx.ModelBuilder
 import app.epistola.suite.htmx.executeOrFormError
 import app.epistola.suite.htmx.form
@@ -567,8 +568,10 @@ class CatalogHandler {
             ).execute()
 
             val failed = results.filter { it.status == InstallStatus.FAILED }
-            val message = if (failed.isNotEmpty()) {
-                null to "Failed to install: ${failed.joinToString(", ") { it.slug }}"
+            if (failed.isNotEmpty()) {
+                // Full slugs are in the log; the notice stays one bounded sentence.
+                logger.warn("Install from catalog $catalogKey failed for: ${failed.joinToString(", ") { it.slug }}")
+                installOutcome(request, catalogKey, error = "Failed to install ${failed.size} of ${results.size} resources.")
             } else {
                 val installed = results.count { it.status == InstallStatus.INSTALLED }
                 val updated = results.count { it.status == InstallStatus.UPDATED }
@@ -576,21 +579,20 @@ class CatalogHandler {
                     if (installed > 0) "$installed installed" else null,
                     if (updated > 0) "$updated updated" else null,
                 )
-                "Resources ${parts.joinToString(", ")}." to null
+                val message = if (parts.isEmpty()) "Resources are already up to date." else "Resources ${parts.joinToString(", ")}."
+                installOutcome(request, catalogKey, success = message)
             }
-
-            browseFragment(request, catalogKey, message.first, message.second)
         } catch (e: Exception) {
             logger.warn("Failed to install from catalog: ${e.message}", e)
-            browseFragment(request, catalogKey, errorMessage = e.message ?: "Failed to install resources from catalog.")
+            installOutcome(request, catalogKey, error = "Failed to install resources from catalog.")
         }
     }
 
-    private fun browseFragment(
+    private fun installOutcome(
         request: ServerRequest,
         catalogKey: CatalogKey,
-        successMessage: String? = null,
-        errorMessage: String? = null,
+        success: String? = null,
+        error: String? = null,
     ): ServerResponse {
         val tenantId = request.tenantId()
         val result = BrowseCatalog(tenantKey = tenantId.key, catalogKey = catalogKey).query()
@@ -601,9 +603,12 @@ class CatalogHandler {
                 "tenantId" to tenantId.key
                 "catalog" to result.catalog
             }
-            oob("catalogs/browse", "alert") {
-                if (successMessage != null) "successMessage" to successMessage
-                if (errorMessage != null) "errorMessage" to errorMessage
+            if (success != null) successNotice(success)
+            if (error != null) {
+                // Real error status: close-on-success keeps the preview dialog open.
+                errorNotice(error, statusCode = 422)
+                // Partial installs did land — refresh the rows behind the dialog.
+                reswap(HxSwap.OUTER_HTML)
             }
             trigger("installComplete")
             onNonHtmx {
@@ -613,7 +618,6 @@ class CatalogHandler {
                     "activeNavSection" to "catalogs"
                     "catalog" to result.catalog
                     "resources" to result.resources
-                    if (errorMessage != null) "error" to errorMessage
                 }
             }
         }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/CatalogHandler.kt
@@ -618,6 +618,9 @@ class CatalogHandler {
                     "activeNavSection" to "catalogs"
                     "catalog" to result.catalog
                     "resources" to result.resources
+                    // Notices are HTMX-only; the plain full-page render reports
+                    // an install failure through the page itself.
+                    "error" to error
                 }
             }
         }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DefaultsHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DefaultsHandler.kt
@@ -11,6 +11,7 @@ import app.epistola.suite.common.ids.CodeListId
 import app.epistola.suite.common.ids.CodeListKey
 import app.epistola.suite.common.ids.TenantId
 import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.htmx.htmx
 import app.epistola.suite.htmx.page
 import app.epistola.suite.htmx.tenantId
 import app.epistola.suite.i18n.TenantLocaleResolver
@@ -27,8 +28,8 @@ import org.springframework.web.servlet.function.ServerResponse
 
 /**
  * Per-tenant default values (currently: default locale). Pattern mirrors
- * `FeatureHandler` — a single GET render and a plain form POST that 303s
- * back, no HTMX fragment plumbing.
+ * `FeatureHandler` — the save answers HTMX submits with the re-rendered
+ * locale form plus a corner notice, and 303s back for plain submits.
  *
  * `GetTenant` only requires authentication, so this handler explicitly
  * gates on `TENANT_SETTINGS` before rendering. `UiExceptionFilter` turns
@@ -41,18 +42,12 @@ class DefaultsHandler(
     fun defaults(request: ServerRequest): ServerResponse {
         val tenantId = request.tenantId()
         requirePermission(tenantId.key, Permission.TENANT_SETTINGS)
-        val tenant = GetTenant(tenantId.key).query()
-            ?: return ServerResponse.notFound().build()
-        val entries = listBcp47Entries(tenantId.key)
+        val model = localeModel(tenantId) ?: return ServerResponse.notFound().build()
 
         return ServerResponse.ok().page("defaults") {
+            putAll(model)
             "pageTitle" to "Defaults - Epistola"
-            "tenantId" to tenantId.key
             "activeNavSection" to "defaults"
-            "tenant" to tenant
-            "entries" to entries
-            "effectiveLocale" to localeResolver.resolve(tenant)
-            "applicationDefault" to localeResolver.applicationDefault
             "error" to null
         }
     }
@@ -66,24 +61,41 @@ class DefaultsHandler(
         try {
             SetTenantDefaultLocale(tenantId = tenantId.key, locale = locale).execute()
         } catch (e: InvalidLocaleException) {
-            val tenant = GetTenant(tenantId.key).query()
-                ?: return ServerResponse.notFound().build()
-            val entries = listBcp47Entries(tenantId.key)
-            return ServerResponse.ok().page("defaults") {
-                "pageTitle" to "Defaults - Epistola"
-                "tenantId" to tenantId.key
-                "activeNavSection" to "defaults"
-                "tenant" to tenant
-                "entries" to entries
-                "effectiveLocale" to localeResolver.resolve(tenant)
-                "applicationDefault" to localeResolver.applicationDefault
-                "error" to "Unknown locale '${e.locale}'. Pick a value from the list."
+            val message = "Unknown locale '${e.locale}'. Pick a value from the list."
+            val model = localeModel(tenantId) ?: return ServerResponse.notFound().build()
+            return request.htmx {
+                globalFormError("defaults-locale-error", message)
+                onFullPage {
+                    page(422, "defaults") {
+                        putAll(model)
+                        "pageTitle" to "Defaults - Epistola"
+                        "activeNavSection" to "defaults"
+                        "error" to message
+                    }
+                }
             }
         }
 
-        return ServerResponse.status(303)
-            .header("Location", "/tenants/${tenantId.key.value}/defaults?saved=true")
-            .build()
+        val model = localeModel(tenantId) ?: return ServerResponse.notFound().build()
+        return request.htmx {
+            fragment("defaults", "locale-form") {
+                putAll(model)
+                "error" to null
+            }
+            successNotice("Defaults saved.")
+            onFullPage { redirect("/tenants/${tenantId.key.value}/defaults") }
+        }
+    }
+
+    private fun localeModel(tenantId: TenantId): Map<String, Any?>? {
+        val tenant = GetTenant(tenantId.key).query() ?: return null
+        return mapOf(
+            "tenantId" to tenantId.key,
+            "tenant" to tenant,
+            "entries" to listBcp47Entries(tenantId.key),
+            "effectiveLocale" to localeResolver.resolve(tenant),
+            "applicationDefault" to localeResolver.applicationDefault,
+        )
     }
 
     private fun listBcp47Entries(tenantKey: TenantKey) = ListCodeListEntries(

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/FeatureHandler.kt
@@ -4,9 +4,11 @@
 
 package app.epistola.suite.handlers
 
+import app.epistola.suite.common.ids.TenantId
 import app.epistola.suite.features.KnownFeatures
 import app.epistola.suite.features.commands.SaveFeatureToggle
 import app.epistola.suite.features.queries.GetFeatureToggles
+import app.epistola.suite.htmx.htmx
 import app.epistola.suite.htmx.page
 import app.epistola.suite.htmx.tenantId
 import app.epistola.suite.mediator.execute
@@ -20,24 +22,12 @@ class FeatureHandler {
     // TODO: Add explicit TENANT_SETTINGS permission check before rendering, to show a proper "not authorized" page instead of a mediator 403 error on direct URL access
     fun featureToggles(request: ServerRequest): ServerResponse {
         val tenantId = request.tenantId()
-        val toggles = GetFeatureToggles(tenantId.key).query()
-
-        val features = toggles.map { (key, enabled) ->
-            val md = KnownFeatures.metadataFor(key)
-            mapOf(
-                "key" to key.value,
-                "title" to (md?.title ?: key.value),
-                "enabled" to enabled,
-                "description" to (md?.description ?: ""),
-                "stage" to (md?.stage ?: KnownFeatures.FeatureStage.STABLE),
-            )
-        }
 
         return ServerResponse.ok().page("features") {
             "pageTitle" to "Feature Toggles - Epistola"
             "tenantId" to tenantId.key
             "activeNavSection" to "features"
-            "features" to features
+            "features" to features(tenantId)
         }
     }
 
@@ -53,8 +43,27 @@ class FeatureHandler {
             ).execute()
         }
 
-        return ServerResponse.status(303)
-            .header("Location", "/tenants/${tenantId.key}/features?saved=true")
-            .build()
+        return request.htmx {
+            fragment("features", "toggles-form") {
+                "tenantId" to tenantId.key
+                "features" to features(tenantId)
+            }
+            successNotice("Feature toggle settings saved.")
+            onFullPage { redirect("/tenants/${tenantId.key}/features") }
+        }
+    }
+
+    private fun features(tenantId: TenantId): List<Map<String, Any>> {
+        val toggles = GetFeatureToggles(tenantId.key).query()
+        return toggles.map { (key, enabled) ->
+            val md = KnownFeatures.metadataFor(key)
+            mapOf(
+                "key" to key.value,
+                "title" to (md?.title ?: key.value),
+                "enabled" to enabled,
+                "description" to (md?.description ?: ""),
+                "stage" to (md?.stage ?: KnownFeatures.FeatureStage.STABLE),
+            )
+        }
     }
 }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/SiteBannerHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/SiteBannerHandler.kt
@@ -8,6 +8,7 @@ import app.epistola.suite.banner.SiteBannerSeverity
 import app.epistola.suite.banner.commands.ClearSiteBanner
 import app.epistola.suite.banner.commands.SetSiteBanner
 import app.epistola.suite.banner.queries.GetSiteBanner
+import app.epistola.suite.htmx.htmx
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
 import org.springframework.stereotype.Component
@@ -36,9 +37,11 @@ class SiteBannerHandler {
     }
 
     fun save(request: ServerRequest): ServerResponse {
-        when (request.param("action").orElse("save")) {
-            "clear" -> ClearSiteBanner().execute()
-            else -> SetSiteBanner(
+        val cleared = request.param("action").orElse("save") == "clear"
+        if (cleared) {
+            ClearSiteBanner().execute()
+        } else {
+            SetSiteBanner(
                 message = request.param("message").orElse(""),
                 severity = request.param("severity")
                     .map { runCatching { SiteBannerSeverity.valueOf(it) }.getOrDefault(SiteBannerSeverity.WARNING) }
@@ -46,8 +49,13 @@ class SiteBannerHandler {
                 enabled = request.param("enabled").isPresent,
             ).execute()
         }
-        return ServerResponse.status(303)
-            .header("Location", "/platform/banner?saved=true")
-            .build()
+        return request.htmx {
+            fragment("platform/banner", "banner-form") {
+                "banner" to GetSiteBanner().query()
+                "severities" to SiteBannerSeverity.entries
+            }
+            successNotice(if (cleared) "Site banner cleared." else "Site banner saved.")
+            onFullPage { redirect("/platform/banner") }
+        }
     }
 }

--- a/apps/epistola/src/main/resources/templates/catalogs/browse.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/browse.html
@@ -12,6 +12,9 @@
 
         <p th:if="${catalog.sourceUrl}" class="text-muted text-sm" style="margin-bottom: var(--ep-space-4);" th:text="${catalog.sourceUrl}"></p>
 
+        <!-- Plain (no-JS) install feedback; the HTMX path reports via notices. -->
+        <div class="alert alert-danger" th:if="${error != null}" th:text="${error}"></div>
+
 
         <div class="card" th:if="${!resources.isEmpty()}">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">

--- a/apps/epistola/src/main/resources/templates/catalogs/browse.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/browse.html
@@ -12,7 +12,6 @@
 
         <p th:if="${catalog.sourceUrl}" class="text-muted text-sm" style="margin-bottom: var(--ep-space-4);" th:text="${catalog.sourceUrl}"></p>
 
-        <div id="catalog-alert"></div>
 
         <div class="card" th:if="${!resources.isEmpty()}">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
@@ -265,12 +264,5 @@
         </div>
     </th:block>
 
-    <!-- OOB alert fragment -->
-    <th:block th:fragment="alert">
-        <div id="catalog-alert" hx-swap-oob="true">
-            <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}" data-testid="alert-success"></div>
-            <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
-        </div>
-    </th:block>
 </body>
 </html>

--- a/apps/epistola/src/main/resources/templates/catalogs/list.html
+++ b/apps/epistola/src/main/resources/templates/catalogs/list.html
@@ -7,9 +7,6 @@
             actions=~{::catalog-list-actions}
         )}"></div>
 
-        <div class="alert alert-success" th:if="${saved}" data-testid="alert-success">
-            Catalog settings updated successfully.
-        </div>
         <div class="alert alert-danger" th:if="${error != null}" th:text="${error}"></div>
 
         <!-- Single, always-present swap region for every list mutation

--- a/apps/epistola/src/main/resources/templates/defaults.html
+++ b/apps/epistola/src/main/resources/templates/defaults.html
@@ -7,10 +7,6 @@
             pageDescription='Manage tenant-wide default settings.'
         )}"></div>
 
-        <div class="alert alert-success" th:if="${param.saved}">
-            Defaults saved successfully.
-        </div>
-
         <div class="card">
             <div class="card-header">
                 <h2>Default locale</h2>
@@ -21,7 +17,13 @@
                 </p>
             </div>
             <div class="card-content">
-                <form th:action="@{/tenants/{tenantId}/defaults/locale(tenantId=${tenantId})}" method="post">
+                <!-- hx-disinherit: without it the boosted Cancel link inherits the
+                     form's target/swap and swaps its page into the form. -->
+                <form th:fragment="locale-form"
+                      th:action="@{/tenants/{tenantId}/defaults/locale(tenantId=${tenantId})}" method="post"
+                      th:hx-post="@{/tenants/{tenantId}/defaults/locale(tenantId=${tenantId})}"
+                      hx-target="this" hx-swap="outerHTML"
+                      hx-disinherit="hx-target hx-swap">
                     <div th:replace="~{epistola-web/form-error :: form-error(id='defaults-locale-error')}"></div>
                     <p class="form-hint">
                         <strong>Effective locale:</strong>

--- a/apps/epistola/src/main/resources/templates/features.html
+++ b/apps/epistola/src/main/resources/templates/features.html
@@ -7,13 +7,15 @@
             pageDescription='Enable or disable tenant features.'
         )}"></div>
 
-        <div class="alert alert-success" th:if="${param.saved}" data-testid="alert-success">
-            Feature toggle settings saved successfully.
-        </div>
-
         <div class="card">
             <div class="card-content">
-                <form th:action="@{/tenants/{tenantId}/features(tenantId=${tenantId})}" method="post">
+                <!-- hx-disinherit: without it the boosted Cancel link inherits the
+                     form's target/swap and swaps its page into the form. -->
+                <form th:fragment="toggles-form"
+                      th:action="@{/tenants/{tenantId}/features(tenantId=${tenantId})}" method="post"
+                      th:hx-post="@{/tenants/{tenantId}/features(tenantId=${tenantId})}"
+                      hx-target="this" hx-swap="outerHTML"
+                      hx-disinherit="hx-target hx-swap">
                     <div th:replace="~{epistola-web/form-error :: form-error(id='feature-toggles-error')}"></div>
 
                     <div class="feature-toggle-item" th:each="feature : ${features}" data-testid="feature-toggle" th:data-feature-key="${feature['key']}">

--- a/apps/epistola/src/main/resources/templates/platform/banner.html
+++ b/apps/epistola/src/main/resources/templates/platform/banner.html
@@ -18,12 +18,11 @@
             <a th:href="@{/}" class="ep-btn ep-btn-ghost ep-btn-sm" data-testid="banner-back">&larr; Back to tenants</a>
         </p>
 
-        <div class="alert alert-success" th:if="${param.saved}" data-testid="alert-success">
-            Site banner saved.
-        </div>
-
         <section class="ep-panel form-section">
-            <form th:action="@{/platform/banner}" method="post">
+            <form th:fragment="banner-form"
+                  th:action="@{/platform/banner}" method="post"
+                  hx-post="/platform/banner"
+                  hx-target="this" hx-swap="outerHTML">
                 <div th:replace="~{epistola-web/form-error :: form-error(id='site-banner-error')}"></div>
 
                 <div class="form-group">
@@ -66,5 +65,12 @@
     </main>
 
     <th:block th:replace="~{fragments/footer :: footer}" />
+
+    <!-- Corner-notice region + client template, same pair as layout/shell:
+         this page renders its own <body>, so it hosts them itself. -->
+    <div id="notices" class="notice-region" aria-live="polite"></div>
+    <template id="notice-template">
+        <th:block th:replace="~{epistola-web/notice :: notice('error', null, '')}" />
+    </template>
 </body>
 </html>

--- a/apps/epistola/src/main/resources/templates/platform/banner.html
+++ b/apps/epistola/src/main/resources/templates/platform/banner.html
@@ -67,10 +67,11 @@
     <th:block th:replace="~{fragments/footer :: footer}" />
 
     <!-- Corner-notice region + client template, same pair as layout/shell:
-         this page renders its own <body>, so it hosts them itself. -->
+         this page renders its own <body>, so it hosts them itself. Title ''
+         (not null) so the clone carries an empty .alert-title slot. -->
     <div id="notices" class="notice-region" aria-live="polite"></div>
     <template id="notice-template">
-        <th:block th:replace="~{epistola-web/notice :: notice('error', null, '')}" />
+        <th:block th:replace="~{epistola-web/notice :: notice('error', '', '')}" />
     </template>
 </body>
 </html>

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/backups/BackupsHubUnavailableTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/backups/BackupsHubUnavailableTest.kt
@@ -97,6 +97,15 @@ class BackupsHubUnavailableTest : BaseIntegrationTest() {
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.headers.getFirst("HX-Redirect")).contains("error=hub-unavailable")
+
+        // A plain (no-JS) submit must get a real 303, not a blank 200 with an
+        // HX-Redirect header the browser ignores. The test client follows the
+        // redirect, so the response is the error-banner landing.
+        val plainBody = HttpEntity(LinkedMultiValueMap<String, String>(), plainForm())
+        val plain = restTemplate.postForEntity("/tenants/${tenant.id.value}/backups", plainBody, String::class.java)
+        assertThat(plain.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(plain.body!!).contains("hub")
+        assertThat(plain.headers.getFirst("HX-Redirect")).isNull()
     }
 
     @Test
@@ -114,6 +123,9 @@ class BackupsHubUnavailableTest : BaseIntegrationTest() {
         contentType = MediaType.APPLICATION_FORM_URLENCODED
         add("HX-Request", "true")
     }
+
+    /** A plain browser form POST — no HX-Request, i.e. the no-JS fallback path. */
+    private fun plainForm() = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
 
     /** A [TenantBackupStore] whose hub-backed reads throw a configurable [HubException] per test. */
     class UnavailableBackupStore : TenantBackupStore {

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/backups/BackupsUpgradingHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/backups/BackupsUpgradingHandlerTest.kt
@@ -144,15 +144,18 @@ class BackupsUpgradingHandlerTest : BaseIntegrationTest() {
         enableSupport(tenant.id)
         val body = HttpEntity(LinkedMultiValueMap<String, String>(), htmxForm())
 
+        // The htmx save answers in place: the backup-list fragment plus an OOB
+        // corner notice — no redirect.
         val first = restTemplate.postForEntity("/tenants/${tenant.id.value}/backups", body, String::class.java)
         assertThat(first.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(first.headers.getFirst("HX-Redirect")).contains("saved=backup")
-        assertThat(first.headers.getFirst("HX-Redirect")).doesNotContain("unchanged")
+        assertThat(first.body!!).contains("id=\"backup-list\"")
+        assertThat(first.body!!).contains("hx-swap-oob=\"afterbegin:#notices\"")
+        assertThat(first.body!!).contains("Backup completed.")
 
         // Same catalogs ⇒ same fingerprint ⇒ dedup, no new snapshot.
         val second = restTemplate.postForEntity("/tenants/${tenant.id.value}/backups", body, String::class.java)
         assertThat(second.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(second.headers.getFirst("HX-Redirect")).contains("saved=backup-unchanged")
+        assertThat(second.body!!).contains("No changes since the last backup.")
     }
 
     private fun htmxForm() = HttpHeaders().apply {

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogInstallHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogInstallHandlerTest.kt
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.catalog
+
+import app.epistola.suite.BaseIntegrationTest
+import app.epistola.suite.catalog.commands.CreateCatalog
+import app.epistola.suite.catalog.commands.RegisterCatalog
+import app.epistola.suite.common.ids.CatalogKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.tenants.Tenant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+
+private const val DEMO_CATALOG_URL = "classpath:epistola/catalogs/demo/catalog.json"
+
+/**
+ * Handler-level coverage for the browse-page install endpoint: a successful
+ * install re-renders the resource rows with an OOB success notice (200 → the
+ * preview dialog closes), and a failed install carries a real error status
+ * with an error notice while STILL refreshing the rows (partial installs did
+ * land) — the 422 keeps the preview dialog open via close-on-success.
+ */
+class CatalogInstallHandlerTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    private fun htmxForm() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_FORM_URLENCODED
+        add("HX-Request", "true")
+    }
+
+    private fun subscribedTenant(name: String): Tenant = fixtureTenant(name).also { t ->
+        withMediator {
+            RegisterCatalog(tenantKey = t.id, sourceUrl = DEMO_CATALOG_URL, authType = AuthType.NONE).execute()
+        }
+    }
+
+    private fun fixtureTenant(name: String): Tenant = createTenant(name)
+
+    @Test
+    fun `htmx install success returns the rows with an OOB success notice`() {
+        val tenant = subscribedTenant("Install Success Tenant")
+
+        val response = restTemplate.postForEntity(
+            "/tenants/${tenant.id.value}/catalogs/epistola-demo/install",
+            HttpEntity(LinkedMultiValueMap<String, String>(), htmxForm()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val body = response.body!!
+        assertThat(body).contains("id=\"resource-table\"")
+        assertThat(body).contains("hx-swap-oob=\"afterbegin:#notices\"")
+        assertThat(body).contains("installed")
+        assertThat(response.headers.getFirst("HX-Trigger")).contains("installComplete")
+    }
+
+    @Test
+    fun `htmx install failure carries 422 with an error notice and still refreshes the rows`() {
+        val tenant = fixtureTenant("Install Failure Tenant")
+        withMediator {
+            CreateCatalog(tenantKey = tenant.id, id = CatalogKey.of("authored-cat"), name = "Authored").execute()
+        }
+
+        // Installing from an AUTHORED catalog is rejected by the command — the
+        // exception path must answer 422 + error notice, not a silent 200.
+        val response = restTemplate.postForEntity(
+            "/tenants/${tenant.id.value}/catalogs/authored-cat/install",
+            HttpEntity(LinkedMultiValueMap<String, String>(), htmxForm()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT)
+        assertThat(response.headers.getFirst("HX-Reswap")).isEqualTo("outerHTML")
+        val body = response.body!!
+        assertThat(body).contains("Failed to install")
+        assertThat(body).contains("id=\"resource-table\"")
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogListHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogListHandlerTest.kt
@@ -158,6 +158,7 @@ class CatalogListHandlerTest : BaseIntegrationTest() {
             assertThat(body).contains("id=\"catalog-list\"")
             assertThat(body).contains("hx-swap-oob")
             assertThat(body).contains("My Catalog")
+            assertThat(body).contains("Catalog created.")
             // Persistence verified through the mediator.
             val persisted = withMediator { ListCatalogs(tenantKey = t.id).query() }
             assertThat(persisted.map { it.name }).contains("My Catalog")
@@ -331,6 +332,7 @@ class CatalogListHandlerTest : BaseIntegrationTest() {
             assertThat(body).contains("id=\"catalog-list\"")
             assertThat(body).contains("hx-swap-oob")
             assertThat(body).contains("Epistola Demo Catalog")
+            assertThat(body).contains("Catalog registered.")
             // Persistence verified through the mediator.
             val persisted = withMediator { ListCatalogs(tenantKey = t.id).query() }
             assertThat(persisted.map { it.name }).contains("Epistola Demo Catalog")
@@ -410,6 +412,7 @@ class CatalogListHandlerTest : BaseIntegrationTest() {
             assertThat(body).contains("<table").contains("</table>")
             assertThat(body).contains("Keep Cat")
             assertThat(body).doesNotContain("Gone Cat")
+            assertThat(body).contains("Catalog deleted.")
         }
     }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogReleaseHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogReleaseHandlerTest.kt
@@ -73,6 +73,7 @@ class CatalogReleaseHandlerTest : BaseIntegrationTest() {
         then {
             val response = result<org.springframework.http.ResponseEntity<String>>()
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(response.body!!).contains("Catalog released.")
             val catalog = withMediator { GetCatalog(testTenant.id, CatalogKey.of("rel-cat")).query() }
             assertThat(catalog!!.releasedVersion).isEqualTo("1.0.0")
         }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogUpgradeHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogUpgradeHandlerTest.kt
@@ -100,6 +100,7 @@ class CatalogUpgradeHandlerTest : BaseIntegrationTest() {
             val response = result<org.springframework.http.ResponseEntity<String>>()
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(response.body).doesNotContain("alert alert-danger")
+            assertThat(response.body!!).contains("Catalog upgraded.")
         }
     }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/DefaultsHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/DefaultsHandlerTest.kt
@@ -20,6 +20,12 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.util.LinkedMultiValueMap
 
+/**
+ * The Defaults page: page render, and the locale save flow — an HTMX submit
+ * re-renders the locale form with an OOB success notice, a plain submit falls
+ * back to a PRG redirect, and an unknown locale reports into the form's global
+ * error slot without persisting.
+ */
 class DefaultsHandlerTest : BaseIntegrationTest() {
 
     @Autowired
@@ -42,35 +48,77 @@ class DefaultsHandlerTest : BaseIntegrationTest() {
     }
 
     @Test
-    fun `POST a valid locale persists the override and the saved page is shown`() {
-        val tenant = createTenant("Defaults Update OK")
+    fun `htmx save re-renders the locale form with an OOB success notice`() {
+        val tenant = createTenant("Defaults Update Htmx")
 
-        // TestRestTemplate follows the 303 by default → we land on the GET page
-        // with ?saved=true so the success banner is rendered.
         val response = postForm(
             "/tenants/${tenant.id.value}/defaults/locale",
             mapOf("locale" to "nl-NL"),
+            htmxForm(),
         )
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).contains("Defaults saved successfully")
+        val body = response.body!!
+        // Primary swap: the form fragment (with the new effective locale), not a full page.
+        assertThat(body).contains("Effective locale")
+        assertThat(body).contains("nl-NL")
+        assertThat(body).doesNotContain("<title")
+        // The success notice rides the same response as an OOB swap into #notices.
+        assertThat(body).contains("hx-swap-oob=\"afterbegin:#notices\"")
+        assertThat(body).contains("Defaults saved.")
         val reloaded = withMediator { GetTenant(tenant.id).query() }
         assertThat(reloaded?.defaultLocale).isEqualTo("nl-NL")
     }
 
     @Test
-    fun `POST an unknown locale re-renders the page with an inline error and leaves the row untouched`() {
-        val tenant = createTenant("Defaults Update Bogus")
+    fun `plain save persists the override and falls back to a PRG redirect`() {
+        val tenant = createTenant("Defaults Update OK")
 
-        // Failure path does NOT redirect — the handler re-renders the page
-        // directly with the `error` model attribute set, so the user keeps the
-        // tab they were on. The row stays untouched.
+        // The test client follows the 303 (POST becomes GET), so the response is
+        // the defaults page again — no notice on the plain path.
         val response = postForm(
             "/tenants/${tenant.id.value}/defaults/locale",
-            mapOf("locale" to "xx-ZZ"),
+            mapOf("locale" to "nl-NL"),
+            plainForm(),
         )
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).contains("Default locale")
+        assertThat(response.body).doesNotContain("Defaults saved.")
+        val reloaded = withMediator { GetTenant(tenant.id).query() }
+        assertThat(reloaded?.defaultLocale).isEqualTo("nl-NL")
+    }
+
+    @Test
+    fun `htmx save of an unknown locale fills the form error slot and leaves the row untouched`() {
+        val tenant = createTenant("Defaults Update Bogus Htmx")
+
+        val response = postForm(
+            "/tenants/${tenant.id.value}/defaults/locale",
+            mapOf("locale" to "xx-ZZ"),
+            htmxForm(),
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT)
+        assertThat(response.headers.getFirst("HX-Reswap")).isEqualTo("none")
+        val body = response.body!!
+        assertThat(body).contains("id=\"defaults-locale-error\"")
+        assertThat(body).contains("Unknown locale")
+        val reloaded = withMediator { GetTenant(tenant.id).query() }
+        assertThat(reloaded?.defaultLocale).isNull()
+    }
+
+    @Test
+    fun `plain save of an unknown locale re-renders the page with an inline error`() {
+        val tenant = createTenant("Defaults Update Bogus")
+
+        val response = postForm(
+            "/tenants/${tenant.id.value}/defaults/locale",
+            mapOf("locale" to "xx-ZZ"),
+            plainForm(),
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT)
         assertThat(response.body).contains("Unknown locale")
         val reloaded = withMediator { GetTenant(tenant.id).query() }
         assertThat(reloaded?.defaultLocale).isNull()
@@ -86,6 +134,7 @@ class DefaultsHandlerTest : BaseIntegrationTest() {
         val response = postForm(
             "/tenants/${tenant.id.value}/defaults/locale",
             mapOf("locale" to ""),
+            plainForm(),
         )
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
@@ -93,8 +142,17 @@ class DefaultsHandlerTest : BaseIntegrationTest() {
         assertThat(reloaded?.defaultLocale).isNull()
     }
 
-    private fun postForm(url: String, form: Map<String, String>): ResponseEntity<String> {
-        val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
+    private fun htmxForm() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_FORM_URLENCODED
+        add("HX-Request", "true")
+    }
+
+    /** A plain browser form POST — no HX-Request, i.e. the no-JS fallback path. */
+    private fun plainForm() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_FORM_URLENCODED
+    }
+
+    private fun postForm(url: String, form: Map<String, String>, headers: HttpHeaders): ResponseEntity<String> {
         val body = LinkedMultiValueMap<String, String>().apply {
             form.forEach { (k, v) -> add(k, v) }
         }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/FeatureTogglePageHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/FeatureTogglePageHtmxTest.kt
@@ -9,16 +9,31 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
 
 /**
- * Verifies the admin Features page renders feature display metadata: the human title (not the raw
- * key) and the maturity badge for non-stable features.
+ * Verifies the admin Features page: feature display metadata (human title, maturity badge) and
+ * the save flow — an HTMX submit re-renders the toggles form with an OOB success notice, a plain
+ * submit falls back to a PRG redirect.
  */
 class FeatureTogglePageHtmxTest : BaseIntegrationTest() {
 
     @Autowired
     private lateinit var restTemplate: TestRestTemplate
+
+    private fun htmxForm() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_FORM_URLENCODED
+        add("HX-Request", "true")
+    }
+
+    /** A plain browser form POST — no HX-Request, i.e. the no-JS fallback path. */
+    private fun plainForm() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_FORM_URLENCODED
+    }
 
     @Test
     fun `features page shows titles and maturity badges`() {
@@ -38,5 +53,43 @@ class FeatureTogglePageHtmxTest : BaseIntegrationTest() {
         assertThat(body).contains("badge badge-alpha")
         assertThat(body).contains(">Alpha<")
         assertThat(body).contains("name=\"ai-chat\"")
+    }
+
+    @Test
+    fun `htmx save re-renders the toggles form with an OOB success notice`() {
+        val tenant = createTenant("Features Save Htmx")
+        val payload = LinkedMultiValueMap<String, String>().apply { add("support-backups", "on") }
+
+        val response = restTemplate.postForEntity(
+            "/tenants/${tenant.id.value}/features",
+            HttpEntity(payload, htmxForm()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val body = response.body!!
+        // Primary swap: the form fragment, not a full page.
+        assertThat(body).contains("name=\"support-backups\"")
+        assertThat(body).doesNotContain("<title")
+        // The success notice rides the same response as an OOB swap into #notices.
+        assertThat(body).contains("hx-swap-oob=\"afterbegin:#notices\"")
+        assertThat(body).contains("Feature toggle settings saved.")
+    }
+
+    @Test
+    fun `plain save falls back to a PRG redirect`() {
+        val tenant = createTenant("Features Save Plain")
+
+        // The test client follows the 303 (POST becomes GET), so the response is
+        // the features page again — no notice on the plain path.
+        val response = restTemplate.postForEntity(
+            "/tenants/${tenant.id.value}/features",
+            HttpEntity(LinkedMultiValueMap<String, String>(), plainForm()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body!!).contains("Feature Toggles")
+        assertThat(response.body!!).doesNotContain("Feature toggle settings saved.")
     }
 }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/SiteBannerHandlerHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/SiteBannerHandlerHtmxTest.kt
@@ -29,15 +29,27 @@ class SiteBannerHandlerHtmxTest : BaseIntegrationTest() {
     @Autowired
     private lateinit var restTemplate: TestRestTemplate
 
-    private fun form() = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
+    private fun htmxForm() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_FORM_URLENCODED
+        add("HX-Request", "true")
+    }
+
+    /** A plain browser form POST — no HX-Request, i.e. the no-JS fallback path. */
+    private fun plainForm() = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
+
+    private fun payload(message: String, severity: String, enabled: Boolean, action: String = "save") = LinkedMultiValueMap<String, String>().apply {
+        add("action", action)
+        add("message", message)
+        add("severity", severity)
+        if (enabled) add("enabled", "on")
+    }
 
     private fun save(message: String, severity: String, enabled: Boolean, action: String = "save") {
-        val payload = LinkedMultiValueMap<String, String>()
-        payload.add("action", action)
-        payload.add("message", message)
-        payload.add("severity", severity)
-        if (enabled) payload.add("enabled", "on")
-        val response = restTemplate.postForEntity("/platform/banner", HttpEntity(payload, form()), String::class.java)
+        val response = restTemplate.postForEntity(
+            "/platform/banner",
+            HttpEntity(payload(message, severity, enabled, action), plainForm()),
+            String::class.java,
+        )
         // 303 redirect (whether or not the client follows it) — never an error.
         assertThat(response.statusCode.value()).isLessThan(400)
     }
@@ -64,6 +76,46 @@ class SiteBannerHandlerHtmxTest : BaseIntegrationTest() {
         assertThat(body).contains("data-site-banner")
         assertThat(body).contains("alert-warning")
         assertThat(body).contains("Scheduled maintenance tonight")
+    }
+
+    @Test
+    fun `htmx save re-renders the banner form with an OOB success notice`() {
+        try {
+            val response = restTemplate.postForEntity(
+                "/platform/banner",
+                HttpEntity(payload("Maintenance window tonight", "WARNING", enabled = true), htmxForm()),
+                String::class.java,
+            )
+
+            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+            val body = response.body!!
+            // Primary swap: the form fragment (showing the saved state incl. the
+            // now-visible Clear button), not a full page.
+            assertThat(body).contains("Maintenance window tonight")
+            assertThat(body).contains("Clear banner")
+            assertThat(body).doesNotContain("<title")
+            // The success notice rides the same response as an OOB swap into #notices.
+            assertThat(body).contains("hx-swap-oob=\"afterbegin:#notices\"")
+            assertThat(body).contains("Site banner saved.")
+        } finally {
+            save("", "INFO", enabled = false, action = "clear")
+        }
+    }
+
+    @Test
+    fun `htmx clear re-renders the form without the clear button and confirms it`() {
+        save("To be cleared", "INFO", enabled = true)
+
+        val response = restTemplate.postForEntity(
+            "/platform/banner",
+            HttpEntity(payload("", "INFO", enabled = false, action = "clear"), htmxForm()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        val body = response.body!!
+        assertThat(body).doesNotContain("Clear banner")
+        assertThat(body).contains("Site banner cleared.")
     }
 
     @Test

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/BackupsUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/BackupsUiTest.kt
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.features.KnownFeatures
+import app.epistola.suite.features.commands.SaveFeatureToggle
+import app.epistola.suite.mediator.execute
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Browser coverage for the Backups page's "Back up now" flow: the hx-post form
+ * in the page-header actions swaps the #backup-list region elsewhere on the
+ * page (an out-of-form target, unlike the self-swapping settings forms) and
+ * the corner notice rides OOB — first run "Backup completed.", unchanged
+ * re-run the dedup message.
+ */
+class BackupsUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `back up now swaps the list in place and shows the corner notice`() {
+        val tenant = createTenant("Backups UI")
+        withMediator {
+            SaveFeatureToggle(tenant.id, KnownFeatures.SUPPORT_BACKUPS, enabled = true).execute()
+        }
+
+        gotoAndReady("/tenants/${tenant.id.value}/backups")
+        page.htmxSettle()
+
+        page.locator("button:has-text('Back up now')").click()
+        page.htmxSettle()
+
+        assertThat(page.locator("#notices .notice-message")).hasText("Backup completed.")
+        // The swapped-in region shows the fresh backup instead of the empty state.
+        assertThat(page.locator("#backup-list .ep-badge:has-text('Latest')")).isVisible()
+
+        // Unchanged re-run: the dedup message replaces the first notice on top.
+        page.locator("button:has-text('Back up now')").click()
+        page.htmxSettle()
+        assertThat(page.locator("#notices .notice-message").first())
+            .hasText("No changes since the last backup.")
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/CatalogInstallUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/CatalogInstallUiTest.kt
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.catalog.AuthType
+import app.epistola.suite.catalog.commands.RegisterCatalog
+import app.epistola.suite.mediator.execute
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Browser coverage for the browse-page install flow: the confirm submit's
+ * success response closes the preview dialog (close-on-success sees the 200),
+ * refreshes the resource rows, and shows the corner success notice — the OOB
+ * chain the handler test can only assert as response text.
+ */
+class CatalogInstallUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `installing from the preview dialog closes it and shows the corner notice`() {
+        val tenant = createTenant("Catalog Install UI")
+        withMediator {
+            RegisterCatalog(
+                tenantKey = tenant.id,
+                sourceUrl = "classpath:epistola/catalogs/demo/catalog.json",
+                authType = AuthType.NONE,
+            ).execute()
+        }
+
+        gotoAndReady("/tenants/${tenant.id.value}/catalogs/epistola-demo/browse")
+        page.htmxSettle()
+
+        val dialog = page.openDialogByTrigger(
+            page.locator("button:has-text('Install All')"),
+            "#install-preview-dialog",
+        )
+        dialog.locator("button[type='submit']").click()
+        page.htmxSettle()
+
+        assertThat(page.locator("dialog[open]#install-preview-dialog")).hasCount(0)
+        assertThat(page.locator("#notices .notice-message")).containsText("installed")
+        assertThat(page.locator("#resource-table")).containsText("Installed")
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/CatalogNoticeUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/CatalogNoticeUiTest.kt
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Browser coverage for the catalog-mutation corner notices: the success notice
+ * arrives as an OOB swap on the SAME response that closes the modal dialog
+ * (HX-Trigger closeDialog + HX-Reswap none), so this pins the whole chain —
+ * OOB processed despite the none-swap, notice surviving the dialog-close
+ * region restore, and the mount (timer) applying. Create stands in for all
+ * four mutation flows; the mechanics are shared.
+ */
+class CatalogNoticeUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `creating a catalog closes the dialog and shows the corner notice`() {
+        val tenant = createTenant("Catalog Notice UI")
+
+        gotoAndReady("/tenants/${tenant.id}/catalogs")
+        page.htmxSettle()
+
+        val dialog = page.openDialogByTrigger(
+            page.locator("[data-testid='catalog-create-open']"),
+            "#create-catalog-dialog",
+        )
+        dialog.locator("input[name='slug']").fill("notice-ui")
+        dialog.locator("input[name='name']").fill("Notice UI Catalog")
+        dialog.locator("button[type='submit']").click()
+        page.htmxSettle()
+
+        assertThat(page.locator("dialog[open]#create-catalog-dialog")).hasCount(0)
+        assertThat(page.locator("#notices .notice-message")).hasText("Catalog created.")
+        assertThat(page.locator("#catalog-list")).containsText("Notice UI Catalog")
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DefaultsUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DefaultsUiTest.kt
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.tenants.Tenant
+import app.epistola.suite.tenants.commands.CreateTenant
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+
+/**
+ * Browser coverage for the defaults (locale) form — same guards as
+ * [FeatureTogglesUiTest]: the hx-post form swap + OOB corner notice, and the
+ * htmx inheritance trap (the boosted Cancel link must navigate, not swap its
+ * page into the form — hence hx-disinherit on the form).
+ */
+class DefaultsUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `saving swaps the form in place and shows the corner notice`() {
+        val tenant = createUiTenant()
+
+        gotoAndReady("/tenants/${tenant.id}/defaults")
+        page.locator("#locale").selectOption("nl-NL")
+        page.locator("button:has-text('Save')").click()
+        page.htmxSettle()
+
+        assertThat(page.locator("#notices .notice-message")).hasText("Defaults saved.")
+        // Still the defaults page; the swapped-in form shows the new effective locale.
+        assertThat(page.locator("[data-testid=page-title]")).hasText("Defaults")
+        assertThat(page.locator("form .form-hint")).containsText("nl-NL")
+    }
+
+    @Test
+    fun `cancel navigates away instead of swapping its page into the form`() {
+        val tenant = createUiTenant()
+
+        gotoAndReady("/tenants/${tenant.id}/defaults")
+        page.locator("a:has-text('Cancel')").click()
+
+        assertThat(page).hasURL(Pattern.compile(".*/tenants/${tenant.id}$"))
+        // The regression left the defaults header standing with the tenant page
+        // swapped inside the form; a real navigation replaces the title.
+        assertThat(page.locator("[data-testid=page-title]")).not().hasText("Defaults")
+    }
+
+    private fun createUiTenant(): Tenant = withMediator {
+        CreateTenant(TenantKey.of("test-dfui-${System.nanoTime()}"), "Defaults UI Test").execute()
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/FeatureTogglesUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/FeatureTogglesUiTest.kt
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.tenants.Tenant
+import app.epistola.suite.tenants.commands.CreateTenant
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+
+/**
+ * Browser coverage for the feature-toggles form, which is browser-only logic on
+ * both sides: the hx-post form swap + OOB corner notice, and — the regression
+ * this guards — htmx attribute inheritance. The form's `hx-target="this"` /
+ * `hx-swap="outerHTML"` are inherited by the boosted Cancel link inside it;
+ * without `hx-disinherit` the link's page swaps INTO the form instead of
+ * navigating (caught live 2026-08-09).
+ */
+class FeatureTogglesUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `saving swaps the form in place and shows the corner notice`() {
+        val tenant = createUiTenant()
+
+        gotoAndReady("/tenants/${tenant.id}/features")
+        page.locator("button:has-text('Save Settings')").click()
+        page.htmxSettle()
+
+        assertThat(page.locator("#notices .notice-message")).hasText("Feature toggle settings saved.")
+        // Still the features page, form intact after the outerHTML swap.
+        assertThat(page.locator("[data-testid=page-title]")).hasText("Feature Toggles")
+        assertThat(page.locator("button:has-text('Save Settings')")).isVisible()
+    }
+
+    @Test
+    fun `cancel navigates away instead of swapping its page into the form`() {
+        val tenant = createUiTenant()
+
+        gotoAndReady("/tenants/${tenant.id}/features")
+        page.locator("a:has-text('Cancel')").click()
+
+        assertThat(page).hasURL(Pattern.compile(".*/tenants/${tenant.id}$"))
+        // The regression left the features header standing with the tenant page
+        // swapped inside the form; a real navigation replaces the title.
+        assertThat(page.locator("[data-testid=page-title]")).not().hasText("Feature Toggles")
+    }
+
+    private fun createUiTenant(): Tenant = withMediator {
+        CreateTenant(TenantKey.of("test-ftui-${System.nanoTime()}"), "Feature Toggles UI Test").execute()
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/SiteBannerAdminUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/SiteBannerAdminUiTest.kt
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.banner.commands.ClearSiteBanner
+import app.epistola.suite.mediator.execute
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Browser coverage for the site-banner admin form on `/platform/banner` — a
+ * standalone page (no layout/shell), so this also proves the corner-notice
+ * region the page hosts itself works outside the shell: the hx-post save swaps
+ * the form in place and the OOB success notice lands and renders.
+ */
+class SiteBannerAdminUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `saving swaps the form in place and shows the corner notice`() {
+        try {
+            gotoAndReady("/platform/banner")
+            page.locator("#message").fill("Scheduled maintenance tonight")
+            page.locator("button[value='save']").click()
+            page.htmxSettle()
+
+            assertThat(page.locator("#notices .notice-message")).hasText("Site banner saved.")
+            // The swapped-in form reflects the saved state: Clear button appeared.
+            assertThat(page.locator("button[value='clear']")).isVisible()
+            assertThat(page.locator("#message")).hasValue("Scheduled maintenance tonight")
+        } finally {
+            withMediator { ClearSiteBanner().execute() }
+        }
+    }
+}

--- a/docs/data-testid-reference.md
+++ b/docs/data-testid-reference.md
@@ -23,7 +23,7 @@ for that consumer.
 | `confirm-dialog-confirm` | Destructive confirmation button, built dynamically by `window.openConfirmDialog` in `fragments/htmx.html` | Every delete flow in the app (tenant, theme, template, attribute, environment, API key, catalog, variant, font, stencil, asset, code-list) |
 | `search-input`           | `<input name="q">` inside `fragments/search.html`                                                         | All pages that use the shared search fragment: themes, templates, environments, stencils, fonts, attributes, code-lists                    |
 | `page-title`             | Page-header `<h1>`                                                                                        | Tenants list, tenant home, template detail, theme detail, generation-history, consumers                                                    |
-| `alert-success`          | `.alert.alert-success` banner                                                                             | Login logout message, catalog saved confirmation, feature toggle saved confirmation, catalog browse success, feedback sync                 |
+| `alert-success`          | `.alert.alert-success` banner                                                                             | Login logout message (the save confirmations moved to corner notices — `#notices`, issue #477)                                             |
 
 ---
 

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
@@ -93,32 +93,41 @@ class BackupsHandler(
     fun backupNow(request: ServerRequest): ServerResponse {
         val tenantId = request.tenantId()
         requirePermission(tenantId.key, Permission.BACKUP_CREATE)
-        return try {
-            val message =
-                when (backupService.backupTenant(tenantId.key)) {
-                    is BackupOutcome.Created -> "Backup completed."
-                    is BackupOutcome.Unchanged -> "No changes since the last backup."
-                }
-            request.htmx {
-                fragment("backups/list", "backup-list") {
-                    "tenantId" to tenantId.key
-                    "backups" to backupViews(tenantId.key)
-                }
-                successNotice(message)
-                onFullPage { redirect("/tenants/${tenantId.key.value}/backups") }
+        val message = try {
+            when (backupService.backupTenant(tenantId.key)) {
+                is BackupOutcome.Created -> "Backup completed."
+                is BackupOutcome.Unchanged -> "No changes since the last backup."
             }
         } catch (e: HubEntitlementDeniedException) {
             log.warn("Backup not entitled for tenant {}: {}", tenantId.key.value, e.message)
-            redirect(request, tenantId.key.value, "error=not-entitled")
+            return redirect(request, tenantId.key.value, "error=not-entitled")
         } catch (e: HubUnauthenticatedException) {
             log.warn("Hub rejected this installation's credentials backing up tenant {}: {}", tenantId.key.value, e.message)
-            redirect(request, tenantId.key.value, "error=hub-auth")
+            return redirect(request, tenantId.key.value, "error=hub-auth")
         } catch (e: HubException) {
             log.warn("Backup could not reach the hub for tenant {}: {}", tenantId.key.value, e.message)
-            redirect(request, tenantId.key.value, "error=hub-unavailable")
+            return redirect(request, tenantId.key.value, "error=hub-unavailable")
         } catch (e: Exception) {
             log.error("Manual backup failed for tenant {}: {}", tenantId.key.value, e.message, e)
-            redirect(request, tenantId.key.value, "error=backup-failed")
+            return redirect(request, tenantId.key.value, "error=backup-failed")
+        }
+
+        // The backup itself succeeded past this point — a failure while listing
+        // for the refreshed fragment must not be reported as a backup failure.
+        // Fall back to a plain reload; list() has its own hub-error degradation.
+        val backups = try {
+            backupViews(tenantId.key)
+        } catch (e: Exception) {
+            log.warn("Backup succeeded but listing the backups failed for tenant {}: {}", tenantId.key.value, e.message)
+            return redirect(request, tenantId.key.value, "")
+        }
+        return request.htmx {
+            fragment("backups/list", "backup-list") {
+                "tenantId" to tenantId.key
+                "backups" to backups
+            }
+            successNotice(message)
+            onFullPage { redirect("/tenants/${tenantId.key.value}/backups") }
         }
     }
 
@@ -153,10 +162,13 @@ class BackupsHandler(
         request: ServerRequest,
         tenantKey: String,
         query: String,
-    ): ServerResponse = if (request.isHtmx) {
-        ServerResponse.ok().header("HX-Redirect", "/tenants/$tenantKey/backups?$query").build()
-    } else {
-        ServerResponse.status(303).header("Location", "/tenants/$tenantKey/backups?$query").build()
+    ): ServerResponse {
+        val location = "/tenants/$tenantKey/backups" + if (query.isEmpty()) "" else "?$query"
+        return if (request.isHtmx) {
+            ServerResponse.ok().header("HX-Redirect", location).build()
+        } else {
+            ServerResponse.status(303).header("Location", location).build()
+        }
     }
 
     private fun StoredBackup.toView(

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
@@ -10,7 +10,9 @@ import app.epistola.hub.client.error.HubUnauthenticatedException
 import app.epistola.suite.backups.BackupOutcome
 import app.epistola.suite.backups.StoredBackup
 import app.epistola.suite.backups.TenantBackupService
+import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.features.KnownFeatures
+import app.epistola.suite.htmx.htmx
 import app.epistola.suite.htmx.page
 import app.epistola.suite.htmx.tenantId
 import app.epistola.suite.mediator.query
@@ -65,8 +67,6 @@ class BackupsHandler(
                 hubStatus = "UNAVAILABLE"
                 emptyList()
             }
-        val restorability = if (backups.isEmpty()) emptyMap() else backupService.restorability(tenantId.key, backups)
-
         return ServerResponse.ok().page("backups/list") {
             "pageTitle" to "Backups - Epistola"
             "tenant" to tenant
@@ -74,12 +74,18 @@ class BackupsHandler(
             "activeNavSection" to "backups"
             "stage" to KnownFeatures.stageOf(KnownFeatures.SUPPORT_BACKUPS)
             "hubStatus" to hubStatus
-            "backups" to
-                backups.mapIndexed { index, backup ->
-                    backup.toView(isLatest = index == 0, restorable = restorability.getValue(backup.id))
-                }
+            "backups" to toViews(tenantId.key, backups)
             "saved" to request.param("saved").orElse(null)
             "error" to request.param("error").orElse(null)
+        }
+    }
+
+    private fun backupViews(tenantKey: TenantKey): List<BackupView> = toViews(tenantKey, backupService.listBackups(tenantKey))
+
+    private fun toViews(tenantKey: TenantKey, backups: List<StoredBackup>): List<BackupView> {
+        val restorability = if (backups.isEmpty()) emptyMap() else backupService.restorability(tenantKey, backups)
+        return backups.mapIndexed { index, backup ->
+            backup.toView(isLatest = index == 0, restorable = restorability.getValue(backup.id))
         }
     }
 
@@ -87,12 +93,19 @@ class BackupsHandler(
         val tenantId = request.tenantId()
         requirePermission(tenantId.key, Permission.BACKUP_CREATE)
         return try {
-            val query =
+            val message =
                 when (backupService.backupTenant(tenantId.key)) {
-                    is BackupOutcome.Created -> "saved=backup"
-                    is BackupOutcome.Unchanged -> "saved=backup-unchanged"
+                    is BackupOutcome.Created -> "Backup completed."
+                    is BackupOutcome.Unchanged -> "No changes since the last backup."
                 }
-            redirect(tenantId.key.value, query)
+            request.htmx {
+                fragment("backups/list", "backup-list") {
+                    "tenantId" to tenantId.key
+                    "backups" to backupViews(tenantId.key)
+                }
+                successNotice(message)
+                onFullPage { redirect("/tenants/${tenantId.key.value}/backups") }
+            }
         } catch (e: HubEntitlementDeniedException) {
             log.warn("Backup not entitled for tenant {}: {}", tenantId.key.value, e.message)
             redirect(tenantId.key.value, "error=not-entitled")

--- a/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
+++ b/modules/epistola-support-backups/src/main/kotlin/app/epistola/suite/support/backups/ui/BackupsHandler.kt
@@ -13,6 +13,7 @@ import app.epistola.suite.backups.TenantBackupService
 import app.epistola.suite.common.ids.TenantKey
 import app.epistola.suite.features.KnownFeatures
 import app.epistola.suite.htmx.htmx
+import app.epistola.suite.htmx.isHtmx
 import app.epistola.suite.htmx.page
 import app.epistola.suite.htmx.tenantId
 import app.epistola.suite.mediator.query
@@ -108,16 +109,16 @@ class BackupsHandler(
             }
         } catch (e: HubEntitlementDeniedException) {
             log.warn("Backup not entitled for tenant {}: {}", tenantId.key.value, e.message)
-            redirect(tenantId.key.value, "error=not-entitled")
+            redirect(request, tenantId.key.value, "error=not-entitled")
         } catch (e: HubUnauthenticatedException) {
             log.warn("Hub rejected this installation's credentials backing up tenant {}: {}", tenantId.key.value, e.message)
-            redirect(tenantId.key.value, "error=hub-auth")
+            redirect(request, tenantId.key.value, "error=hub-auth")
         } catch (e: HubException) {
             log.warn("Backup could not reach the hub for tenant {}: {}", tenantId.key.value, e.message)
-            redirect(tenantId.key.value, "error=hub-unavailable")
+            redirect(request, tenantId.key.value, "error=hub-unavailable")
         } catch (e: Exception) {
             log.error("Manual backup failed for tenant {}: {}", tenantId.key.value, e.message, e)
-            redirect(tenantId.key.value, "error=backup-failed")
+            redirect(request, tenantId.key.value, "error=backup-failed")
         }
     }
 
@@ -127,31 +128,36 @@ class BackupsHandler(
         val backupId = request.pathVariable("backupId")
         return try {
             backupService.restoreFromBackup(tenantId.key, backupId)
-            redirect(tenantId.key.value, "saved=restore")
+            redirect(request, tenantId.key.value, "saved=restore")
         } catch (e: IncompatibleBackupSchemaException) {
             log.warn("Restore refused for tenant {} from backup {}: {}", tenantId.key.value, backupId, e.reason)
-            redirect(tenantId.key.value, "error=restore-incompatible")
+            redirect(request, tenantId.key.value, "error=restore-incompatible")
         } catch (e: HubEntitlementDeniedException) {
             log.warn("Restore not entitled for tenant {}: {}", tenantId.key.value, e.message)
-            redirect(tenantId.key.value, "error=not-entitled")
+            redirect(request, tenantId.key.value, "error=not-entitled")
         } catch (e: HubUnauthenticatedException) {
             log.warn("Hub rejected this installation's credentials restoring tenant {} backup {}: {}", tenantId.key.value, backupId, e.message)
-            redirect(tenantId.key.value, "error=hub-auth")
+            redirect(request, tenantId.key.value, "error=hub-auth")
         } catch (e: HubException) {
             log.warn("Restore could not reach the hub for tenant {} backup {}: {}", tenantId.key.value, backupId, e.message)
-            redirect(tenantId.key.value, "error=hub-unavailable")
+            redirect(request, tenantId.key.value, "error=hub-unavailable")
         } catch (e: Exception) {
             log.error("Restore failed for tenant {} from backup {}: {}", tenantId.key.value, backupId, e.message, e)
-            redirect(tenantId.key.value, "error=restore-failed")
+            redirect(request, tenantId.key.value, "error=restore-failed")
         }
     }
 
-    // Both actions are triggered via htmx; return 200 with HX-Redirect so htmx navigates the whole
-    // page — a 303 would be followed transparently by the XHR and the HX-Redirect header would be lost.
+    // htmx gets 200 + HX-Redirect for a full-page navigation (a 303 would be followed
+    // transparently by the XHR and the header lost); a plain form gets a real 303.
     private fun redirect(
+        request: ServerRequest,
         tenantKey: String,
         query: String,
-    ): ServerResponse = ServerResponse.ok().header("HX-Redirect", "/tenants/$tenantKey/backups?$query").build()
+    ): ServerResponse = if (request.isHtmx) {
+        ServerResponse.ok().header("HX-Redirect", "/tenants/$tenantKey/backups?$query").build()
+    } else {
+        ServerResponse.status(303).header("Location", "/tenants/$tenantKey/backups?$query").build()
+    }
 
     private fun StoredBackup.toView(
         isLatest: Boolean,

--- a/modules/epistola-support-backups/src/main/resources/templates/backups/list.html
+++ b/modules/epistola-support-backups/src/main/resources/templates/backups/list.html
@@ -9,8 +9,6 @@
             actions=~{::backup-list-actions}
         )}"></div>
 
-        <div th:if="${saved == 'backup'}" class="alert alert-success" role="status">Backup completed.</div>
-        <div th:if="${saved == 'backup-unchanged'}" class="alert alert-info" role="status">No changes since the last backup — nothing new to store.</div>
         <div th:if="${saved == 'restore'}" class="alert alert-success" role="status">Tenant restored from the backup.</div>
         <div th:if="${error == 'backup-failed'}" class="alert alert-error" role="alert">The backup failed. Please try again or check the logs.</div>
         <div th:if="${error == 'restore-failed'}" class="alert alert-error" role="alert">The restore failed and was rolled back. Please try again or check the logs.</div>
@@ -22,6 +20,7 @@
         <div th:if="${hubStatus == 'AUTH'}" class="alert alert-error" role="alert">The Epistola hub rejected this installation's credentials (authentication failed), so stored backups can't be listed. Reconnect this installation on Support → Overview.</div>
         <div th:if="${hubStatus == 'NOT_ENTITLED'}" class="alert alert-info" role="status">This installation isn't entitled to backups — contact Epistola for a service contract.</div>
 
+        <div id="backup-list" th:fragment="backup-list">
         <div th:if="${#lists.isEmpty(backups)}" class="empty-state">
             <div class="empty-state-icon">
                 <th:block th:replace="~{epistola-web/icon :: icon(name='database', class='ep-icon ep-icon-xl')}" />
@@ -76,11 +75,14 @@
                 </tr>
             </tbody>
         </table>
+        </div>
 
         <th:block th:replace="~{fragments/confirm-dialog :: confirm-dialog}" />
     </th:block>
     <th:block th:fragment="backup-list-actions">
-        <form th:action="@{/tenants/{tenantId}/backups(tenantId=${tenantId})}" method="post">
+        <form th:action="@{/tenants/{tenantId}/backups(tenantId=${tenantId})}" method="post"
+              th:hx-post="@{/tenants/{tenantId}/backups(tenantId=${tenantId})}"
+              hx-target="#backup-list" hx-swap="outerHTML">
             <button type="submit" class="ep-btn ep-btn-primary" th:disabled="${hubStatus != 'OK'}">
                 <th:block th:replace="~{epistola-web/icon :: icon(name='upload-cloud', class='ep-icon')}" />
                 Back up now


### PR DESCRIPTION
## Description

Layer 3 of the #477 stack, on #819. #818 made requests interceptable, #819 made feedback guaranteed — this layer makes every save use it: all legacy save confirmations (redirect-then-banner pages, in-page alerts, and one dishonest success) become in-place form swaps with corner notices.

**Conversions** (one commit each): feature toggles, tenant defaults, platform site banner, catalog mutations (create/register/release/upgrade/unregister), catalog browse install, on-demand backups. The shared pattern: the form becomes a `th:fragment` posting over htmx (`hx-target="this"`, `hx-swap="outerHTML"`, keeping `th:action` as the no-JS fallback); the handler re-renders the fragment and rides a `successNotice` along, with `onFullPage` redirecting plain requests to the clean URL. `hx-disinherit="hx-target hx-swap"` guards forms containing boosted links — without it a Cancel link swaps its destination page *into* the form.

**Correctness fixes that fell out**:

- **Catalog install stopped lying.** A failed install returned 200 and closed the preview dialog as if it had succeeded. It now returns 422 with an error notice while still refreshing the resource rows (`reswap`), so `data-close-dialog-on-success` keeps the dialog open — no new machinery. The summary message is bounded ("Failed to install N of M resources.", slugs to the log) and the "Resources ." empty-summary artifact is gone.
- **Backup/restore failure paths got a real plain-request fallback**: `redirect()` now negotiates on `request.isHtmx` — htmx gets 200 + `HX-Redirect` (a 303 would be followed by the XHR and the header lost), a plain form gets a genuine 303 instead of a blank 200.
- Catalog unregister, which never confirmed at all, now does ("Catalog deleted.").

**Deletions**: the `?saved=true` / `?saved=…` query-param protocol and its four redirect targets, the success banners on features/defaults/catalogs/backups pages, the browse page's `#catalog-alert` OOB alert plumbing. Deliberate banner survivors (page *state*, not save feedback): restore-from-backup success, the backups hub-status and error banners, the catalogs list error alert.

**Standalone-page precedent**: `platform/banner.html` renders its own `<body>` (no shell), so it now hosts the `#notices` region + `notice-template` pair itself — the pattern for any future shell-less page.

## Related Issue(s)

References #477. Remaining after this layer, deliberately out of scope: the editor surface (`templates/editor.html` hosts no notice region yet, and the editor-boot callbacks still swallow several failures silently) — next branch in the stack.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (static JS/CSS/templates — not the editor module)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

Verified live throughout development (each converted form: in-place swap, corner notice, Cancel navigation, dialog flows on catalogs, backup dedup notice).

## Additional Notes

**Demo catalog**: not applicable — this changes UI feedback behavior (shell chrome), not catalog resources; there is nothing a catalog entry could exercise. No catalog resources touched, so no fingerprint bump is owed.

**Tests**: handler contracts in `FeatureTogglePageHtmxTest`, `DefaultsHandlerTest`, `SiteBannerHandlerHtmxTest`, `CatalogInstallHandlerTest` (new), `BackupsUpgradingHandlerTest`, `BackupsHubUnavailableTest` (incl. the plain-path 303 assertions); browser coverage in six new UI suites (`FeatureTogglesUiTest`, `DefaultsUiTest`, `SiteBannerAdminUiTest`, `CatalogNoticeUiTest`, `CatalogInstallUiTest`, `BackupsUiTest`).

**Deliberately out of scope**:
- **Editor surface** (see Related Issues) — including a consistent success/error return shape for the editor's mount callbacks, to be designed before conversion.
- **Plain (no-JS) success confirmation**: a plain submit now lands on the clean reloaded page with no banner — the saved state itself is the confirmation. Re-adding `?saved` params for that path would reintroduce exactly what this PR deletes; the no-JS path is a script-load-window resilience fallback, not a supported UX.
- **Login page**: pre-auth, not a shell page — untouched.
