### PR TITLE
fix(catalog): round-trip pdfa_enabled through catalog exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   heartbeat/assignment updates and generation-result acknowledgement cursor advances are excluded
   from auditing, and a scoped migration removes their existing success and failure entries while
   preserving genuine audit history.
+- **[user]** fix(catalog): **A template's PDF/A setting survives catalog export and re-import.**
+  Import previously hardcoded PDF/A to enabled and never updated it on re-import, and export never
+  emitted it at all — so disabling PDF/A on a template was silently reverted the next time its
+  catalog was imported or upgraded. The setting now round-trips both ways.
 
 ## [1.0.1] - 2026-08-04
 

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/CatalogContentBuilder.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/CatalogContentBuilder.kt
@@ -132,13 +132,13 @@ class CatalogContentBuilder(
     }
 
     private fun loadTemplates(tenantKey: TenantKey, catalogKey: CatalogKey): List<TemplateResource> {
-        data class TemplateRow(val id: String, val name: String, val themeKey: String?, val themeCatalogKey: String?, val dataModel: String?, val dataExamples: String?)
+        data class TemplateRow(val id: String, val name: String, val themeKey: String?, val themeCatalogKey: String?, val dataModel: String?, val dataExamples: String?, val pdfaEnabled: Boolean)
         data class VariantRow(val id: String, val title: String?, val attributes: String?, val templateModel: TemplateDocument?, val isDefault: Boolean)
 
         val templates = jdbi.withHandle<List<TemplateRow>, Exception> { handle ->
             handle.createQuery(
                 """
-                SELECT dt.id, dt.name, dt.theme_key, dt.theme_catalog_key,
+                SELECT dt.id, dt.name, dt.theme_key, dt.theme_catalog_key, dt.pdfa_enabled,
                        cv.data_model::text, cv.data_examples::text
                 FROM document_templates dt
                 LEFT JOIN LATERAL (
@@ -160,6 +160,7 @@ class CatalogContentBuilder(
                         themeCatalogKey = rs.getString("theme_catalog_key"),
                         dataModel = rs.getString("data_model"),
                         dataExamples = rs.getString("data_examples"),
+                        pdfaEnabled = rs.getBoolean("pdfa_enabled"),
                     )
                 }
                 .list()
@@ -216,6 +217,7 @@ class CatalogContentBuilder(
                     objectMapper.readValue(it, objectMapper.typeFactory.constructCollectionType(List::class.java, DataExampleEntry::class.java))
                 },
                 templateModel = defaultModel,
+                pdfaEnabled = template.pdfaEnabled,
                 variants = variants.map { v ->
                     VariantEntry(
                         id = v.id,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ImportCatalogZip.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ImportCatalogZip.kt
@@ -636,6 +636,7 @@ class ImportCatalogZipHandler(
                     )
                 },
                 publishTo = emptyList(),
+                pdfaEnabled = resource.pdfaEnabled,
             )
             val results = ImportTemplates(
                 tenantId = tenantId,

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ImportTemplates.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/ImportTemplates.kt
@@ -79,6 +79,7 @@ data class ImportTemplateInput(
     val templateModel: TemplateDocument,
     val variants: List<ImportVariantInput>,
     val publishTo: List<String>,
+    val pdfaEnabled: Boolean = true,
 )
 
 data class ImportVariantInput(
@@ -228,9 +229,9 @@ class ImportTemplatesHandler(
             handle.createUpdate(
                 """
                     INSERT INTO document_templates (id, tenant_key, catalog_key, name, theme_key, theme_catalog_key, pdfa_enabled, created_at, updated_at, created_by, updated_by)
-                    VALUES (:id, :tenantId, :catalogKey, :name, :themeKey, :themeCatalogKey, TRUE, NOW(), NOW(), :createdBy, :updatedBy)
+                    VALUES (:id, :tenantId, :catalogKey, :name, :themeKey, :themeCatalogKey, :pdfaEnabled, NOW(), NOW(), :createdBy, :updatedBy)
                     ON CONFLICT (tenant_key, catalog_key, id) DO UPDATE
-                    SET name = :name, theme_key = :themeKey, theme_catalog_key = :themeCatalogKey, updated_at = NOW(), updated_by = :updatedBy
+                    SET name = :name, theme_key = :themeKey, theme_catalog_key = :themeCatalogKey, pdfa_enabled = :pdfaEnabled, updated_at = NOW(), updated_by = :updatedBy
                     """,
             )
                 .bind("id", templateId)
@@ -239,6 +240,7 @@ class ImportTemplatesHandler(
                 .bind("name", input.name)
                 .bind("themeKey", input.themeId)
                 .bind("themeCatalogKey", input.themeCatalogKey)
+                .bind("pdfaEnabled", input.pdfaEnabled)
                 .bind("createdBy", auditUser).bind("updatedBy", auditUser)
                 .execute()
             ImportStatus.CREATED
@@ -246,7 +248,7 @@ class ImportTemplatesHandler(
             handle.createUpdate(
                 """
                     UPDATE document_templates
-                    SET name = :name, theme_key = :themeKey, theme_catalog_key = :themeCatalogKey, updated_at = NOW(), updated_by = :updatedBy
+                    SET name = :name, theme_key = :themeKey, theme_catalog_key = :themeCatalogKey, pdfa_enabled = :pdfaEnabled, updated_at = NOW(), updated_by = :updatedBy
                     WHERE id = :id AND tenant_key = :tenantId AND catalog_key = :catalogKey
                     """,
             )
@@ -256,6 +258,7 @@ class ImportTemplatesHandler(
                 .bind("name", input.name)
                 .bind("themeKey", input.themeId)
                 .bind("themeCatalogKey", input.themeCatalogKey)
+                .bind("pdfaEnabled", input.pdfaEnabled)
                 .bind("createdBy", auditUser).bind("updatedBy", auditUser)
                 .execute()
             ImportStatus.UPDATED

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/InstallFromCatalog.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/catalog/commands/InstallFromCatalog.kt
@@ -156,6 +156,7 @@ class InstallFromCatalogHandler(
                 )
             },
             publishTo = emptyList(),
+            pdfaEnabled = resource.pdfaEnabled,
         )
 
         val results = ImportTemplates(

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogExportImportTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogExportImportTest.kt
@@ -993,6 +993,95 @@ class CatalogExportImportTest : IntegrationTestBase() {
         }
     }
 
+    @Test
+    fun `pdfa_enabled false round-trips through export and import into a new tenant`() {
+        // Issue #745: pdfa_enabled was hardcoded TRUE on import and never exported,
+        // so a disabled template's setting was silently lost on catalog exchange.
+        val tenant = createTenant("Pdfa Export")
+        val tenantKey = tenant.id
+        val tenantId = TenantId(tenantKey)
+        val catalogKey = CatalogKey.of("pdfa-export-catalog")
+        val catalogId = CatalogId(catalogKey, tenantId)
+        val templateKey = TestIdHelpers.nextTemplateId()
+
+        val exported = withMediator {
+            CreateCatalog(tenantKey = tenantKey, id = catalogKey, name = "Pdfa Export Catalog").execute()
+
+            val templateId = TemplateId(templateKey, catalogId)
+            CreateDocumentTemplate(id = templateId, name = "Pdfa Export Template").execute()
+            UpdateDocumentTemplate(id = templateId, pdfaEnabled = false).execute()
+
+            val variantId = VariantId(VariantKey.INITIAL, templateId)
+            PublishVersion(versionId = VersionId(VersionKey.of(1), variantId)).execute()
+
+            ExportCatalogZip(tenantKey = tenantKey, catalogKey = catalogKey).execute()
+        }
+
+        // The exported wire resource carries the disabled flag, not a hardcoded default.
+        val exportedPdfaEnabled = readTemplateResourcePdfaEnabled(exported.zipBytes, templateKey.value)
+        assertThat(exportedPdfaEnabled).isFalse()
+
+        val target = createTenant("Pdfa Export Target")
+        val targetId = TenantId(target.id)
+
+        withMediator {
+            val importResult = ImportCatalogZip(
+                tenantKey = target.id,
+                zipBytes = exported.zipBytes,
+                catalogType = CatalogType.AUTHORED,
+            ).execute()
+            assertThat(importResult.results).allSatisfy { result ->
+                assertThat(result.status).isNotEqualTo(InstallStatus.FAILED)
+            }
+
+            val importedTemplateId = TemplateId(templateKey, CatalogId(importResult.catalogKey, targetId))
+            val imported = GetDocumentTemplate(importedTemplateId).query()
+            assertThat(imported).isNotNull
+            assertThat(imported!!.pdfaEnabled).isFalse()
+        }
+    }
+
+    @Test
+    fun `re-importing a catalog restores pdfa_enabled from the payload, undoing a local disable`() {
+        // Issue #745: the import UPDATE path never touched pdfa_enabled, so a template
+        // disabled locally stayed disabled forever, even across re-imports whose payload
+        // said otherwise. This guards the ON CONFLICT / UPDATE half of the fix.
+        val tenant = createTenant("Pdfa Reimport")
+        val tenantKey = tenant.id
+        val tenantId = TenantId(tenantKey)
+        val catalogKey = CatalogKey.of("pdfa-reimport-catalog")
+        val catalogId = CatalogId(catalogKey, tenantId)
+        val templateKey = TestIdHelpers.nextTemplateId()
+        val templateId = TemplateId(templateKey, catalogId)
+
+        withMediator {
+            CreateCatalog(tenantKey = tenantKey, id = catalogKey, name = "Pdfa Reimport Catalog").execute()
+
+            CreateDocumentTemplate(id = templateId, name = "Pdfa Reimport Template").execute()
+            val variantId = VariantId(VariantKey.INITIAL, templateId)
+            PublishVersion(versionId = VersionId(VersionKey.of(1), variantId)).execute()
+
+            // Export while pdfa is enabled (the default) — the payload's pdfaEnabled is true.
+            val exportResult = ExportCatalogZip(tenantKey = tenantKey, catalogKey = catalogKey).execute()
+
+            // Disable locally.
+            UpdateDocumentTemplate(id = templateId, pdfaEnabled = false).execute()
+            assertThat(GetDocumentTemplate(templateId).query()!!.pdfaEnabled).isFalse()
+
+            // Re-import the same catalog — the payload carries pdfaEnabled=true and must win.
+            val importResult = ImportCatalogZip(
+                tenantKey = tenantKey,
+                zipBytes = exportResult.zipBytes,
+                catalogType = CatalogType.AUTHORED,
+            ).execute()
+            assertThat(importResult.results).allSatisfy { result ->
+                assertThat(result.status).isNotEqualTo(InstallStatus.FAILED)
+            }
+
+            assertThat(GetDocumentTemplate(templateId).query()!!.pdfaEnabled).isTrue()
+        }
+    }
+
     /**
      * A template that embeds the parametrised "greeting" stencil: a stencil node
      * carrying the schema snapshot + a binding for `recipientName`, whose slot holds
@@ -1087,6 +1176,21 @@ class CatalogExportImportTest : IntegrationTestBase() {
             }
         }
         return emptyList()
+    }
+
+    /** Reads a template resource's `pdfaEnabled` field from an export ZIP's resource detail JSON. */
+    private fun readTemplateResourcePdfaEnabled(zipBytes: ByteArray, slug: String): Boolean? {
+        ZipInputStream(zipBytes.inputStream()).use { zin ->
+            var entry = zin.nextEntry
+            while (entry != null) {
+                if (entry.name == "resources/template/$slug.json") {
+                    val root = ObjectMapper().readTree(zin.readBytes())
+                    return root.get("resource")?.get("pdfaEnabled")?.asBoolean()
+                }
+                entry = zin.nextEntry
+            }
+        }
+        return null
     }
 
     private fun stencilContentWithRoot(rootId: String): TemplateDocument {


### PR DESCRIPTION
## Description

Fixes the silent loss of a template's PDF/A setting on catalog exchange:

- **Import** hardcoded `pdfa_enabled = TRUE` on insert and never touched it on re-import — a template with PDF/A deliberately disabled re-enabled itself the next time its catalog was imported.
- **Export** never emitted the setting at all.

The fix threads `pdfaEnabled` through all three plumbing points: `ImportTemplateInput` + the INSERT and **both** update paths (`ON CONFLICT DO UPDATE` and the pre-existence `UPDATE` branch) in `ImportTemplates`, the exported `TemplateResource` in `CatalogContentBuilder`, and both importers (`InstallFromCatalog`, `ImportCatalogZip`).

Tests (both failed against the unfixed code):

- a `pdfaEnabled = false` template exports with the flag in the wire JSON (asserted directly in the ZIP) and imports into a fresh tenant as `false` (insert path);
- a template disabled locally then re-imported from a `true` payload converges back to `true` (the previously-missing update half).

Downstream surfaces inherit the fix: snapshots/upgrading ride `CatalogContentBuilder`/`ImportTemplates`, and the tenant-backup primitive already copies rows faithfully. Bundled demo/system catalogs are unchanged (absent field = `true` default), so no catalog version/fingerprint bump is needed.

## Related Issue(s)

Closes #745

**Depends on epistola-app/epistola-contract#64** — the new `TemplateResource.pdfaEnabled` contract field. This PR is a **draft** because it cannot compile until that PR is merged and released; the `epistola-contract` pin here is still the current `1.0.1` on purpose. Once the contract release exists, a final commit will bump the pin (`gradle/libs.versions.toml` + `modules/editor/package.json` + `pnpm-lock.yaml` together, verified with `checkContractVersionAlignment`), which turns CI green and makes this ready for review.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [ ] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

Verified locally against a locally-published contract build carrying the new field: full `unitTest integrationTest` sweep green, including the extended `CatalogExportImportTest` and the catalog commands package (118 tests).
