### PR TITLE
fix(editor): escape uploaded filenames and stencil names in picker dialogs (stored XSS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **[user]** fix(editor,assets): **Asset picker escapes uploaded filenames.** Stored XSS via
   crafted upload filenames rendered through `innerHTML` is fixed; asset names containing markup
   or control characters are now rejected at upload. (#644)
+- **[user]** fix(editor,stencils): **Stencil picker escapes stencil names, descriptions, and
+  tags.** The same stored-XSS class in the stencil picker is fixed; stencil names and tags with
+  markup or control characters are now rejected at the command boundary (descriptions escape on
+  render but stay free text). (#644)
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer
   processes can emit newline-delimited Logstash, ECS, or GELF output through
   `LOGGING_STRUCTURED_FORMAT_CONSOLE`, including tenant context when available and bounded stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- **[user]** fix(editor,assets): **Asset picker escapes uploaded filenames.** Stored XSS via
+  crafted upload filenames rendered through `innerHTML` is fixed; asset names containing markup
+  or control characters are now rejected at upload. (#644)
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer
   processes can emit newline-delimited Logstash, ECS, or GELF output through
   `LOGGING_STRUCTURED_FORMAT_CONSOLE`, including tenant context when available and bounded stack

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/AssetHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/AssetHandler.kt
@@ -21,6 +21,7 @@ import app.epistola.suite.htmx.isHtmx
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.mediator.query
 import app.epistola.suite.tenants.queries.GetTenant
+import app.epistola.suite.validation.ValidationException
 import jakarta.servlet.http.Part
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
@@ -244,6 +245,9 @@ class AssetHandler(
                 errors["file"] = e.message ?: "That image is too large."
             } catch (e: CatalogReadOnlyException) {
                 errors["catalog"] = e.message ?: "Catalog is read-only"
+            } catch (e: ValidationException) {
+                // Bad file name (markup/control chars #644, over-long #692) → file field, not a 500.
+                errors["file"] = e.message
             }
         }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/api/v1/EpistolaAssetsApiIT.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/api/v1/EpistolaAssetsApiIT.kt
@@ -104,6 +104,33 @@ class EpistolaAssetsApiIT : IntegrationTestBase() {
         assertThat(delete.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
     }
 
+    @Test
+    fun `asset upload rejects a filename containing markup`() {
+        // #644: with no explicit name, the raw filename becomes the asset name.
+        // UploadAsset must reject markup so the stored value can never carry a
+        // payload, and the REST layer must surface that as 400, not 500.
+        val (tenantKey, key) = seedTenantAndKey()
+        val payload = LinkedMultiValueMap<String, Any>().apply {
+            add(
+                "file",
+                object : ByteArrayResource("asset-api-bytes".toByteArray()) {
+                    override fun getFilename() = "evil<img src=x onerror=alert(1)>.png"
+                },
+            )
+            add("mediaType", "image/png")
+        }
+
+        val upload = restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/default/assets",
+            HttpMethod.POST,
+            HttpEntity(payload, multipartHeaders(key)),
+            String::class.java,
+        )
+
+        assertThat(upload.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(upload.body).contains("Name must not contain")
+    }
+
     private fun multipartHeaders(apiKey: String): HttpHeaders = baseHeaders(apiKey).apply {
         contentType = MediaType.MULTIPART_FORM_DATA
     }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/assets/AssetRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/assets/AssetRoutesTest.kt
@@ -64,4 +64,46 @@ class AssetRoutesTest : BaseIntegrationTest() {
             assertThat(response.body).contains("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
         }
     }
+
+    @Test
+    fun `POST assets returns validation error for a filename containing markup`() = fixture {
+        lateinit var testTenant: Tenant
+
+        given {
+            testTenant = tenant("Asset Tenant")
+        }
+
+        whenever {
+            val headers = HttpHeaders()
+            headers.contentType = MediaType.MULTIPART_FORM_DATA
+            headers.accept = listOf(MediaType.APPLICATION_JSON)
+
+            val payload = LinkedMultiValueMap<String, Any>()
+            payload.add(
+                "file",
+                HttpEntity(
+                    object : ByteArrayResource("not-an-image".toByteArray()) {
+                        override fun getFilename(): String = "evil<img src=x onerror=alert(1)>.png"
+                    },
+                    HttpHeaders().apply {
+                        contentType = MediaType.IMAGE_PNG
+                    },
+                ),
+            )
+            payload.add("catalog", "default")
+
+            restTemplate.postForEntity(
+                "/tenants/${testTenant.id}/images",
+                HttpEntity(payload, headers),
+                String::class.java,
+            )
+        }
+
+        then {
+            val response = result<org.springframework.http.ResponseEntity<String>>()
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.headers.contentType).isEqualTo(MediaType.APPLICATION_JSON)
+            assertThat(response.body).contains("Name must not contain")
+        }
+    }
 }

--- a/modules/editor/src/main/typescript/components/image/asset-picker-dialog.test.ts
+++ b/modules/editor/src/main/typescript/components/image/asset-picker-dialog.test.ts
@@ -146,3 +146,69 @@ describe('openAssetPickerDialog catalog selector', () => {
     expect(cb.listAssets).toHaveBeenCalledWith('epistola-demo');
   });
 });
+
+// Regression coverage for issue #644 (stored XSS): asset/catalog names come from
+// raw uploaded filenames and must never be interpolated into innerHTML.
+describe('openAssetPickerDialog XSS hardening (#644)', () => {
+  const MALICIOUS_ASSET_NAME = '"><img src=x onerror=window.__pwned=1>.png';
+  const MALICIOUS_CATALOG_NAME = '"><img src=x onerror=window.__pwned=1>';
+
+  beforeEach(() => {
+    vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(() => {});
+    vi.spyOn(HTMLDialogElement.prototype, 'close').mockImplementation(() => {});
+    (window as unknown as { __pwned?: unknown }).__pwned = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('renders a crafted asset name as inert text, never as markup', async () => {
+    const cb = makeCallbacks();
+    cb.listAssets.mockImplementation(async () => [
+      { ...demoAssets[0], id: 'evil-asset', name: MALICIOUS_ASSET_NAME },
+    ]);
+
+    openAssetPickerDialog(cb);
+    await flush();
+    await flush();
+
+    const dialog = document.querySelector('dialog.asset-picker-dialog');
+    expect(dialog).not.toBeNull();
+
+    const card = dialog!.querySelector<HTMLElement>('[data-asset-id="evil-asset"]')!;
+    expect(card).not.toBeNull();
+
+    const nameEl = card.querySelector<HTMLElement>('.asset-picker-card-name')!;
+    expect(nameEl).not.toBeNull();
+    expect(nameEl.textContent).toBe(MALICIOUS_ASSET_NAME);
+    expect(nameEl.getAttribute('title')).toBe(MALICIOUS_ASSET_NAME);
+
+    // Exactly one <img> (the thumbnail) and no onerror-bearing element anywhere.
+    expect(card.querySelectorAll('img').length).toBe(1);
+    expect(card.querySelector('[onerror]')).toBeNull();
+    expect(dialog!.querySelector('[onerror]')).toBeNull();
+
+    // The malicious markup never actually executed.
+    expect((window as unknown as { __pwned?: unknown }).__pwned).toBeUndefined();
+  });
+
+  it('renders a crafted catalog name as inert text in the catalog select', async () => {
+    const cb = makeCallbacks();
+    cb.listCatalogs.mockResolvedValue([
+      { key: 'epistola-demo', name: MALICIOUS_CATALOG_NAME, type: 'AUTHORED' },
+    ]);
+
+    openAssetPickerDialog(cb);
+    await flush();
+    await flush();
+
+    const select = catalogSelect();
+    const option = select.querySelector('option')!;
+
+    expect(option.textContent).toBe(MALICIOUS_CATALOG_NAME);
+    expect(select.querySelector('[onerror]')).toBeNull();
+    expect((window as unknown as { __pwned?: unknown }).__pwned).toBeUndefined();
+  });
+});

--- a/modules/editor/src/main/typescript/components/image/asset-picker-dialog.ts
+++ b/modules/editor/src/main/typescript/components/image/asset-picker-dialog.ts
@@ -108,12 +108,22 @@ export function openAssetPickerDialog(callbacks: AssetPickerCallbacks): Promise<
         const card = document.createElement('div');
         card.className = 'asset-picker-card';
         card.dataset.assetId = asset.id;
-        card.innerHTML = `
-          <div class="asset-picker-card-img">
-            <img src="${asset.contentUrl}" alt="${asset.name}" loading="lazy" />
-          </div>
-          <div class="asset-picker-card-name" title="${asset.name}">${asset.name}</div>
-        `;
+
+        const imgWrapper = document.createElement('div');
+        imgWrapper.className = 'asset-picker-card-img';
+        const img = document.createElement('img');
+        img.src = asset.contentUrl;
+        img.alt = asset.name;
+        img.loading = 'lazy';
+        imgWrapper.appendChild(img);
+
+        const nameEl = document.createElement('div');
+        nameEl.className = 'asset-picker-card-name';
+        nameEl.title = asset.name;
+        nameEl.textContent = asset.name;
+
+        card.appendChild(imgWrapper);
+        card.appendChild(nameEl);
         card.addEventListener('click', () => {
           // Deselect previous
           grid

--- a/modules/editor/src/main/typescript/components/stencil/stencil-picker-dialog.test.ts
+++ b/modules/editor/src/main/typescript/components/stencil/stencil-picker-dialog.test.ts
@@ -116,3 +116,43 @@ describe('openStencilPickerDialog parameter binding step', () => {
     });
   });
 });
+
+describe('openStencilPickerDialog escapes author-controlled text', () => {
+  const MALICIOUS = '"><img src=x onerror=window.__pwned=1>';
+
+  afterEach(() => {
+    document.querySelectorAll('dialog').forEach((dialog) => dialog.remove());
+    (window as unknown as { __pwned?: unknown }).__pwned = undefined;
+  });
+
+  it('renders a crafted stencil name, description, and tag as inert text', async () => {
+    const evil: StencilSummary = {
+      id: 'evil',
+      catalogKey: 'default',
+      name: `Name ${MALICIOUS}`,
+      description: `Desc ${MALICIOUS}`,
+      tags: [`Tag ${MALICIOUS}`],
+      latestPublishedVersion: 1,
+      latestVersion: 1,
+    };
+    void openStencilPickerDialog({
+      searchStencils: () => Promise.resolve([evil]),
+      listVersions: () => Promise.resolve([VERSION]),
+      getStencilVersion: () => Promise.resolve(versionInfo(undefined)),
+    });
+    await tick();
+
+    const card = pickerDialog().querySelector<HTMLElement>('#stencil-list .stencil-picker-card')!;
+    expect(card).not.toBeNull();
+    expect(card.querySelector('img')).toBeNull();
+    expect(card.querySelector('[onerror]')).toBeNull();
+    expect(card.querySelector('.stencil-picker-card-name')!.textContent).toContain(
+      `Name ${MALICIOUS}`,
+    );
+    expect(card.querySelector('.stencil-picker-card-desc')!.textContent).toBe(`Desc ${MALICIOUS}`);
+    expect(card.querySelector('.stencil-picker-card-tags')!.textContent).toContain(
+      `Tag ${MALICIOUS}`,
+    );
+    expect((window as unknown as { __pwned?: unknown }).__pwned).toBeUndefined();
+  });
+});

--- a/modules/editor/src/main/typescript/components/stencil/stencil-picker-dialog.ts
+++ b/modules/editor/src/main/typescript/components/stencil/stencil-picker-dialog.ts
@@ -23,6 +23,19 @@ import type { FieldPath } from '../../engine/schema-paths.js';
 import { renderBindingRow } from './binding-row.js';
 import { missingRequiredParameters } from './parameter-requirements.js';
 
+const HTML_ENTITIES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/** Escape author-controlled text for HTML element-content interpolation. */
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => HTML_ENTITIES[c] ?? c);
+}
+
 export type StencilPickerResult =
   | { action: 'create-new'; ref: StencilRef; version: number }
   | {
@@ -196,7 +209,9 @@ export async function openStencilPickerDialog(
 
         const tags =
           stencil.tags.length > 0
-            ? stencil.tags.map((t) => `<span class="stencil-picker-tag">${t}</span>`).join('')
+            ? stencil.tags
+                .map((t) => `<span class="stencil-picker-tag">${escapeHtml(t)}</span>`)
+                .join('')
             : '';
         const versionLabel = stencil.latestPublishedVersion
           ? `v${stencil.latestPublishedVersion}`
@@ -213,12 +228,12 @@ export async function openStencilPickerDialog(
           : '';
 
         card.innerHTML = `
-          <div class="stencil-picker-card-name">${stencil.name} ${catalogBadge}${recursionBadge}</div>
+          <div class="stencil-picker-card-name">${escapeHtml(stencil.name)} ${catalogBadge}${recursionBadge}</div>
           <div class="stencil-picker-card-meta">
             <span class="stencil-picker-card-version">${versionLabel}</span>
             ${tags ? `<span class="stencil-picker-card-tags">${tags}</span>` : ''}
           </div>
-          ${stencil.description ? `<div class="stencil-picker-card-desc">${stencil.description}</div>` : ''}
+          ${stencil.description ? `<div class="stencil-picker-card-desc">${escapeHtml(stencil.description)}</div>` : ''}
         `;
 
         if (!isRecursive) {

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/commands/UploadAsset.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/assets/commands/UploadAsset.kt
@@ -59,6 +59,10 @@ data class UploadAsset(
         // Column ceiling (#692): assets.name is VARCHAR(255). The blank check stays in
         // the handler; this bounds length so an over-long name never overflows the column.
         validate("name", name.length <= MAX_NAME_COLUMN_LENGTH) { "Name must be $MAX_NAME_COLUMN_LENGTH characters or less" }
+        // Load-bearing for the stored-XSS fix (#644) — don't relax without reading it.
+        validate("name", name.none { it == '<' || it == '>' || it.isISOControl() }) {
+            "Name must not contain '<', '>', or control characters"
+        }
     }
 
     override fun equals(other: Any?): Boolean {

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/commands/CreateStencil.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/commands/CreateStencil.kt
@@ -48,12 +48,19 @@ data class CreateStencil(
     init {
         validate("name", name.isNotBlank()) { "Name is required" }
         validate("name", name.length <= MAX_NAME_LENGTH) { "Name must be $MAX_NAME_LENGTH characters or less" }
+        // Load-bearing for the stencil-picker stored-XSS fix — don't relax without reading it.
+        validate("name", name.none { it == '<' || it == '>' || it.isISOControl() }) {
+            "Name must not contain '<', '>', or control characters"
+        }
         description?.let {
             validate("description", it.length <= 1000) { "Description must be 1000 characters or less" }
         }
         validate("tags", tags.size <= 20) { "Maximum 20 tags allowed" }
         tags.forEachIndexed { i, tag ->
             validate("tags[$i]", tag.length <= 50) { "Tag must be 50 characters or less" }
+            validate("tags[$i]", tag.none { it == '<' || it == '>' || it.isISOControl() }) {
+                "Tag must not contain '<', '>', or control characters"
+            }
         }
     }
 }

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/commands/UpdateStencil.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/stencils/commands/UpdateStencil.kt
@@ -39,6 +39,10 @@ data class UpdateStencil(
         name?.let {
             validate("name", it.isNotBlank()) { "Name cannot be blank" }
             validate("name", it.length <= MAX_NAME_LENGTH) { "Name must be $MAX_NAME_LENGTH characters or less" }
+            // Load-bearing for the stencil-picker stored-XSS fix — don't relax without reading it.
+            validate("name", it.none { c -> c == '<' || c == '>' || c.isISOControl() }) {
+                "Name must not contain '<', '>', or control characters"
+            }
         }
         description?.let {
             validate("description", it.length <= 1000) { "Description must be 1000 characters or less" }
@@ -47,6 +51,9 @@ data class UpdateStencil(
             validate("tags", it.size <= 20) { "Maximum 20 tags allowed" }
             it.forEachIndexed { i, tag ->
                 validate("tags[$i]", tag.length <= 50) { "Tag must be 50 characters or less" }
+                validate("tags[$i]", tag.none { c -> c == '<' || c == '>' || c.isISOControl() }) {
+                    "Tag must not contain '<', '>', or control characters"
+                }
             }
         }
     }

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/assets/commands/UploadAssetNameValidationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/assets/commands/UploadAssetNameValidationTest.kt
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.assets.commands
+
+import app.epistola.suite.assets.AssetMediaType
+import app.epistola.suite.common.ids.CatalogKey
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.validation.ValidationException
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.fail
+
+/**
+ * Defense-in-depth server-side guard for issue #644 (stored XSS in the editor's
+ * asset picker dialog): the raw uploaded filename becomes `UploadAsset.name`, which
+ * the catalog/API surfaces back to any viewer verbatim. The client fix (rendering
+ * via DOM properties/`textContent` instead of `innerHTML`) is the primary fix; this
+ * command-level check rejects the payload shape at the source so it never reaches
+ * storage, independent of how a future render path might treat it.
+ *
+ * Pure unit test — no Spring, no DB, same shape as `NameLengthValidationTest`.
+ */
+class UploadAssetNameValidationTest {
+
+    private val tenantKey = TenantKey("testtenant")
+    private val catalogKey = CatalogKey.DEFAULT
+    private val mediaType = AssetMediaType.fromMimeType("image/png")
+
+    private fun upload(name: String) = UploadAsset(
+        tenantId = tenantKey,
+        name = name,
+        mediaType = mediaType,
+        content = ByteArray(1),
+        width = null,
+        height = null,
+        catalogKey = catalogKey,
+    )
+
+    @Test
+    fun `rejects a name containing markup`() {
+        val thrown = assertFailsWith<ValidationException> {
+            upload("\"><img src=x onerror=window.__pwned=1>.png")
+        }
+        if (thrown.field != "name") {
+            fail("Expected the 'name' field to be rejected, but '${thrown.field}' was rejected instead: ${thrown.message}")
+        }
+    }
+
+    @Test
+    fun `rejects a name containing a control character`() {
+        // Built via Char(0)/Char(1) rather than a raw literal, to keep control bytes
+        // out of the source file itself.
+        val nulByte = Char(0)
+        val withNul = assertFailsWith<ValidationException> { upload("evil$nulByte.png") }
+        if (withNul.field != "name") fail("Expected 'name' rejection for a NUL byte, got '${withNul.field}': ${withNul.message}")
+
+        val withNewline = assertFailsWith<ValidationException> { upload("evil\n.png") }
+        if (withNewline.field != "name") fail("Expected 'name' rejection for a newline, got '${withNewline.field}': ${withNewline.message}")
+    }
+
+    @Test
+    fun `accepts an ordinary filename`() {
+        val asset = upload("logo (v2).png")
+        assertEquals("logo (v2).png", asset.name)
+    }
+}

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/commands/StencilNameValidationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/commands/StencilNameValidationTest.kt
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.stencils.commands
+
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.StencilId
+import app.epistola.suite.common.ids.StencilKey
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.validation.ValidationException
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.fail
+
+/**
+ * Server-side guard for the stencil-picker stored XSS. `name` and `tags` are short
+ * labels, rejected like the asset `name`; `description` is deliberately not rejected
+ * (free text where '<' is legitimate) and relies on the client escape alone.
+ */
+class StencilNameValidationTest {
+
+    private val stencilId = StencilId(StencilKey.of("teststencil"), CatalogId.default(TenantId(TenantKey.of("testtenant"))))
+
+    @Test
+    fun `create rejects a name containing markup`() {
+        val thrown = assertFailsWith<ValidationException> {
+            CreateStencil(id = stencilId, name = "\"><img src=x onerror=alert(1)>")
+        }
+        if (thrown.field != "name") fail("Expected 'name' rejection, got '${thrown.field}': ${thrown.message}")
+    }
+
+    @Test
+    fun `create rejects a name containing a control character`() {
+        val thrown = assertFailsWith<ValidationException> {
+            CreateStencil(id = stencilId, name = "evil${Char(0)}")
+        }
+        if (thrown.field != "name") fail("Expected 'name' rejection, got '${thrown.field}': ${thrown.message}")
+    }
+
+    @Test
+    fun `create rejects a tag containing markup`() {
+        val thrown = assertFailsWith<ValidationException> {
+            CreateStencil(id = stencilId, name = "Fine", tags = listOf("ok", "<img onerror=alert(1)>"))
+        }
+        if (thrown.field != "tags[1]") fail("Expected 'tags[1]' rejection, got '${thrown.field}': ${thrown.message}")
+    }
+
+    @Test
+    fun `create accepts an ordinary name, tags, and a description containing angle brackets`() {
+        val cmd = CreateStencil(
+            id = stencilId,
+            name = "Invoice Header",
+            description = "Shows when a < b in the totals row",
+            tags = listOf("billing", "header"),
+        )
+        assertEquals("Invoice Header", cmd.name)
+        assertEquals("Shows when a < b in the totals row", cmd.description)
+    }
+
+    @Test
+    fun `update rejects a name containing markup`() {
+        val thrown = assertFailsWith<ValidationException> {
+            UpdateStencil(id = stencilId, name = "<script>")
+        }
+        if (thrown.field != "name") fail("Expected 'name' rejection, got '${thrown.field}': ${thrown.message}")
+    }
+
+    @Test
+    fun `update rejects a tag containing markup`() {
+        val thrown = assertFailsWith<ValidationException> {
+            UpdateStencil(id = stencilId, tags = listOf("<b>"))
+        }
+        if (thrown.field != "tags[0]") fail("Expected 'tags[0]' rejection, got '${thrown.field}': ${thrown.message}")
+    }
+
+    @Test
+    fun `update accepts an ordinary name and a description containing angle brackets`() {
+        val cmd = UpdateStencil(id = stencilId, name = "Renamed", description = "keeps a < b intact")
+        assertEquals("Renamed", cmd.name)
+        assertEquals("keeps a < b intact", cmd.description)
+    }
+}


### PR DESCRIPTION
## Description

Fixes two instances of the same **stored, cross-tenant XSS** in the editor's picker dialogs: values derived from user/author input were interpolated into the DOM via `innerHTML` without escaping, and are browsable across tenants via subscribed catalogs — so a low-privilege author could plant a payload that executes in any viewer's authenticated editor session.

### 1. Asset picker (`asset-picker-dialog.ts`)

Asset names come from the raw uploaded filename (`submittedFileName` → `UploadAsset.name`).

- **Client (primary):** `renderGrid` builds each card with DOM APIs (`createElement`, `img.src`/`alt`, `textContent`/`title`) instead of interpolating the name into `innerHTML`.
- **Server (defense in depth):** `UploadAsset` rejects names containing `<`, `>`, or control characters at the command `init`. Both the UI handler and the REST API (`EpistolaAssetsApi.uploadAsset`, which falls back to `file.originalFilename`) dispatch this command, so every upload path is covered.
- UI handler now surfaces the rejection as a file-field error instead of a 500 (REST already mapped it to 400).

### 2. Stencil picker (`stencil-picker-dialog.ts`)

The same sink for a stencil's **name, description, and tags** (author input).

- **Client (primary):** name, description, and tags are escaped on render (HTML element-content context).
- **Server (defense in depth):** `CreateStencil`/`UpdateStencil` reject `<`, `>`, and control characters in **name and tags**. **Description is deliberately not rejected** — it is free text where `<` is legitimate ("a < b") — so it relies on the client escape alone.

## Related Issue(s)

Closes #644

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)

## Checklist

- [x] My code follows the project's code style (ktlint, EditorConfig)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally (`gradle test`)
- [ ] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a notable change
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

**Tests at every layer of each fix (each regression test red-checked against the unfixed code before landing):**

| Layer | Asset | Stencil |
| --- | --- | --- |
| Command (`init`) unit | `UploadAssetNameValidationTest` | `StencilNameValidationTest` |
| UI integration | `AssetRoutesTest` (→ 400 field error) | — |
| REST integration | `EpistolaAssetsApiIT` (→ 400) | — |
| Client (vitest, happy-dom) | `asset-picker-dialog.test.ts` | `stencil-picker-dialog.test.ts` |

The `StencilNameValidationTest` includes a case asserting a description containing `<` is **accepted**, locking in the deliberate name/tags-vs-description asymmetry.

**Dialog-family audit:** the other four hand-rolled dialogs (`table`, `datatable`, `parameter-bindings`, `parameter-definitions`) were audited and interpolate only compile-time constants or already-escaped values (`binding-row.ts` uses `escapeHtml`) — no live sink. Asset and stencil pickers were the only two.

**Out of scope (deliberate):**
- **Catalog-import paths** (`ImportStencil`, and `ImportAsset`'s re-import `UPDATE`) are not hardened server-side. The client escape is source-agnostic and neutralizes imported/subscribed-catalog content regardless of how it reached the DB, so there is no live XSS; blocking on import would break restore/round-trip fidelity (a catalog exported before these guards must still import).
- A future **Lit conversion** of the imperative dialog family (lit-html escapes by default) would make this sink class impossible by construction — a separate refactor, not security work.

Docs checkbox left unchecked: escaping/validation fix with no doc-facing surface.
