### PR TITLE
feat(editor): surface every silent editor failure (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   keeps the preview dialog open with an error notice and a real error status when the
   install fails (previously the dialog closed as if it had succeeded); a plain full-page
   submit shows the error on the page itself. (#477)
+- **[user]** fix(editor): **Editor failures are no longer silent.** The template, theme, and
+  data-contract editors now surface every failed background request: stencil search and
+  version-list failures report inside the picker, and failures with no UI of their own —
+  the stencil upgrade check, loading a stencil version for Insert, deleting a data example,
+  loading tenant fonts or image catalogs — show a corner error notice. Inserting a stencil
+  while the version fetch fails no longer strands the Insert button on "Loading…", and a
+  theme save error now shows the actual reason instead of a raw response dump. (#477)
 - **[dev]** test(ui): **The app's static JS is unit-testable.** `apps/epistola` joined the pnpm
   workspace with a vitest + happy-dom test ground (`src/test/js/`) that evaluates the real
   classic scripts and drives them through DOM events, synthetic htmx events, and fake timers —

--- a/apps/epistola/src/main/resources/static/js/editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/editor-boot.js
@@ -96,52 +96,47 @@ async function mount(container) {
     },
     stencilOptions: {
       // Must never reject — the editor's upgrade check has no catch (lib.ts).
+      // The per-stencil fetches are independent, so they run concurrently:
+      // the upgrade badge costs one RTT, not one per referenced stencil.
       checkUpgrades: async (refs) => {
         const uniqueKeys = [...new Set(refs.map((r) => r.catalogKey + '/' + r.stencilId))];
-        const results = [];
-        let failed = false;
-        for (const key of uniqueKeys) {
-          const [cat, sid] = key.split('/');
-          try {
-            const resp = await fetch(
-              '/tenants/' + tenantId + '/stencils/' + cat + '/' + sid + '/versions',
-              {
-                headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
-              },
-            );
-            if (!resp.ok) {
-              failed = true;
-              continue;
-            }
-            const data = await resp.json();
-            const versions = data.items ?? data;
-            const latestPublished = versions
-              .filter((v) => v.status === 'published')
-              .toSorted((a, b) => b.version - a.version)[0];
-            if (latestPublished) {
-              const currentVersions = refs.filter(
-                (r) => r.stencilId === sid && r.catalogKey === cat,
+        const perKey = await Promise.all(
+          uniqueKeys.map(async (key) => {
+            const [cat, sid] = key.split('/');
+            try {
+              const resp = await fetch(
+                '/tenants/' + tenantId + '/stencils/' + cat + '/' + sid + '/versions',
+                {
+                  headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
+                },
               );
-              for (const ref of currentVersions) {
-                if (latestPublished.version > ref.version) {
-                  results.push({
-                    stencilId: sid,
-                    currentVersion: ref.version,
-                    latestVersion: latestPublished.version,
-                  });
-                }
-              }
+              if (!resp.ok) return { upgrades: [], failed: true };
+              const data = await resp.json();
+              const versions = data.items ?? data;
+              const latestPublished = versions
+                .filter((v) => v.status === 'published')
+                .toSorted((a, b) => b.version - a.version)[0];
+              if (!latestPublished) return { upgrades: [], failed: false };
+              const upgrades = refs
+                .filter((r) => r.stencilId === sid && r.catalogKey === cat)
+                .filter((ref) => latestPublished.version > ref.version)
+                .map((ref) => ({
+                  stencilId: sid,
+                  currentVersion: ref.version,
+                  latestVersion: latestPublished.version,
+                }));
+              return { upgrades: upgrades, failed: false };
+            } catch {
+              return { upgrades: [], failed: true };
             }
-          } catch {
-            failed = true;
-          }
-        }
-        if (failed) {
+          }),
+        );
+        if (perKey.some((r) => r.failed)) {
           window.epistolaNotice.error('Could not check for stencil upgrades.', {
             dedupeKey: 'stencil-upgrade-check',
           });
         }
-        return results;
+        return perKey.flatMap((r) => r.upgrades);
       },
       // Throws on failure — the picker catches and reports in-dialog.
       searchStencils: async (query) => {

--- a/apps/epistola/src/main/resources/static/js/editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/editor-boot.js
@@ -41,22 +41,34 @@ async function mount(container) {
     locale: config.locale,
     fontOptions: {
       listFonts: async () => {
-        const resp = await fetch('/tenants/' + tenantId + '/fonts/search?catalog=' + catalogId, {
-          headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
-        });
-        if (!resp.ok) throw new Error('Failed to list fonts');
-        return await resp.json();
+        try {
+          const resp = await fetch('/tenants/' + tenantId + '/fonts/search?catalog=' + catalogId, {
+            headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
+          });
+          if (!resp.ok) throw new Error('Failed to list fonts');
+          return await resp.json();
+        } catch (e) {
+          window.epistolaNotice.error('Could not load the tenant fonts. Default fonts are shown.');
+          throw e;
+        }
       },
     },
     imageOptions: {
       defaultCatalogKey: catalogId,
       contentUrlPattern: '/tenants/' + tenantId + '/images/{catalogId}/{assetId}/content',
       listCatalogs: async () => {
-        const resp = await fetch('/tenants/' + tenantId + '/images/catalogs', {
-          headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
-        });
-        if (!resp.ok) throw new Error('Failed to list catalogs');
-        return await resp.json();
+        try {
+          const resp = await fetch('/tenants/' + tenantId + '/images/catalogs', {
+            headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
+          });
+          if (!resp.ok) throw new Error('Failed to list catalogs');
+          return await resp.json();
+        } catch (e) {
+          window.epistolaNotice.error(
+            'Could not load the image catalogs. Uploads are unavailable.',
+          );
+          throw e;
+        }
       },
       listAssets: async (catalog) => {
         const params = new URLSearchParams({ catalog });
@@ -83,48 +95,66 @@ async function mount(container) {
       },
     },
     stencilOptions: {
+      // Must never reject — the editor's upgrade check has no catch (lib.ts).
       checkUpgrades: async (refs) => {
         const uniqueKeys = [...new Set(refs.map((r) => r.catalogKey + '/' + r.stencilId))];
         const results = [];
+        let failed = false;
         for (const key of uniqueKeys) {
           const [cat, sid] = key.split('/');
-          const resp = await fetch(
-            '/tenants/' + tenantId + '/stencils/' + cat + '/' + sid + '/versions',
-            {
-              headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
-            },
-          );
-          if (!resp.ok) continue;
-          const data = await resp.json();
-          const versions = data.items ?? data;
-          const latestPublished = versions
-            .filter((v) => v.status === 'published')
-            .toSorted((a, b) => b.version - a.version)[0];
-          if (latestPublished) {
-            const currentVersions = refs.filter((r) => r.stencilId === sid && r.catalogKey === cat);
-            for (const ref of currentVersions) {
-              if (latestPublished.version > ref.version) {
-                results.push({
-                  stencilId: sid,
-                  currentVersion: ref.version,
-                  latestVersion: latestPublished.version,
-                });
+          try {
+            const resp = await fetch(
+              '/tenants/' + tenantId + '/stencils/' + cat + '/' + sid + '/versions',
+              {
+                headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
+              },
+            );
+            if (!resp.ok) {
+              failed = true;
+              continue;
+            }
+            const data = await resp.json();
+            const versions = data.items ?? data;
+            const latestPublished = versions
+              .filter((v) => v.status === 'published')
+              .toSorted((a, b) => b.version - a.version)[0];
+            if (latestPublished) {
+              const currentVersions = refs.filter(
+                (r) => r.stencilId === sid && r.catalogKey === cat,
+              );
+              for (const ref of currentVersions) {
+                if (latestPublished.version > ref.version) {
+                  results.push({
+                    stencilId: sid,
+                    currentVersion: ref.version,
+                    latestVersion: latestPublished.version,
+                  });
+                }
               }
             }
+          } catch {
+            failed = true;
           }
+        }
+        if (failed) {
+          window.epistolaNotice.error('Could not check for stencil upgrades.', {
+            dedupeKey: 'stencil-upgrade-check',
+          });
         }
         return results;
       },
+      // Throws on failure — the picker catches and reports in-dialog.
       searchStencils: async (query) => {
         const params = new URLSearchParams();
         if (query) params.set('q', query);
         const resp = await fetch('/tenants/' + tenantId + '/stencils/search?' + params, {
           headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
         });
-        if (!resp.ok) return [];
+        if (!resp.ok) throw new Error('Failed to search stencils');
         const data = await resp.json();
         return data.items ?? data;
       },
+      // Throws on failure — both callers catch and report themselves.
       listVersions: async (ref) => {
         const resp = await fetch(
           '/tenants/' +
@@ -138,34 +168,44 @@ async function mount(container) {
             headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
           },
         );
-        if (!resp.ok) return [];
+        if (!resp.ok) throw new Error('Failed to list stencil versions');
         const data = await resp.json();
         return data.items ?? data;
       },
+      // Must never reject — a rejection strands the picker's Insert button;
+      // null is its handled failure path.
       getStencilVersion: async (ref, version) => {
-        const resp = await fetch(
-          '/tenants/' +
-            tenantId +
-            '/stencils/' +
-            ref.catalogKey +
-            '/' +
-            ref.stencilId +
-            '/versions/' +
-            version,
-          {
-            headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
-          },
-        );
-        if (!resp.ok) return null;
-        const v = await resp.json();
-        return {
-          ref,
-          stencilName: ref.stencilId,
-          version: v.id ?? version,
-          status: v.status,
-          content: v.content,
-          parameterSchema: v.parameterSchema ?? undefined,
-        };
+        try {
+          const resp = await fetch(
+            '/tenants/' +
+              tenantId +
+              '/stencils/' +
+              ref.catalogKey +
+              '/' +
+              ref.stencilId +
+              '/versions/' +
+              version,
+            {
+              headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
+            },
+          );
+          if (!resp.ok) {
+            window.epistolaNotice.error('Failed to load the stencil version. Please try again.');
+            return null;
+          }
+          const v = await resp.json();
+          return {
+            ref,
+            stencilName: ref.stencilId,
+            version: v.id ?? version,
+            status: v.status,
+            content: v.content,
+            parameterSchema: v.parameterSchema ?? undefined,
+          };
+        } catch {
+          window.epistolaNotice.error('Failed to load the stencil version. Please try again.');
+          return null;
+        }
       },
       createStencil: async (slug, name) => {
         const resp = await fetch('/tenants/' + tenantId + '/stencils', {

--- a/apps/epistola/src/main/resources/static/js/pages/template-detail.js
+++ b/apps/epistola/src/main/resources/static/js/pages/template-detail.js
@@ -362,6 +362,8 @@
               }
             },
             onDeleteDataExample: async (exampleId) => {
+              // The contract editor ignores success:false — the notice is the
+              // only feedback.
               try {
                 const response = await fetch(
                   `/tenants/${tenantId}/templates/${catalogId}/${templateId}/data-examples/${exampleId}`,
@@ -370,8 +372,12 @@
                     headers: { 'X-XSRF-TOKEN': csrfToken() },
                   },
                 );
+                if (!response.ok) {
+                  window.epistolaNotice.error('Failed to delete the data example.');
+                }
                 return { success: response.ok };
               } catch (e) {
+                window.epistolaNotice.error('Failed to delete the data example.');
                 return { success: false };
               }
             },

--- a/apps/epistola/src/main/resources/static/js/theme-editor-boot.js
+++ b/apps/epistola/src/main/resources/static/js/theme-editor-boot.js
@@ -30,11 +30,16 @@ async function mount(container) {
     readonly: !editable,
     fontOptions: {
       listFonts: async () => {
-        const resp = await fetch('/tenants/' + tenantId + '/fonts/search?catalog=' + catalogId, {
-          headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
-        });
-        if (!resp.ok) throw new Error('Failed to list fonts');
-        return await resp.json();
+        try {
+          const resp = await fetch('/tenants/' + tenantId + '/fonts/search?catalog=' + catalogId, {
+            headers: { Accept: 'application/json', 'X-XSRF-TOKEN': window.getCsrfToken() },
+          });
+          if (!resp.ok) throw new Error('Failed to list fonts');
+          return await resp.json();
+        } catch (e) {
+          window.epistolaNotice.error('Could not load the tenant fonts. Default fonts are shown.');
+          throw e;
+        }
       },
     },
     onSave: async (payload) => {
@@ -51,12 +56,22 @@ async function mount(container) {
       );
 
       if (!response.ok) {
-        const text = await response.text().catch(() => response.statusText);
-        throw new Error('Failed to save theme: ' + text);
+        // The status indicator renders this verbatim — never a raw body.
+        let detail = null;
+        try {
+          const body = JSON.parse(await response.text());
+          detail = body.detail || body.message || body.error;
+        } catch {
+          detail = null;
+        }
+        throw new Error(
+          'Failed to save theme: ' + (detail || response.statusText || response.status),
+        );
       }
 
-      // Update page title if name changed
-      const result = await response.json();
+      // Update page title if name changed; the save already succeeded, so a
+      // malformed body must not surface as a false error.
+      const result = await response.json().catch(() => ({}));
       if (result.name) {
         document.title = result.name + ' - Epistola';
         const h1 = document.querySelector('.page-header h1');

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -117,5 +117,13 @@
     }
     </script>
     <script type="module" th:src="@{/js/editor-boot.js}"></script>
+
+    <!-- Corner-notice region + client template, same pair as layout/shell:
+         this page renders its own <body>, so it hosts them itself. Title ''
+         (not null) so the clone carries an empty .alert-title slot. -->
+    <div id="notices" class="notice-region" aria-live="polite"></div>
+    <template id="notice-template">
+        <th:block th:replace="~{epistola-web/notice :: notice('error', '', '')}" />
+    </template>
 </body>
 </html>

--- a/apps/epistola/src/main/resources/templates/templates/editor.html
+++ b/apps/epistola/src/main/resources/templates/templates/editor.html
@@ -118,12 +118,7 @@
     </script>
     <script type="module" th:src="@{/js/editor-boot.js}"></script>
 
-    <!-- Corner-notice region + client template, same pair as layout/shell:
-         this page renders its own <body>, so it hosts them itself. Title ''
-         (not null) so the clone carries an empty .alert-title slot. -->
-    <div id="notices" class="notice-region" aria-live="polite"></div>
-    <template id="notice-template">
-        <th:block th:replace="~{epistola-web/notice :: notice('error', '', '')}" />
-    </template>
+    <!-- This page renders its own <body>, so it hosts the notice pair itself. -->
+    <th:block th:replace="~{epistola-web/notice :: notice-host}" />
 </body>
 </html>

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/EditorJsonContractTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/EditorJsonContractTest.kt
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.handlers
+
+import app.epistola.suite.BaseIntegrationTest
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.StencilId
+import app.epistola.suite.common.ids.StencilVersionId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.ThemeId
+import app.epistola.suite.common.ids.ThemeKey
+import app.epistola.suite.common.ids.VersionKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.stencils.commands.CreateStencil
+import app.epistola.suite.stencils.commands.CreateStencilVersion
+import app.epistola.suite.stencils.commands.PublishStencilVersion
+import app.epistola.suite.templates.commands.CreateDocumentTemplate
+import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.themes.commands.CreateTheme
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+
+/**
+ * JSON contracts of the UI endpoints the editors' mount callbacks consume
+ * (editor-boot.js, theme-editor-boot.js, pages/template-detail.js). These
+ * responses are parsed by client fetch code that no browser test exercises
+ * against a failure — a handler converted to return HTML (as the settings
+ * controls were, deliberately, in #818) would break the editor at runtime
+ * with nothing failing. Each test pins the response's content type and the
+ * fields the JS actually reads.
+ */
+class EditorJsonContractTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    private fun jsonHeaders() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_JSON
+        accept = listOf(MediaType.APPLICATION_JSON)
+    }
+
+    @Test
+    fun `stencil listVersions returns the items envelope the version pickers read`() {
+        val seeded = seedPublishedStencil("List Versions Contract")
+
+        val response = restTemplate.exchange(
+            "/tenants/${seeded.tenantKey}/stencils/${seeded.catalogKey}/${seeded.stencilKey}/versions",
+            HttpMethod.GET,
+            HttpEntity<Void>(jsonHeaders()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.contentType.toString()).contains("application/json")
+        // editor-boot.js listVersions/checkUpgrades read items[].version and items[].status.
+        assertThat(response.body).contains("\"items\"")
+        assertThat(response.body).contains("\"version\":1")
+        assertThat(response.body).contains("\"status\":\"published\"")
+    }
+
+    @Test
+    fun `stencil getVersion returns the content fields the Insert flow reads`() {
+        val seeded = seedPublishedStencil("Get Version Contract")
+
+        val response = restTemplate.exchange(
+            "/tenants/${seeded.tenantKey}/stencils/${seeded.catalogKey}/${seeded.stencilKey}/versions/1",
+            HttpMethod.GET,
+            HttpEntity<Void>(jsonHeaders()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.contentType.toString()).contains("application/json")
+        // editor-boot.js getStencilVersion reads id, status, content, parameterSchema.
+        assertThat(response.body).contains("\"id\":1")
+        assertThat(response.body).contains("\"status\"")
+        assertThat(response.body).contains("\"content\"")
+    }
+
+    @Test
+    fun `stencil getVersion returns 404 for a missing version`() {
+        val seeded = seedPublishedStencil("Get Version Missing")
+
+        val response = restTemplate.exchange(
+            "/tenants/${seeded.tenantKey}/stencils/${seeded.catalogKey}/${seeded.stencilKey}/versions/99",
+            HttpMethod.GET,
+            HttpEntity<Void>(jsonHeaders()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `stencil publishVersion returns the version and status the editor reads`() {
+        val seeded = seedDraftStencil("Publish Version Contract")
+
+        val response = restTemplate.exchange(
+            "/tenants/${seeded.tenantKey}/stencils/${seeded.catalogKey}/${seeded.stencilKey}/versions/1/publish",
+            HttpMethod.POST,
+            HttpEntity("{}", jsonHeaders()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.contentType.toString()).contains("application/json")
+        assertThat(response.body).contains("\"version\":1")
+        assertThat(response.body).contains("\"status\":\"published\"")
+    }
+
+    @Test
+    fun `theme update PATCH returns the JSON the theme editor's onSave reads`() {
+        val tenantKey = withMediator {
+            val tenant = createTenant("Theme Update Contract")
+            val tenantId = TenantId(tenant.id)
+            CreateTheme(ThemeId(ThemeKey.of("brand"), CatalogId.default(tenantId)), "Brand Theme").execute()
+            tenant.id.value
+        }
+
+        val response = restTemplate.exchange(
+            "/tenants/$tenantKey/themes/default/brand",
+            HttpMethod.PATCH,
+            HttpEntity("""{"name": "Brand Theme Renamed"}""", jsonHeaders()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.contentType.toString()).contains("application/json")
+        // theme-editor-boot.js onSave reads result.name to update the page title.
+        assertThat(response.body).contains("\"name\":\"Brand Theme Renamed\"")
+        assertThat(response.body).contains("\"id\":\"brand\"")
+    }
+
+    @Test
+    fun `contract draft PATCH on the UI route returns the success envelope the contract editor reads`() {
+        val (tenantKey, templateKey) = withMediator {
+            val tenant = createTenant("Contract Draft UI Route")
+            val tenantId = TenantId(tenant.id)
+            val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
+            CreateDocumentTemplate(id = templateId, name = "Contract Draft Template").execute()
+            tenant.id.value to templateId.key.value
+        }
+
+        val body = """{"dataModel": {"type": "object", "properties": {"customer": {"type": "string"}}}}"""
+        val response = restTemplate.exchange(
+            "/tenants/$tenantKey/templates/default/$templateKey/contract/draft",
+            HttpMethod.PATCH,
+            HttpEntity(body, jsonHeaders()),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.contentType.toString()).contains("application/json")
+        // template-detail.js onSaveSchema branches on success and reads warnings.
+        assertThat(response.body).contains("\"success\":true")
+        assertThat(response.body).contains("\"status\":\"draft\"")
+    }
+
+    private data class SeededStencil(
+        val tenantKey: String,
+        val catalogKey: String,
+        val stencilKey: String,
+    )
+
+    private fun seedPublishedStencil(name: String): SeededStencil = withMediator {
+        val tenant = createTenant(name)
+        val tenantId = TenantId(tenant.id)
+        val stencilId = StencilId(TestIdHelpers.nextStencilId(), CatalogId.default(tenantId))
+        CreateStencil(id = stencilId, name = name).execute()
+        CreateStencilVersion(stencilId = stencilId).execute()
+        PublishStencilVersion(versionId = StencilVersionId(VersionKey.of(1), stencilId)).execute()
+        SeededStencil(tenant.id.value, stencilId.catalogKey.value, stencilId.key.value)
+    }
+
+    private fun seedDraftStencil(name: String): SeededStencil = withMediator {
+        val tenant = createTenant(name)
+        val tenantId = TenantId(tenant.id)
+        val stencilId = StencilId(TestIdHelpers.nextStencilId(), CatalogId.default(tenantId))
+        CreateStencil(id = stencilId, name = name).execute()
+        CreateStencilVersion(stencilId = stencilId).execute()
+        SeededStencil(tenant.id.value, stencilId.catalogKey.value, stencilId.key.value)
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/EditorNoticeUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/EditorNoticeUiTest.kt
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.templates.commands.CreateDocumentTemplate
+import app.epistola.suite.tenants.commands.CreateTenant
+import app.epistola.suite.testing.TestIdHelpers
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import com.microsoft.playwright.options.AriaRole
+import org.junit.jupiter.api.Test
+
+/**
+ * Corner notices on the template editor page (#477). The editor renders its
+ * own `<body>` (no layout/shell), hosting the #notices region + template pair
+ * itself — and its dialogs are Lit-rendered, removed from the DOM outright on
+ * close. That removal is the real-world case the notices.js MutationObserver
+ * rescue exists for; NoticeModalPlacementUiTest simulates it on a shell page,
+ * this test exercises the genuine Lit unmount.
+ */
+class EditorNoticeUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `the editor page hosts a working notice region`() {
+        gotoEditor("Editor Notice Region")
+
+        page.evaluate("() => window.epistolaNotice.error('Editor notices work.')")
+
+        val notice = page.locator("body > #notices .notice")
+        assertThat(notice).isVisible()
+        assertThat(notice).containsText("Editor notices work.")
+    }
+
+    @Test
+    fun `a notice survives the stencil dialog's real Lit unmount`() {
+        gotoEditor("Editor Notice Lit Rescue")
+
+        // The stencil picker is a Lit-rendered modal <dialog>.
+        page.openDialogByTrigger(
+            page.getByTestId("palette-item-stencil"),
+            "dialog.stencil-picker-dialog",
+        )
+        page.evaluate("() => window.epistolaNotice.error('Survives the Lit unmount.')")
+        assertThat(page.locator("dialog.stencil-picker-dialog #notices .notice")).isVisible()
+
+        // Cancel closes AND removes the dialog element — no htmx event, no
+        // toggle-close before removal. The MutationObserver rescue must
+        // re-home the region with the live notice.
+        page.locator("dialog.stencil-picker-dialog")
+            .getByRole(AriaRole.BUTTON, com.microsoft.playwright.Locator.GetByRoleOptions().setName("Cancel"))
+            .click()
+
+        val rescued = page.locator("body > #notices:not([popover]) .notice")
+        assertThat(rescued).isVisible()
+        assertThat(rescued).containsText("Survives the Lit unmount.")
+    }
+
+    private fun gotoEditor(name: String) {
+        val (tenantKey, templateKey) = withMediator {
+            val tenant = CreateTenant(
+                id = TenantKey.of("editor-notice-${System.nanoTime()}"),
+                name = name,
+            ).execute()
+            val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(TenantId(tenant.id)))
+            CreateDocumentTemplate(id = templateId, name = name).execute()
+            tenant.id.value to templateId.key.value
+        }
+        gotoAndReady("/tenants/$tenantKey/templates/default/$templateKey/variants/initial/editor")
+    }
+}


### PR DESCRIPTION
## Description

Layer 3 (top) of the #477 stack, on #819. The editor half: the template, theme, and data-contract editors stop swallowing failures.

**The region.** `templates/editor.html` renders its own `<body>` (no `layout/shell`), so it hosts the notice pair itself by replacing #819's shared `epistola-web/notice :: notice-host` fragment — the standalone-page pattern. The notice scripts and CSS were already loading; only the markup was missing.

**The failure surfacing** — grounded in a full audit of all ~20 mount callbacks across the three editors. Most throws already land in purpose-built editor UI (dialog slots, inspector callouts, toolbar retry, preview pane) and are untouched. The fixes target what was genuinely silent, with **zero return-shape changes** — feedback is a side-effect at the boundary, the editor module's contracts are unchanged:

- `searchStencils` / `listVersions` throw on HTTP errors instead of returning `[]`, so the picker's existing in-dialog reporting fires — a failing server no longer masquerades as "no stencils found".
- `getStencilVersion` never rejects: any failure shows an error notice and returns `null`, the picker's handled path. A rejection used to strand the Insert button on "Loading…" permanently — that bug is fixed.
- `checkUpgrades` never rejects (its caller has no catch — a rejection died as an unhandled promise) and reports a partial or failed sweep once via a **deduped** notice. Its per-stencil version fetches run concurrently — the upgrade badge costs one RTT, not one per referenced stencil.
- `listFonts` / `listCatalogs` report every failure mode (HTTP, network, malformed body) with a notice before rethrowing into the editor's existing graceful degrade — a stale font list or a silently disabled upload button is no longer unexplained.
- A failed data-example delete shows a notice instead of an invisible no-op (the contract editor ignores `success: false`).
- A theme save error surfaces the problem detail instead of embedding a raw response body (which could be an entire HTML error page), and a malformed body on a *successful* save no longer reports a false error.

**No success notices.** Deliberate: routine actions (search, autosave) already have their own affirmation or need none.

**Tests:**

- `EditorJsonContractTest` (6) — pins the JSON contracts the editor callbacks parse but no test protected: theme `PATCH`, the contract-draft UI route, and the stencil `listVersions`/`getVersion`(+404)/`publishVersion` JSON branches. Asserts content type + the exact fields the JS reads, so a future HTMX/HTML conversion of these handlers fails a test instead of the editor at runtime (the audit verified the current stack made no such change).
- `EditorNoticeUiTest` (2) — the editor page hosts a working region, and a notice survives the stencil dialog's **real Lit unmount** (the dialog element is removed from the DOM on close) — the genuine case #819's shell-page placement test only simulates.

## Related Issue(s)

References #477. This closes the issue's editor bullets ("Editor calls", "Stencil save/upgrade"). Still open from earlier layers, deliberately: success feedback across publish/discard hard-redirect navigations.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [ ] Backend (Spring Boot/Kotlin)
- [x] Frontend (static JS/templates — not the editor module)
- [x] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if applicable)

Verified live throughout development: in-dialog "Search failed." on a failing stencil search, the corner notice + recovered Insert button on a failing version fetch (offline), and the data-example delete notice.

## Additional Notes

**Demo catalog**: not applicable — this changes client-side failure feedback, not catalog resources; nothing a catalog entry could exercise. No catalog resources touched, so no fingerprint bump is owed.

**Deliberately out of scope**: richer error messages in the notices (the server endpoints don't yet emit meaningful problem details for these routes, and several editor fetches negotiate into HTML error pages — a server-side message-quality follow-up); the `onUpdateDataExample` dead wiring (no editor-side caller — removal is its own decision); browser tests for the failure paths via `page.route()` interception (noted as candidates, the un-wedge regression test foremost).

