### PR TITLE
feat(data-contracts): require at least one example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- **[user]** feat(data contracts): **Every authored data contract keeps at least one example.**
+  Saving or publishing without an example is rejected with an actionable validation error, the
+  editor highlights the requirement, and the final example can no longer be deleted. Existing
+  empty contract versions remain readable and importable.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer
   processes can emit newline-delimited Logstash, ECS, or GELF output through
   `LOGGING_STRUCTURED_FORMAT_CONSOLE`, including tenant context when available and bounded stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 - **[user]** feat(data contracts): **Every authored data contract keeps at least one example.**
   Saving or publishing without an example is rejected with an actionable validation error, the
-  editor highlights the requirement, and the final example can no longer be deleted. Existing
-  empty contract versions remain readable and importable.
+  editor highlights the requirement, and replaces the final example's delete action with an
+  explanation of why it must remain. Existing empty contract versions remain readable and
+  importable.
 - **[user]** fix(data contracts): **Examples can be deleted directly from a published contract.**
   The editor now starts a draft automatically before applying the deletion.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
   Saving or publishing without an example is rejected with an actionable validation error, the
   editor highlights the requirement, and replaces the final example's delete action with an
   explanation of why it must remain. Unsaved examples are removed locally and do not make saved
-  examples prematurely deletable. A save action beside the example undo/redo controls avoids
-  scrolling back to the schema toolbar. Existing empty contract versions remain readable and
-  importable.
+  examples prematurely deletable. A sticky contract-wide save bar identifies whether schema or
+  examples have unsaved changes without conflating their separate undo histories. Existing empty
+  contract versions remain readable and importable.
 - **[user]** fix(data contracts): **Examples can be deleted directly from a published contract.**
   The editor now starts a draft automatically before applying the deletion.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
   Saving or publishing without an example is rejected with an actionable validation error, the
   editor highlights the requirement, and replaces the final example's delete action with an
   explanation of why it must remain. Unsaved examples are removed locally and do not make saved
-  examples prematurely deletable. Existing empty contract versions remain readable and importable.
+  examples prematurely deletable. A save action beside the example undo/redo controls avoids
+  scrolling back to the schema toolbar. Existing empty contract versions remain readable and
+  importable.
 - **[user]** fix(data contracts): **Examples can be deleted directly from a published contract.**
   The editor now starts a draft automatically before applying the deletion.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   Saving or publishing without an example is rejected with an actionable validation error, the
   editor highlights the requirement, and the final example can no longer be deleted. Existing
   empty contract versions remain readable and importable.
+- **[user]** fix(data contracts): **Examples can be deleted directly from a published contract.**
+  The editor now starts a draft automatically before applying the deletion.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer
   processes can emit newline-delimited Logstash, ECS, or GELF output through
   `LOGGING_STRUCTURED_FORMAT_CONSOLE`, including tenant context when available and bounded stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
   Saving or publishing without an example is rejected with an actionable validation error, the
   editor highlights the requirement, and replaces the final example's delete action with an
   explanation of why it must remain. Unsaved examples are removed locally and do not make saved
-  examples prematurely deletable. A sticky contract-wide save bar identifies whether schema or
-  examples have unsaved changes without conflating their separate undo histories. Existing empty
-  contract versions remain readable and importable.
+  examples prematurely deletable. A sticky contract action bar keeps **Save draft**, editing,
+  publishing, usage, and history controls visible, and identifies whether schema or examples have
+  unsaved changes without conflating their separate undo histories. Existing empty contract
+  versions remain readable and importable.
 - **[user]** fix(data contracts): **Examples can be deleted directly from a published contract.**
   The editor now starts a draft automatically before applying the deletion.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - **[user]** feat(data contracts): **Every authored data contract keeps at least one example.**
   Saving or publishing without an example is rejected with an actionable validation error, the
   editor highlights the requirement, and replaces the final example's delete action with an
-  explanation of why it must remain. Existing empty contract versions remain readable and
-  importable.
+  explanation of why it must remain. Unsaved examples are removed locally and do not make saved
+  examples prematurely deletable. Existing empty contract versions remain readable and importable.
 - **[user]** fix(data contracts): **Examples can be deleted directly from a published contract.**
   The editor now starts a draft automatically before applying the deletion.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ContractVersionHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ContractVersionHandler.kt
@@ -4,6 +4,7 @@
 
 package app.epistola.suite.templates
 
+import app.epistola.suite.api.v1.toValidationProblemBody
 import app.epistola.suite.common.ids.CatalogId
 import app.epistola.suite.common.ids.CatalogKey
 import app.epistola.suite.common.ids.TemplateId
@@ -22,6 +23,7 @@ import app.epistola.suite.templates.contracts.queries.GetLatestContractVersion
 import app.epistola.suite.templates.contracts.queries.GetLatestPublishedContractVersion
 import app.epistola.suite.templates.contracts.queries.ListContractVersions
 import app.epistola.suite.templates.model.DataExample
+import app.epistola.suite.validation.ValidationException
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.function.ServerRequest
@@ -73,12 +75,18 @@ class ContractVersionHandler(
         CreateContractVersion(templateId = templateId).execute()
             ?: return ServerResponse.notFound().build()
 
-        val result = UpdateContractVersion(
-            templateId = templateId,
-            dataModel = updateRequest.dataModel,
-            dataExamples = updateRequest.dataExamples,
-            forceUpdate = updateRequest.forceUpdate ?: false,
-        ).execute() ?: return ServerResponse.notFound().build()
+        val result = try {
+            UpdateContractVersion(
+                templateId = templateId,
+                dataModel = updateRequest.dataModel,
+                dataExamples = updateRequest.dataExamples,
+                forceUpdate = updateRequest.forceUpdate ?: false,
+            ).execute() ?: return ServerResponse.notFound().build()
+        } catch (e: ValidationException) {
+            return ServerResponse.badRequest()
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(e.toValidationProblemBody(request.servletRequest()))
+        }
 
         val response = mutableMapOf<String, Any?>(
             "success" to true,
@@ -118,8 +126,14 @@ class ContractVersionHandler(
         val tabUrl = "/tenants/${templateId.tenantKey.value}/templates/${templateId.catalogKey.value}/${templateId.key.value}/data-contract"
 
         // Publish directly with the confirmed flag
-        val result = PublishContractVersion(templateId = templateId, confirmed = confirmed).execute()
-            ?: return ServerResponse.notFound().build()
+        val result = try {
+            PublishContractVersion(templateId = templateId, confirmed = confirmed).execute()
+                ?: return ServerResponse.notFound().build()
+        } catch (e: ValidationException) {
+            return ServerResponse.badRequest()
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(e.toValidationProblemBody(request.servletRequest()))
+        }
 
         if (result.published) {
             if (isHtmx) {

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ContractVersionHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/ContractVersionHandler.kt
@@ -34,6 +34,7 @@ import tools.jackson.databind.node.ObjectNode
 @Component
 class ContractVersionHandler(
     private val objectMapper: ObjectMapper,
+    private val detailHelper: TemplateDetailHelper,
 ) {
     private fun resolveTemplateId(request: ServerRequest): TemplateId {
         val tenantId = TenantId(TenantKey.of(request.pathVariable("tenantId")))
@@ -200,7 +201,9 @@ class ContractVersionHandler(
      * GET /{catalogId}/{id}/contract/status-bar — status bar fragment (HTMX).
      */
     fun statusBar(request: ServerRequest): ServerResponse {
-        val templateId = resolveTemplateId(request)
+        val ctx = detailHelper.loadContext(request) ?: return ServerResponse.notFound().build()
+        val templateId = ctx.templateId
+        val editMode = request.params().getFirst("edit") == "true"
         val contractVersion = GetLatestContractVersion(templateId = templateId).query()
         val draftContract = GetDraftContractVersion(templateId = templateId).query()
         val latestPublished = GetLatestPublishedContractVersion(templateId = templateId).query()
@@ -216,8 +219,8 @@ class ContractVersionHandler(
                 "contractVersionId" to contractVersion?.id?.value
                 "contractVersionStatus" to contractVersion?.status?.name?.lowercase()
                 "hasDraftContract" to (draftContract != null)
-                "editable" to true
-                "editMode" to false
+                "editable" to ctx.editable
+                "editMode" to editMode
                 "hasOutdatedVersions" to usage.versions.any {
                     it.status == "published" && it.contractVersion != latestPublishedId && latestPublishedId != null
                 }

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
@@ -43,6 +43,7 @@ import app.epistola.suite.templates.commands.DeleteDataExample
 import app.epistola.suite.templates.commands.DeleteDocumentTemplate
 import app.epistola.suite.templates.commands.UpdateDataExample
 import app.epistola.suite.templates.commands.UpdateDocumentTemplate
+import app.epistola.suite.templates.contracts.commands.CreateContractVersion
 import app.epistola.suite.templates.contracts.queries.GetLatestContractVersion
 import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.model.DataExamples
@@ -655,6 +656,11 @@ class DocumentTemplateHandler(
         val templateId = request.templateId(tenantId)
             ?: return ServerResponse.badRequest().build()
         val exampleId = request.pathVariable("exampleId")
+
+        // The editor can show examples from the latest published contract when no draft exists yet.
+        // Materialize that published contract as a draft before applying the deletion.
+        CreateContractVersion(templateId = templateId).execute()
+            ?: return ServerResponse.notFound().build()
 
         val result = try {
             DeleteDataExample(

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/handlers/DocumentTemplateHandler.kt
@@ -4,6 +4,7 @@
 
 package app.epistola.suite.templates
 
+import app.epistola.suite.api.v1.toValidationProblemBody
 import app.epistola.suite.attributes.queries.ListAttributeDefinitions
 import app.epistola.suite.catalog.Catalog
 import app.epistola.suite.catalog.CatalogType
@@ -59,6 +60,7 @@ import app.epistola.suite.tenants.queries.GetTenant
 import app.epistola.suite.themes.BlockStylePresets
 import app.epistola.suite.themes.ThemeStyleResolver
 import app.epistola.suite.themes.queries.ListThemes
+import app.epistola.suite.validation.ValidationException
 import app.epistola.template.model.DocumentStyles
 import app.epistola.template.model.PageSettings
 import org.springframework.http.MediaType
@@ -654,10 +656,16 @@ class DocumentTemplateHandler(
             ?: return ServerResponse.badRequest().build()
         val exampleId = request.pathVariable("exampleId")
 
-        val result = DeleteDataExample(
-            templateId = templateId,
-            exampleId = exampleId,
-        ).execute() ?: return ServerResponse.notFound().build()
+        val result = try {
+            DeleteDataExample(
+                templateId = templateId,
+                exampleId = exampleId,
+            ).execute() ?: return ServerResponse.notFound().build()
+        } catch (e: ValidationException) {
+            return ServerResponse.badRequest()
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(e.toValidationProblemBody(request.servletRequest()))
+        }
 
         return if (result.deleted) {
             ServerResponse.noContent().build()

--- a/apps/epistola/src/main/resources/static/css/navigation.css
+++ b/apps/epistola/src/main/resources/static/css/navigation.css
@@ -99,3 +99,44 @@
   flex-shrink: 0;
   flex-wrap: wrap;
 }
+
+/* ── Data contract actions ───────────────────────────────────────────── */
+
+.contract-status-bar {
+  position: sticky;
+  top: 48px;
+  z-index: var(--ep-z-sticky);
+  display: flex;
+  align-items: center;
+  gap: var(--ep-space-3);
+  flex-wrap: wrap;
+  padding: var(--ep-space-2) var(--ep-space-3);
+  margin-bottom: var(--ep-space-3);
+  border: 1px solid var(--ep-stone-200);
+  border-radius: var(--ep-radius-md);
+  background: color-mix(in srgb, var(--ep-white) 96%, transparent);
+  box-shadow: var(--ep-shadow-sm);
+  backdrop-filter: blur(8px);
+  font-size: var(--ep-text-sm);
+}
+
+.contract-status-save-controls {
+  display: flex;
+  flex: 1 1 28rem;
+  min-width: 0;
+}
+
+.contract-status-spacer {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 640px) {
+  .contract-status-save-controls {
+    flex-basis: 100%;
+    order: 2;
+  }
+
+  .contract-status-spacer {
+    display: none;
+  }
+}

--- a/apps/epistola/src/main/resources/static/js/pages/template-detail.js
+++ b/apps/epistola/src/main/resources/static/js/pages/template-detail.js
@@ -337,10 +337,15 @@
 
     const statusBar = document.getElementById('contract-status-bar');
     const statusBarUrl = statusBar && statusBar.dataset ? statusBar.dataset.statusUrl : undefined;
+    let editorInstance;
 
-    function refreshStatusBar() {
+    async function refreshStatusBar() {
       if (statusBarUrl && typeof htmx !== 'undefined') {
-        htmx.ajax('GET', statusBarUrl, { target: '#contract-status-bar', swap: 'outerHTML' });
+        await htmx.ajax('GET', statusBarUrl, {
+          target: '#contract-status-bar',
+          swap: 'outerHTML',
+        });
+        editorInstance?.setSaveControlsContainer(document.getElementById('contract-save-controls'));
       }
     }
 
@@ -351,12 +356,13 @@
     const contractBasePath = `/tenants/${tenantId}/templates/${catalogId}/${templateId}/contract`;
     const jsonHeaders = { 'Content-Type': 'application/json', 'X-XSRF-TOKEN': csrfToken() };
 
-    mountDataContractEditor({
+    editorInstance = mountDataContractEditor({
       container: container,
       templateId: templateId,
       initialSchema: initialSchema,
       initialExamples: initialExamples,
       readonly: readonly,
+      saveControlsContainer: document.getElementById('contract-save-controls'),
       callbacks: readonly
         ? {}
         : {
@@ -378,7 +384,7 @@
                   };
                 }
                 const result = await response.json();
-                refreshStatusBar();
+                await refreshStatusBar();
                 return { success: true, warnings: result.warnings };
               } catch (e) {
                 return { success: false, error: e.message };
@@ -400,7 +406,7 @@
                   };
                 }
                 const result = await response.json();
-                refreshStatusBar();
+                await refreshStatusBar();
                 return { success: true, warnings: result.warnings };
               } catch (e) {
                 return { success: false };

--- a/apps/epistola/src/main/resources/static/js/pages/template-detail.js
+++ b/apps/epistola/src/main/resources/static/js/pages/template-detail.js
@@ -371,7 +371,11 @@
                 });
                 if (!response.ok) {
                   const err = await response.json();
-                  return { success: false, error: err.message, warnings: err.warnings };
+                  return {
+                    success: false,
+                    error: err.detail ?? err.message,
+                    warnings: err.warnings,
+                  };
                 }
                 const result = await response.json();
                 refreshStatusBar();
@@ -389,7 +393,11 @@
                 });
                 if (!response.ok) {
                   const err = await response.json();
-                  return { success: false, warnings: err.warnings };
+                  return {
+                    success: false,
+                    error: err.detail ?? err.message,
+                    warnings: err.warnings,
+                  };
                 }
                 const result = await response.json();
                 refreshStatusBar();

--- a/apps/epistola/src/main/resources/static/js/pages/template-detail.js
+++ b/apps/epistola/src/main/resources/static/js/pages/template-detail.js
@@ -337,7 +337,6 @@
 
     const statusBar = document.getElementById('contract-status-bar');
     const statusBarUrl = statusBar && statusBar.dataset ? statusBar.dataset.statusUrl : undefined;
-    let editorInstance;
 
     async function refreshStatusBar() {
       if (statusBarUrl && typeof htmx !== 'undefined') {
@@ -345,7 +344,6 @@
           target: '#contract-status-bar',
           swap: 'outerHTML',
         });
-        editorInstance?.setSaveControlsContainer(document.getElementById('contract-save-controls'));
       }
     }
 
@@ -356,7 +354,7 @@
     const contractBasePath = `/tenants/${tenantId}/templates/${catalogId}/${templateId}/contract`;
     const jsonHeaders = { 'Content-Type': 'application/json', 'X-XSRF-TOKEN': csrfToken() };
 
-    editorInstance = mountDataContractEditor({
+    mountDataContractEditor({
       container: container,
       templateId: templateId,
       initialSchema: initialSchema,

--- a/apps/epistola/src/main/resources/templates/templates/detail/contract-status-bar.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail/contract-status-bar.html
@@ -14,7 +14,7 @@
             </span>
 
             <!-- Editor-owned save state and actions are rendered here. -->
-            <div th:if="${editMode && editable}" id="contract-save-controls"
+            <div th:if="${editMode && editable}" id="contract-save-controls" hx-preserve
                  class="contract-status-save-controls" role="region"
                  aria-label="Data contract save controls"></div>
 

--- a/apps/epistola/src/main/resources/templates/templates/detail/contract-status-bar.html
+++ b/apps/epistola/src/main/resources/templates/templates/detail/contract-status-bar.html
@@ -3,16 +3,8 @@
 <body>
     <th:block th:fragment="content">
         <div id="contract-status-bar"
-             th:data-status-url="@{/tenants/{tenantId}/templates/{catalogId}/{id}/contract/status-bar(tenantId=${tenantId},catalogId=${catalogId},id=${template.id})}"
-             class="ep-row ep-gap-3" style="padding: var(--ep-space-2) var(--ep-space-3); margin-bottom: var(--ep-space-3); border: 1px solid var(--ep-stone-200); border-radius: var(--ep-radius-md); font-size: var(--ep-text-sm);">
-
-            <!-- Edit mode: Done button -->
-            <th:block th:if="${editMode}">
-                <a th:href="@{/tenants/{tenantId}/templates/{catalogId}/{id}/data-contract(tenantId=${tenantId},catalogId=${catalogId},id=${template.id})}"
-                   class="ep-btn ep-btn-ghost ep-btn-sm" hx-boost="false">
-                    &larr; Done Editing
-                </a>
-            </th:block>
+             th:data-status-url="@{/tenants/{tenantId}/templates/{catalogId}/{id}/contract/status-bar(tenantId=${tenantId},catalogId=${catalogId},id=${template.id},edit=${editMode})}"
+             class="contract-status-bar">
 
             <!-- Version + status -->
             <span th:if="${contractVersionId != null}">
@@ -20,6 +12,19 @@
                 <span th:if="${contractVersionStatus == 'draft'}" class="badge badge-primary" style="margin-left: var(--ep-space-1);">Draft</span>
                 <span th:if="${contractVersionStatus == 'published'}" class="badge badge-success" style="margin-left: var(--ep-space-1);">Published</span>
             </span>
+
+            <!-- Editor-owned save state and actions are rendered here. -->
+            <div th:if="${editMode && editable}" id="contract-save-controls"
+                 class="contract-status-save-controls" role="region"
+                 aria-label="Data contract save controls"></div>
+
+            <!-- Edit mode: leave editing without publishing. -->
+            <th:block th:if="${editMode}">
+                <a th:href="@{/tenants/{tenantId}/templates/{catalogId}/{id}/data-contract(tenantId=${tenantId},catalogId=${catalogId},id=${template.id})}"
+                   class="ep-btn ep-btn-outline ep-btn-sm" hx-boost="false">
+                    Done editing
+                </a>
+            </th:block>
 
             <!-- View mode actions -->
             <th:block th:if="${!editMode}">
@@ -42,7 +47,7 @@
                 </th:block>
             </th:block>
 
-            <span style="flex: 1;"></span>
+            <span class="contract-status-spacer"></span>
 
             <!-- Usage + History (always visible) -->
             <th:block th:if="${hasOutdatedVersions}">

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/api/v1/EpistolaTemplateApiIT.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/api/v1/EpistolaTemplateApiIT.kt
@@ -202,7 +202,10 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         val patch = restTemplate.exchange(
             "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
             HttpMethod.PATCH,
-            HttpEntity("""{"dataModel": $dataModel}""", baseHeaders(key)),
+            HttpEntity(
+                """{"dataModel": $dataModel, "dataExamples": [{"id":"ex1","name":"Example 1","data":{"name":"Ada"}}]}""",
+                baseHeaders(key),
+            ),
             String::class.java,
         )
         assertThat(patch.statusCode).isEqualTo(HttpStatus.OK)
@@ -217,6 +220,33 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         assertThat(get.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(JsonPath.read<String>(get.body!!, "$.dataModel.type")).isEqualTo("object")
         assertThat(JsonPath.read<String>(get.body!!, "$.dataModel.properties.name.type")).isEqualTo("string")
+    }
+
+    @Test
+    fun `update template contract without an example returns required example problem`() {
+        val (tenantKey, key) = seedTenantAndKey()
+        val slug = "required-example-${randomSuffix()}"
+
+        restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/default/templates",
+            HttpMethod.POST,
+            HttpEntity("""{"id": "$slug", "name": "Required Example"}""", baseHeaders(key)),
+            String::class.java,
+        )
+
+        val response = restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
+            HttpMethod.PATCH,
+            HttpEntity("""{"dataModel":{"type":"object"}}""", baseHeaders(key)),
+            String::class.java,
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.headers.contentType?.includes(MediaType.APPLICATION_PROBLEM_JSON)).isTrue()
+        assertThat(JsonPath.read<String>(response.body!!, "$.type"))
+            .isEqualTo("https://epistola.app/errors/data-example-required")
+        assertThat(JsonPath.read<String>(response.body!!, "$.detail"))
+            .isEqualTo("At least one data example is required")
     }
 
     @Test
@@ -291,12 +321,16 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         restTemplate.exchange(
             "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
             HttpMethod.PATCH,
-            HttpEntity("""{"dataModel": {"type":"object","properties":{"name":{"type":"string"}}}}""", baseHeaders(key)),
+            HttpEntity(
+                """{"dataModel":{"type":"object","properties":{"name":{"type":"string"}}},"dataExamples":[{"id":"ex1","name":"Example 1","data":{"name":"Ada"}}]}""",
+                baseHeaders(key),
+            ),
             String::class.java,
         )
 
         // Change name:string -> name:integer is a breaking type change.
-        val breaking = """{"dataModel": {"type":"object","properties":{"name":{"type":"integer"}}}}"""
+        val breaking =
+            """{"dataModel":{"type":"object","properties":{"name":{"type":"integer"}}},"dataExamples":[{"id":"ex1","name":"Example 1","data":{"name":42}}]}"""
         val rejected = restTemplate.exchange(
             "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
             HttpMethod.PATCH,
@@ -333,11 +367,15 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         restTemplate.exchange(
             "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
             HttpMethod.PATCH,
-            HttpEntity("""{"dataModel": {"type":"object","properties":{"name":{"type":"string"}}}}""", baseHeaders(key)),
+            HttpEntity(
+                """{"dataModel":{"type":"object","properties":{"name":{"type":"string"}}},"dataExamples":[{"id":"ex1","name":"Example 1","data":{"name":"Ada"}}]}""",
+                baseHeaders(key),
+            ),
             String::class.java,
         )
 
-        val breaking = """{"dataModel": {"type":"object","properties":{"name":{"type":"integer"}}}, "forceUpdate": true}"""
+        val breaking =
+            """{"dataModel":{"type":"object","properties":{"name":{"type":"integer"}}},"dataExamples":[{"id":"ex1","name":"Example 1","data":{"name":42}}],"forceUpdate":true}"""
         val response = restTemplate.exchange(
             "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
             HttpMethod.PATCH,
@@ -367,7 +405,10 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         restTemplate.exchange(
             "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
             HttpMethod.PATCH,
-            HttpEntity("""{"dataModel": {"type":"object","properties":{"name":{"type":"string"}}}}""", baseHeaders(key)),
+            HttpEntity(
+                """{"dataModel":{"type":"object","properties":{"name":{"type":"string"}}},"dataExamples":[{"id":"ex1","name":"Example 1","data":{"name":"Ada"}}]}""",
+                baseHeaders(key),
+            ),
             String::class.java,
         )
 
@@ -375,7 +416,10 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         val rejected = restTemplate.exchange(
             "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug",
             HttpMethod.PATCH,
-            HttpEntity("""{"dataModel": {"type":"object","properties":{"name":{"type":"integer"}}}}""", baseHeaders(key)),
+            HttpEntity(
+                """{"dataModel":{"type":"object","properties":{"name":{"type":"integer"}}},"dataExamples":[{"id":"ex1","name":"Example 1","data":{"name":42}}]}""",
+                baseHeaders(key),
+            ),
             String::class.java,
         )
         assertThat(rejected.statusCode).isEqualTo(HttpStatus.CONFLICT)
@@ -707,6 +751,17 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         assertThat(create.statusCode).isEqualTo(HttpStatus.CREATED)
         val variantId = JsonPath.read<String>(create.body!!, "$.variants[0].id")
         val draftUrl = "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug/variants/$variantId/draft"
+
+        val contractUpdate = restTemplate.exchange(
+            "/api/tenants/${tenantKey.value}/catalogs/default/templates/$slug/contract/draft",
+            HttpMethod.PATCH,
+            HttpEntity(
+                """{"dataExamples":[{"id":"ex1","name":"Example 1","data":{}}]}""",
+                baseHeaders(key),
+            ),
+            String::class.java,
+        )
+        assertThat(contractUpdate.statusCode).isEqualTo(HttpStatus.OK)
 
         val publish = restTemplate.exchange(
             "$draftUrl/publish",
@@ -1054,6 +1109,7 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
                     HttpStatus.NO_CONTENT,
                     HttpStatus.NOT_FOUND,
                     HttpStatus.CONFLICT,
+                    HttpStatus.BAD_REQUEST,
                 )
             }
         } finally {
@@ -1097,7 +1153,10 @@ class EpistolaTemplateApiIT : IntegrationTestBase() {
         val updateDraft = restTemplate.exchange(
             contractDraftUrl,
             HttpMethod.PATCH,
-            HttpEntity("""{"dataModel": $dataModel}""", baseHeaders(key)),
+            HttpEntity(
+                """{"dataModel": $dataModel, "dataExamples": [{"id":"ex1","name":"Example 1","data":{"name":"Ada"}}]}""",
+                baseHeaders(key),
+            ),
             String::class.java,
         )
         assertThat(updateDraft.statusCode).isEqualTo(HttpStatus.OK)

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogListHandlerTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/catalog/CatalogListHandlerTest.kt
@@ -37,6 +37,7 @@ import app.epistola.suite.templates.model.Node
 import app.epistola.suite.templates.model.Slot
 import app.epistola.suite.templates.model.TemplateDocument
 import app.epistola.suite.tenants.Tenant
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.themes.commands.CreateTheme
 import app.epistola.template.model.ThemeRef
 import org.assertj.core.api.Assertions.assertThat
@@ -640,7 +641,7 @@ class CatalogListHandlerTest : BaseIntegrationTest() {
         stencilVersion: Int,
     ) {
         val templateId = TemplateId(TemplateKey.of(slug), catalogId)
-        CreateDocumentTemplate(id = templateId, name = name).execute()
+        CreateDocumentTemplate(id = templateId, name = name).execute().withRequiredDataExample()
         val variantId = VariantId(VariantKey.INITIAL, templateId)
         UpdateDraft(
             variantId = variantId,

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/StencilHandlerHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/StencilHandlerHtmxTest.kt
@@ -26,6 +26,7 @@ import app.epistola.suite.templates.commands.versions.PublishVersion
 import app.epistola.suite.templates.commands.versions.UpdateDraft
 import app.epistola.suite.tenants.Tenant
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.template.model.Node
 import app.epistola.template.model.Slot
 import app.epistola.template.model.TemplateDocument
@@ -711,7 +712,7 @@ class StencilHandlerHtmxTest : BaseIntegrationTest() {
 
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute()
+        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute().withRequiredDataExample()
         val variantKey = VariantKey.INITIAL
         UpdateDraft(
             variantId = VariantId(variantKey, templateId),
@@ -747,7 +748,7 @@ class StencilHandlerHtmxTest : BaseIntegrationTest() {
 
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute()
+        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute().withRequiredDataExample()
         val variantKey = VariantKey.INITIAL
         val variantId = VariantId(variantKey, templateId)
         UpdateDraft(
@@ -785,7 +786,7 @@ class StencilHandlerHtmxTest : BaseIntegrationTest() {
 
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute()
+        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute().withRequiredDataExample()
         val variantKey = VariantKey.INITIAL
         val variantId = VariantId(variantKey, templateId)
         UpdateDraft(variantId = variantId, templateModel = templateEmbedding(stencilId.key.value)).execute()

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/StencilHandlerHtmxTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/handlers/StencilHandlerHtmxTest.kt
@@ -712,7 +712,7 @@ class StencilHandlerHtmxTest : BaseIntegrationTest() {
 
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute().withRequiredDataExample()
+        CreateDocumentTemplate(id = templateId, name = "Letter $name").execute()
         val variantKey = VariantKey.INITIAL
         UpdateDraft(
             variantId = VariantId(variantKey, templateId),

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DiscardDraftRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DiscardDraftRoutesTest.kt
@@ -17,6 +17,7 @@ import app.epistola.suite.templates.commands.versions.CreateVersion
 import app.epistola.suite.templates.commands.versions.PublishVersion
 import app.epistola.suite.templates.queries.versions.GetDraft
 import app.epistola.suite.tenants.Tenant
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,7 +40,7 @@ class DiscardDraftRoutesTest : BaseIntegrationTest() {
 
         given {
             testTenant = tenant("Discard Test")
-            val template = template(testTenant, "Invoice Template")
+            val template = template(testTenant, "Invoice Template").withRequiredDataExample()
             templateId = template.id.value
             val tplId = TemplateId(template.id, CatalogId.default(TenantId(testTenant.id)))
             variantKey = VariantKey.INITIAL.value

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -19,6 +19,9 @@ import app.epistola.suite.features.commands.SaveFeatureToggle
 import app.epistola.suite.mediator.execute
 import app.epistola.suite.templates.commands.CreateDocumentTemplate
 import app.epistola.suite.templates.commands.UpdateDocumentTemplate
+import app.epistola.suite.templates.contracts.commands.CreateContractVersion
+import app.epistola.suite.templates.contracts.commands.PublishContractVersion
+import app.epistola.suite.templates.contracts.commands.UpdateContractVersion
 import app.epistola.suite.templates.contracts.queries.GetLatestContractVersion
 import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.queries.ListDocumentTemplates
@@ -1276,6 +1279,55 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
                 assertThat(contractVersion).isNotNull
                 assertThat(contractVersion!!.dataExamples).hasSize(1)
                 assertThat(contractVersion.dataExamples[0].id).isEqualTo("example-2")
+            }
+        }
+
+        @Test
+        fun `DELETE data-example creates a draft from the published contract before deleting`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+            lateinit var templateId: TemplateId
+
+            given {
+                testTenant = tenant("Test Tenant")
+                template = template(testTenant, "Test Template")
+                templateId = TemplateId(template.id, CatalogId.default(TenantId(testTenant.id)))
+
+                CreateContractVersion(templateId = templateId).execute()
+                UpdateContractVersion(
+                    templateId = templateId,
+                    dataExamples = listOf(
+                        DataExample(
+                            id = "example-1",
+                            name = "Example 1",
+                            data = objectMapper.createObjectNode(),
+                        ),
+                        DataExample(
+                            id = "example-2",
+                            name = "Example 2",
+                            data = objectMapper.createObjectNode(),
+                        ),
+                    ),
+                ).execute()
+                PublishContractVersion(templateId = templateId, confirmed = true).execute()
+            }
+
+            whenever {
+                restTemplate.exchange(
+                    "/tenants/${testTenant.id}/templates/default/${template.id}/data-examples/example-1",
+                    HttpMethod.DELETE,
+                    null,
+                    String::class.java,
+                )
+            }
+
+            then {
+                val response = result<org.springframework.http.ResponseEntity<String>>()
+                assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+
+                val contractVersion = mediator.query(GetLatestContractVersion(templateId = templateId))
+                assertThat(contractVersion!!.status.name).isEqualTo("DRAFT")
+                assertThat(contractVersion.dataExamples.map { it.id }).containsExactly("example-2")
             }
         }
 

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -1280,6 +1280,54 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
         }
 
         @Test
+        fun `DELETE data-example rejects removing the last example`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+
+            given {
+                testTenant = tenant("Test Tenant")
+                template = template(testTenant, "Test Template")
+                insertDraftContract(
+                    tenantKey = testTenant.id.value,
+                    templateKey = template.id.value,
+                    dataExamples = objectMapper.writeValueAsString(
+                        listOf(
+                            DataExample(
+                                id = "example-1",
+                                name = "Example 1",
+                                data = objectMapper.createObjectNode(),
+                            ),
+                        ),
+                    ),
+                )
+            }
+
+            whenever {
+                restTemplate.exchange(
+                    "/tenants/${testTenant.id}/templates/default/${template.id}/data-examples/example-1",
+                    HttpMethod.DELETE,
+                    null,
+                    String::class.java,
+                )
+            }
+
+            then {
+                val response = result<org.springframework.http.ResponseEntity<String>>()
+                assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+                assertThat(response.headers.contentType).isEqualTo(MediaType.APPLICATION_PROBLEM_JSON)
+                assertThat(response.body).contains("/data-example-required")
+                assertThat(response.body).contains("At least one data example is required")
+
+                val contractVersion = mediator.query(
+                    GetLatestContractVersion(
+                        templateId = TemplateId(template.id, CatalogId.default(TenantId(testTenant.id))),
+                    ),
+                )
+                assertThat(contractVersion!!.dataExamples).hasSize(1)
+            }
+        }
+
+        @Test
         fun `DELETE data-example returns 404 for non-existent example`() = fixture {
             lateinit var testTenant: Tenant
             lateinit var template: DocumentTemplate

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/DocumentTemplateRoutesTest.kt
@@ -81,6 +81,21 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
         }
     }
 
+    private fun createDraftContractWithExample(tenant: Tenant, template: DocumentTemplate) = withMediator {
+        val templateId = TemplateId(template.id, CatalogId.default(TenantId(tenant.id)))
+        CreateContractVersion(templateId = templateId).execute()
+        UpdateContractVersion(
+            templateId = templateId,
+            dataExamples = listOf(
+                DataExample(
+                    id = "example-1",
+                    name = "Example 1",
+                    data = objectMapper.createObjectNode(),
+                ),
+            ),
+        ).execute()
+    }
+
     private fun pdfPageCount(pdfBytes: ByteArray): Int = Regex("""/Type\s*/Page\b""")
         .findAll(pdfBytes.toString(Charsets.ISO_8859_1))
         .count()
@@ -1438,6 +1453,102 @@ class DocumentTemplateRoutesTest : BaseIntegrationTest() {
             then {
                 val response = result<org.springframework.http.ResponseEntity<String>>()
                 assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+            }
+        }
+    }
+
+    @Nested
+    inner class DataContractPageTest {
+
+        @Test
+        fun `GET data contract edit mode renders the sticky save controls host`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+
+            given {
+                testTenant = tenant("Data Contract Edit Tenant")
+                template = template(testTenant, "Data Contract Edit Template")
+                createDraftContractWithExample(testTenant, template)
+            }
+
+            whenever {
+                restTemplate.getForEntity(
+                    "/tenants/${testTenant.id}/templates/default/${template.id}/data-contract?edit=true",
+                    String::class.java,
+                )
+            }
+
+            then {
+                val response = result<org.springframework.http.ResponseEntity<String>>()
+                assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+                assertThat(response.body).contains("class=\"contract-status-bar\"")
+                assertThat(response.body).contains("id=\"contract-save-controls\"")
+                assertThat(response.body).contains("Done editing")
+                assertThat(response.body).contains("contract/status-bar?edit=true")
+            }
+        }
+
+        @Test
+        fun `GET contract status bar preserves edit mode during HTMX refresh`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+
+            given {
+                testTenant = tenant("Status Bar Edit Tenant")
+                template = template(testTenant, "Status Bar Edit Template")
+                createDraftContractWithExample(testTenant, template)
+            }
+
+            whenever {
+                val headers = HttpHeaders()
+                headers.set("HX-Request", "true")
+                restTemplate.exchange(
+                    "/tenants/${testTenant.id}/templates/default/${template.id}/contract/status-bar?edit=true",
+                    HttpMethod.GET,
+                    HttpEntity<Unit>(headers),
+                    String::class.java,
+                )
+            }
+
+            then {
+                val response = result<org.springframework.http.ResponseEntity<String>>()
+                assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+                assertThat(response.body).contains("id=\"contract-save-controls\"")
+                assertThat(response.body).contains("Done editing")
+                assertThat(response.body).doesNotContain(">Publish</button>")
+                assertThat(response.body).doesNotContain(">Edit</a>")
+            }
+        }
+
+        @Test
+        fun `GET contract status bar keeps publish and edit actions in view mode`() = fixture {
+            lateinit var testTenant: Tenant
+            lateinit var template: DocumentTemplate
+
+            given {
+                testTenant = tenant("Status Bar View Tenant")
+                template = template(testTenant, "Status Bar View Template")
+                createDraftContractWithExample(testTenant, template)
+            }
+
+            whenever {
+                val headers = HttpHeaders()
+                headers.set("HX-Request", "true")
+                restTemplate.exchange(
+                    "/tenants/${testTenant.id}/templates/default/${template.id}/contract/status-bar",
+                    HttpMethod.GET,
+                    HttpEntity<Unit>(headers),
+                    String::class.java,
+                )
+            }
+
+            then {
+                val response = result<org.springframework.http.ResponseEntity<String>>()
+                assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+                assertThat(response.body).contains("Publish")
+                assertThat(response.body).contains("Edit")
+                assertThat(response.body).doesNotContain("id=\"contract-save-controls\"")
+                assertThat(response.body).doesNotContain("Done editing")
             }
         }
     }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/templates/VersionComparisonRoutesTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/templates/VersionComparisonRoutesTest.kt
@@ -20,6 +20,7 @@ import app.epistola.suite.templates.commands.versions.PublishToEnvironment
 import app.epistola.suite.templates.contracts.commands.PublishContractVersion
 import app.epistola.suite.tenants.Tenant
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -46,7 +47,7 @@ class VersionComparisonRoutesTest : BaseIntegrationTest() {
 
             given {
                 testTenant = tenant("Test Tenant")
-                val template = template(testTenant, "Invoice Template")
+                val template = template(testTenant, "Invoice Template").withRequiredDataExample()
                 val tenantId = TenantId(testTenant.id)
                 val tplId = TemplateId(template.id, CatalogId.default(tenantId))
                 templateId = template.id.value
@@ -153,7 +154,7 @@ class VersionComparisonRoutesTest : BaseIntegrationTest() {
 
             given {
                 testTenant = tenant("Test Tenant")
-                val template = template(testTenant, "Invoice Template")
+                val template = template(testTenant, "Invoice Template").withRequiredDataExample()
                 val tenantId = TenantId(testTenant.id)
                 val tplId = TemplateId(template.id, CatalogId.default(tenantId))
                 templateId = template.id.value

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DataContractSaveBarUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DataContractSaveBarUiTest.kt
@@ -66,12 +66,16 @@ class DataContractSaveBarUiTest : BasePlaywrightTest() {
         assertThat(saveButton).isEnabled()
         assertThat(statusBar).containsText("Unsaved draft changes")
         assertThat(statusBar).containsText("Examples")
+        page.locator("#contract-save-controls").evaluate(
+            "element => element.dataset.preservedIdentity = 'original-host'",
+        )
 
         saveButton.click()
         page.htmxSettle()
 
         assertThat(page.locator("#contract-status-bar .dc-status-success")).hasText("Draft saved")
-        assertThat(page.locator("#contract-status-bar #contract-save-controls")).hasCount(1)
+        assertThat(page.locator("#contract-status-bar #contract-save-controls"))
+            .hasAttribute("data-preserved-identity", "original-host")
         assertThat(page.locator("#contract-status-bar a[href$='/data-contract']")).isVisible()
         assertThat(page.locator("#contract-status-bar button[hx-post*='/contract/publish']")).hasCount(0)
     }

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DataContractSaveBarUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DataContractSaveBarUiTest.kt
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.ui
+
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.common.ids.TenantKey
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.templates.commands.CreateDocumentTemplate
+import app.epistola.suite.templates.contracts.commands.CreateContractVersion
+import app.epistola.suite.templates.contracts.commands.UpdateContractVersion
+import app.epistola.suite.templates.model.DataExample
+import app.epistola.suite.tenants.commands.CreateTenant
+import app.epistola.suite.testing.TestIdHelpers
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.node.JsonNodeFactory
+
+class DataContractSaveBarUiTest : BasePlaywrightTest() {
+
+    @Test
+    fun `sticky action bar saves a draft and remains in edit mode after refresh`() {
+        val (tenant, template) = withMediator {
+            val tenant = CreateTenant(
+                id = TenantKey.of("contract-save-ui-${System.nanoTime()}"),
+                name = "Contract Save Bar UI Tenant",
+            ).execute()
+            val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(TenantId(tenant.id)))
+            val template = CreateDocumentTemplate(
+                id = templateId,
+                name = "Contract Save Bar UI Template",
+            ).execute()
+            CreateContractVersion(templateId = templateId).execute()
+            UpdateContractVersion(
+                templateId = templateId,
+                dataExamples = listOf(
+                    DataExample(
+                        id = "save-bar-example",
+                        name = "Original example",
+                        data = JsonNodeFactory.instance.objectNode(),
+                    ),
+                ),
+            ).execute()
+            tenant to template
+        }
+
+        gotoAndReady("/tenants/${tenant.id}/templates/default/${template.id}/data-contract?edit=true")
+
+        val statusBar = page.locator("#contract-status-bar")
+        val saveButton = page.locator("#contract-save-controls .dc-save-btn")
+        assertThat(statusBar).isVisible()
+        assertThat(saveButton).hasText("Save draft")
+        assertThat(saveButton).isDisabled()
+        org.assertj.core.api.Assertions.assertThat(
+            statusBar.evaluate(
+                "element => getComputedStyle(element).position + ' ' + getComputedStyle(element).top",
+            ),
+        ).isEqualTo("sticky 48px")
+
+        val exampleName = page.locator("#example-name-input")
+        exampleName.fill("Updated example")
+        exampleName.press("Tab")
+        assertThat(saveButton).isEnabled()
+        assertThat(statusBar).containsText("Unsaved draft changes")
+        assertThat(statusBar).containsText("Examples")
+
+        saveButton.click()
+        page.htmxSettle()
+
+        assertThat(page.locator("#contract-status-bar .dc-status-success")).hasText("Draft saved")
+        assertThat(page.locator("#contract-status-bar #contract-save-controls")).hasCount(1)
+        assertThat(page.locator("#contract-status-bar a[href$='/data-contract']")).isVisible()
+        assertThat(page.locator("#contract-status-bar button[hx-post*='/contract/publish']")).hasCount(0)
+    }
+}

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DiscardDraftUiTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/ui/DiscardDraftUiTest.kt
@@ -17,12 +17,17 @@ import app.epistola.suite.templates.DocumentTemplate
 import app.epistola.suite.templates.commands.CreateDocumentTemplate
 import app.epistola.suite.templates.commands.versions.CreateVersion
 import app.epistola.suite.templates.commands.versions.PublishVersion
+import app.epistola.suite.templates.contracts.commands.CreateContractVersion
+import app.epistola.suite.templates.contracts.commands.PublishContractVersion
+import app.epistola.suite.templates.contracts.commands.UpdateContractVersion
+import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.queries.versions.GetDraft
 import app.epistola.suite.tenants.Tenant
 import app.epistola.suite.tenants.commands.CreateTenant
 import app.epistola.suite.testing.TestIdHelpers
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.node.JsonNodeFactory
 
 class DiscardDraftUiTest : BasePlaywrightTest() {
 
@@ -79,11 +84,25 @@ class DiscardDraftUiTest : BasePlaywrightTest() {
         val tenantKey = TenantKey.of("discard-ui-${System.nanoTime()}")
         val tenant = CreateTenant(id = tenantKey, name = "Discard UI Tenant").execute()
         val tenantId = TenantId(tenant.id)
+        val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
         val template = CreateDocumentTemplate(
-            id = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId)),
+            id = templateId,
             name = "Discard UI Template",
         ).execute()
-        val variantId = VariantId(VariantKey.INITIAL, TemplateId(template.id, CatalogId.default(tenantId)))
+        CreateContractVersion(templateId = templateId).execute()
+        UpdateContractVersion(
+            templateId = templateId,
+            dataExamples = listOf(
+                DataExample(
+                    id = "discard-example",
+                    name = "Discard example",
+                    data = JsonNodeFactory.instance.objectNode(),
+                ),
+            ),
+        ).execute()
+        PublishContractVersion(templateId = templateId).execute()
+
+        val variantId = VariantId(VariantKey.INITIAL, templateId)
         val draft = GetDraft(variantId).query()!!
         PublishVersion(versionId = VersionId(draft.id, variantId)).execute()
         CreateVersion(variantId = variantId).execute()

--- a/modules/editor/src/main/typescript/data-contract-lib.test.ts
+++ b/modules/editor/src/main/typescript/data-contract-lib.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mountDataContractEditor, type DataContractEditorInstance } from './data-contract-lib.js';
+import type { EpistolaDataContractEditor } from './data-contract/EpistolaDataContractEditor.js';
+
+const instances: DataContractEditorInstance[] = [];
+
+function mount(saveControlsContainer: HTMLElement | null, readonly = false) {
+  const container = document.createElement('div');
+  document.body.append(container);
+
+  const instance = mountDataContractEditor({
+    container,
+    templateId: 'example-template',
+    initialSchema: null,
+    initialExamples: [{ id: 'example-1', name: 'Example 1', data: {} }],
+    callbacks: {},
+    readonly,
+    saveControlsContainer,
+  });
+  instances.push(instance);
+
+  return {
+    container,
+    editor: container.querySelector<EpistolaDataContractEditor>('epistola-data-contract-editor')!,
+    instance,
+  };
+}
+
+afterEach(() => {
+  for (const instance of instances.splice(0)) instance.unmount();
+  document.body.innerHTML = '';
+});
+
+describe('mountDataContractEditor save controls', () => {
+  it('renders save controls in the host bar rather than inside the editor', async () => {
+    const saveControlsContainer = document.createElement('div');
+    document.body.append(saveControlsContainer);
+    const { container, editor } = mount(saveControlsContainer);
+
+    await editor.updateComplete;
+
+    expect(saveControlsContainer.textContent).toContain('All changes saved');
+    expect(saveControlsContainer.textContent).toContain('Save draft');
+    expect(container.querySelector('.dc-contract-save-controls')).toBeNull();
+  });
+
+  it('keeps external save state in sync with editor changes', async () => {
+    const saveControlsContainer = document.createElement('div');
+    document.body.append(saveControlsContainer);
+    const { editor } = mount(saveControlsContainer);
+    await editor.updateComplete;
+
+    editor.contractState?.updateDraftExample('example-1', { name: 'Updated example' });
+    await editor.updateComplete;
+
+    expect(saveControlsContainer.textContent).toContain('Unsaved draft changes');
+    expect(saveControlsContainer.textContent).toContain('Examples');
+  });
+
+  it('retargets and clears externally rendered save controls', async () => {
+    const firstContainer = document.createElement('div');
+    const nextContainer = document.createElement('div');
+    document.body.append(firstContainer, nextContainer);
+    const { editor, instance } = mount(firstContainer);
+    await editor.updateComplete;
+
+    instance.setSaveControlsContainer(nextContainer);
+
+    expect(firstContainer.querySelector('.dc-contract-save-controls')).toBeNull();
+    expect(nextContainer.textContent).toContain('Save draft');
+
+    instance.unmount();
+    expect(nextContainer.querySelector('.dc-contract-save-controls')).toBeNull();
+  });
+
+  it('renders no save controls when read-only', async () => {
+    const externalContainer = document.createElement('div');
+    document.body.append(externalContainer);
+    const readOnlyMount = mount(externalContainer, true);
+    await readOnlyMount.editor.updateComplete;
+
+    expect(externalContainer.querySelector('.dc-contract-save-controls')).toBeNull();
+    expect(readOnlyMount.container.querySelector('.dc-contract-save-controls')).toBeNull();
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract-lib.test.ts
+++ b/modules/editor/src/main/typescript/data-contract-lib.test.ts
@@ -63,20 +63,16 @@ describe('mountDataContractEditor save controls', () => {
     expect(saveControlsContainer.textContent).toContain('Examples');
   });
 
-  it('retargets and clears externally rendered save controls', async () => {
-    const firstContainer = document.createElement('div');
-    const nextContainer = document.createElement('div');
-    document.body.append(firstContainer, nextContainer);
-    const { editor, instance } = mount(firstContainer);
+  it('clears externally rendered save controls when unmounted', async () => {
+    const saveControlsContainer = document.createElement('div');
+    document.body.append(saveControlsContainer);
+    const { editor, instance } = mount(saveControlsContainer);
     await editor.updateComplete;
 
-    instance.setSaveControlsContainer(nextContainer);
-
-    expect(firstContainer.querySelector('.dc-contract-save-controls')).toBeNull();
-    expect(nextContainer.textContent).toContain('Save draft');
+    expect(saveControlsContainer.textContent).toContain('Save draft');
 
     instance.unmount();
-    expect(nextContainer.querySelector('.dc-contract-save-controls')).toBeNull();
+    expect(saveControlsContainer.querySelector('.dc-contract-save-controls')).toBeNull();
   });
 
   it('renders no save controls when read-only', async () => {

--- a/modules/editor/src/main/typescript/data-contract-lib.ts
+++ b/modules/editor/src/main/typescript/data-contract-lib.ts
@@ -39,8 +39,6 @@ export interface DataContractEditorOptions {
 }
 
 export interface DataContractEditorInstance {
-  /** Move contract-wide save controls to a new host element */
-  setSaveControlsContainer(container: HTMLElement | null): void;
   /** Tear down the editor and clean up */
   unmount(): void;
 }
@@ -70,9 +68,6 @@ export function mountDataContractEditor(
   container.appendChild(editorEl);
 
   return {
-    setSaveControlsContainer(nextContainer) {
-      editorEl.setSaveControlsContainer(nextContainer);
-    },
     unmount() {
       editorEl.setSaveControlsContainer(null);
       editorEl.remove();

--- a/modules/editor/src/main/typescript/data-contract-lib.ts
+++ b/modules/editor/src/main/typescript/data-contract-lib.ts
@@ -34,9 +34,13 @@ export interface DataContractEditorOptions {
   callbacks: SaveCallbacks;
   /** When true, all editing controls are disabled */
   readonly?: boolean;
+  /** Host element for contract-wide save controls, or null in read-only mode */
+  saveControlsContainer: HTMLElement | null;
 }
 
 export interface DataContractEditorInstance {
+  /** Move contract-wide save controls to a new host element */
+  setSaveControlsContainer(container: HTMLElement | null): void;
   /** Tear down the editor and clean up */
   unmount(): void;
 }
@@ -47,18 +51,30 @@ export interface DataContractEditorInstance {
 export function mountDataContractEditor(
   options: DataContractEditorOptions,
 ): DataContractEditorInstance {
-  const { container, initialSchema, initialExamples, callbacks, readonly = false } = options;
+  const {
+    container,
+    initialSchema,
+    initialExamples,
+    callbacks,
+    readonly = false,
+    saveControlsContainer,
+  } = options;
 
   const editorEl = document.createElement('epistola-data-contract-editor');
   editorEl.style.display = 'block';
 
   editorEl.init(initialSchema, initialExamples, callbacks, readonly);
+  editorEl.setSaveControlsContainer(saveControlsContainer);
 
   container.innerHTML = '';
   container.appendChild(editorEl);
 
   return {
+    setSaveControlsContainer(nextContainer) {
+      editorEl.setSaveControlsContainer(nextContainer);
+    },
     unmount() {
+      editorEl.setSaveControlsContainer(null);
       editorEl.remove();
     },
   };

--- a/modules/editor/src/main/typescript/data-contract/DataContractState.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/DataContractState.test.ts
@@ -315,12 +315,57 @@ describe('DataContractState', () => {
   describe('deleteSingleExample', () => {
     it('calls onDeleteDataExample and removes on success', async () => {
       const onDeleteDataExample = vi.fn().mockResolvedValue({ success: true });
-      const state = createState(testSchema, testExamples, { onDeleteDataExample });
+      const state = createState(
+        testSchema,
+        [...testExamples, { id: '2', name: 'Example 2', data: {} }],
+        { onDeleteDataExample },
+      );
 
       const result = await state.deleteSingleExample('1');
 
       expect(result.success).toBe(true);
-      expect(state.dataExamples).toHaveLength(0);
+      expect(state.dataExamples).toHaveLength(1);
+      expect(state.isExamplesDirty).toBe(false);
+    });
+
+    it('removes an unsaved example locally without calling the backend', async () => {
+      const onDeleteDataExample = vi.fn();
+      const state = createState(testSchema, testExamples, { onDeleteDataExample });
+      state.addDraftExample({ id: 'new', name: 'New example', data: {} });
+
+      const result = await state.deleteSingleExample('new');
+
+      expect(result.success).toBe(true);
+      expect(onDeleteDataExample).not.toHaveBeenCalled();
+      expect(state.dataExamples).toEqual(testExamples);
+      expect(state.isExamplesDirty).toBe(false);
+    });
+
+    it('does not delete the only saved example while its alternative is unsaved', async () => {
+      const onDeleteDataExample = vi.fn();
+      const state = createState(testSchema, testExamples, { onDeleteDataExample });
+      state.addDraftExample({ id: 'new', name: 'New example', data: {} });
+
+      const result = await state.deleteSingleExample('1');
+
+      expect(result.success).toBe(false);
+      expect(onDeleteDataExample).not.toHaveBeenCalled();
+      expect(state.dataExamples).toHaveLength(2);
+    });
+
+    it('does not report success for an unknown example', async () => {
+      const onDeleteDataExample = vi.fn();
+      const state = createState(
+        testSchema,
+        [...testExamples, { id: '2', name: 'Example 2', data: {} }],
+        { onDeleteDataExample },
+      );
+
+      const result = await state.deleteSingleExample('unknown');
+
+      expect(result.success).toBe(false);
+      expect(onDeleteDataExample).not.toHaveBeenCalled();
+      expect(state.dataExamples).toHaveLength(2);
     });
 
     it('does not remove on failure', async () => {
@@ -334,12 +379,16 @@ describe('DataContractState', () => {
 
     it('handles exceptions', async () => {
       const onDeleteDataExample = vi.fn().mockRejectedValue(new Error('Fail'));
-      const state = createState(testSchema, testExamples, { onDeleteDataExample });
+      const state = createState(
+        testSchema,
+        [...testExamples, { id: '2', name: 'Example 2', data: {} }],
+        { onDeleteDataExample },
+      );
 
       const result = await state.deleteSingleExample('1');
 
       expect(result.success).toBe(false);
-      expect(state.dataExamples).toHaveLength(1);
+      expect(state.dataExamples).toHaveLength(2);
     });
   });
 

--- a/modules/editor/src/main/typescript/data-contract/DataContractState.ts
+++ b/modules/editor/src/main/typescript/data-contract/DataContractState.ts
@@ -60,6 +60,19 @@ export class DataContractState extends EventTarget {
     return this._draftExamples;
   }
 
+  isExampleCommitted(exampleId: string): boolean {
+    return this._committedExamples.some((example) => example.id === exampleId);
+  }
+
+  canDeleteExample(exampleId: string): boolean {
+    if (!this._draftExamples.some((example) => example.id === exampleId)) return false;
+    if (this._draftExamples.length <= 1) return false;
+    if (!this.isExampleCommitted(exampleId)) return true;
+    return this._draftExamples.some(
+      (example) => example.id !== exampleId && this.isExampleCommitted(example.id),
+    );
+  }
+
   get schemaEditMode(): SchemaEditMode {
     return this._schemaEditMode;
   }
@@ -223,6 +236,15 @@ export class DataContractState extends EventTarget {
   }
 
   async deleteSingleExample(exampleId: string): Promise<{ success: boolean }> {
+    if (!this.canDeleteExample(exampleId)) {
+      return { success: false };
+    }
+
+    if (!this.isExampleCommitted(exampleId)) {
+      this.deleteDraftExample(exampleId);
+      return { success: true };
+    }
+
     if (!this._callbacks.onDeleteDataExample) {
       return { success: false };
     }
@@ -231,7 +253,8 @@ export class DataContractState extends EventTarget {
       const result = await this._callbacks.onDeleteDataExample(exampleId);
       if (result.success) {
         this._draftExamples = this._draftExamples.filter((e) => e.id !== exampleId);
-        this._markExamplesCommitted();
+        this._committedExamples = this._committedExamples.filter((e) => e.id !== exampleId);
+        this._fireChange();
       }
       return result;
     } catch {

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
@@ -60,6 +60,7 @@ import { renderMigrationDialog, migrationKey } from './sections/MigrationAssista
 import { renderJsonSchemaView } from './sections/JsonSchemaView.js';
 import { renderImportSchemaDialog } from './sections/ImportSchemaDialog.js';
 import { setNestedValue, buildFieldErrorMap } from './sections/ExampleForm.js';
+import { renderContractSaveBar } from './sections/ContractSaveBar.js';
 
 @customElement('epistola-data-contract-editor')
 export class EpistolaDataContractEditor extends LitElement {
@@ -213,6 +214,12 @@ export class EpistolaDataContractEditor extends LitElement {
     return (this.contractState?.dataExamples.length ?? 0) > 0;
   }
 
+  private get _saveBlockedReason(): string | null {
+    if (!this._hasRequiredExample) return 'Add at least one test data example before saving';
+    if (this._hasExampleErrors) return 'Fix example validation errors before saving';
+    return null;
+  }
+
   override render() {
     if (!this.contractState) {
       return html`<div class="dc-empty-state">No data contract loaded.</div>`;
@@ -238,6 +245,23 @@ export class EpistolaDataContractEditor extends LitElement {
               </div>
             `
           : nothing}
+        ${this._readOnly
+          ? nothing
+          : renderContractSaveBar(
+              {
+                schemaDirty: this.contractState.isSchemaDirty,
+                examplesDirty: this.contractState.isExamplesDirty,
+                saving: this._saving,
+                saveSuccess: this._saveSuccess,
+                saveError: this._saveError,
+                canForceSave: this._canForceSave,
+                blockedReason: this._saveBlockedReason,
+              },
+              {
+                onSave: () => this._saveAll(),
+                onForceSave: () => this._executeForceSave(),
+              },
+            )}
 
         <!-- Page content: schema then examples -->
         <div class="dc-page-content">
@@ -346,16 +370,6 @@ export class EpistolaDataContractEditor extends LitElement {
       selectedFieldId: this._selectedFieldId,
       readOnly: this._readOnly,
       jsonPanelOpen: this._jsonPanelOpen,
-      saving: this._saving,
-      canSave: state.isDirty && !this._hasExampleErrors && this._hasRequiredExample,
-      saveSuccess: this._saveSuccess,
-      saveError: this._saveError,
-      canForceSave: this._canForceSave,
-      saveTooltip: !this._hasRequiredExample
-        ? 'Add at least one test data example before saving'
-        : this._hasExampleErrors
-          ? 'Fix example validation errors before saving'
-          : '',
     };
 
     const callbacks: SchemaSectionCallbacks = {
@@ -369,8 +383,6 @@ export class EpistolaDataContractEditor extends LitElement {
       onToggleJson: () => {
         this._jsonPanelOpen = !this._jsonPanelOpen;
       },
-      onSave: () => this._saveAll(),
-      onForceSave: () => this._executeForceSave(),
     };
 
     return html`
@@ -419,13 +431,6 @@ export class EpistolaDataContractEditor extends LitElement {
       canUndo: this._exampleCanUndo,
       canRedo: this._exampleCanRedo,
       readOnly: this._readOnly,
-      saving: this._saving,
-      canSave: state.isDirty && !this._hasExampleErrors && this._hasRequiredExample,
-      saveTooltip: !this._hasRequiredExample
-        ? 'Add at least one test data example before saving'
-        : this._hasExampleErrors
-          ? 'Fix example validation errors before saving'
-          : '',
     };
 
     const callbacks: ExamplesSectionCallbacks = {
@@ -436,7 +441,6 @@ export class EpistolaDataContractEditor extends LitElement {
       onUpdateExampleData: (id, path, value) => this._updateExampleData(id, path, value),
       onUndo: () => this._undoExampleData(),
       onRedo: () => this._redoExampleData(),
-      onSave: () => this._saveAll(),
     };
 
     return renderExamplesSection(state, uiState, callbacks);

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
@@ -209,6 +209,10 @@ export class EpistolaDataContractEditor extends LitElement {
     return false;
   }
 
+  private get _hasRequiredExample(): boolean {
+    return (this.contractState?.dataExamples.length ?? 0) > 0;
+  }
+
   override render() {
     if (!this.contractState) {
       return html`<div class="dc-empty-state">No data contract loaded.</div>`;
@@ -343,11 +347,15 @@ export class EpistolaDataContractEditor extends LitElement {
       readOnly: this._readOnly,
       jsonPanelOpen: this._jsonPanelOpen,
       saving: this._saving,
-      canSave: state.isDirty && !this._hasExampleErrors,
+      canSave: state.isDirty && !this._hasExampleErrors && this._hasRequiredExample,
       saveSuccess: this._saveSuccess,
       saveError: this._saveError,
       canForceSave: this._canForceSave,
-      saveTooltip: this._hasExampleErrors ? 'Fix example validation errors before saving' : '',
+      saveTooltip: !this._hasRequiredExample
+        ? 'Add at least one test data example before saving'
+        : this._hasExampleErrors
+          ? 'Fix example validation errors before saving'
+          : '',
     };
 
     const callbacks: SchemaSectionCallbacks = {
@@ -568,6 +576,7 @@ export class EpistolaDataContractEditor extends LitElement {
   private async _saveAll(): Promise<void> {
     const state = this.contractState!;
     if (this._saving) return;
+    if (!this._hasRequiredExample) return;
     if (this._hasExampleErrors) return;
 
     // Confirm breaking changes before saving
@@ -608,6 +617,7 @@ export class EpistolaDataContractEditor extends LitElement {
 
   private async _executeSave(forceUpdate: boolean): Promise<void> {
     const state = this.contractState!;
+    if (!this._hasRequiredExample) return;
     this._saving = true;
     this._saveSuccess = false;
     this._saveError = null;
@@ -779,6 +789,7 @@ export class EpistolaDataContractEditor extends LitElement {
 
   private async _deleteExample(id: string): Promise<void> {
     const state = this.contractState!;
+    if (state.dataExamples.length <= 1) return;
 
     const result = await state.deleteSingleExample(id);
     if (result.success) {
@@ -914,7 +925,12 @@ export class EpistolaDataContractEditor extends LitElement {
     // Ctrl+S: save
     if (e.key === 's') {
       e.preventDefault();
-      if (!this._saving && this.contractState?.isDirty && !this._hasExampleErrors) {
+      if (
+        !this._saving &&
+        this.contractState?.isDirty &&
+        this._hasRequiredExample &&
+        !this._hasExampleErrors
+      ) {
         this._saveAll();
       }
       return;

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
@@ -19,7 +19,7 @@
  * chip-level badges.
  */
 
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html, nothing, render as renderLit } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { nanoid } from 'nanoid';
 import { DataContractState } from './DataContractState.js';
@@ -60,7 +60,7 @@ import { renderMigrationDialog, migrationKey } from './sections/MigrationAssista
 import { renderJsonSchemaView } from './sections/JsonSchemaView.js';
 import { renderImportSchemaDialog } from './sections/ImportSchemaDialog.js';
 import { setNestedValue, buildFieldErrorMap } from './sections/ExampleForm.js';
-import { renderContractSaveBar } from './sections/ContractSaveBar.js';
+import { renderContractSaveControls } from './sections/ContractSaveBar.js';
 
 @customElement('epistola-data-contract-editor')
 export class EpistolaDataContractEditor extends LitElement {
@@ -111,6 +111,7 @@ export class EpistolaDataContractEditor extends LitElement {
   @state() private _saveSuccess = false;
   @state() private _saveError: string | null = null;
   @state() private _canForceSave = false;
+  private _saveControlsContainer: HTMLElement | null = null;
 
   // Per-example undo/redo stacks
   private _exampleHistories = new Map<string, SnapshotHistory<JsonObject>>();
@@ -192,11 +193,25 @@ export class EpistolaDataContractEditor extends LitElement {
     window.addEventListener('keydown', this._boundKeyDown);
   }
 
+  override updated(): void {
+    this._renderExternalSaveControls();
+  }
+
   override disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('beforeunload', this._boundBeforeUnload);
     window.removeEventListener('keydown', this._boundKeyDown);
     if (this._successTimer) clearTimeout(this._successTimer);
+    this._clearExternalSaveControls();
+  }
+
+  setSaveControlsContainer(container: HTMLElement | null): void {
+    if (this._saveControlsContainer === container) return;
+
+    this._clearExternalSaveControls();
+    this._saveControlsContainer = container;
+    this._renderExternalSaveControls();
+    this.requestUpdate();
   }
 
   // ---------------------------------------------------------------------------
@@ -218,6 +233,42 @@ export class EpistolaDataContractEditor extends LitElement {
     if (!this._hasRequiredExample) return 'Add at least one test data example before saving';
     if (this._hasExampleErrors) return 'Fix example validation errors before saving';
     return null;
+  }
+
+  private _saveControlsState() {
+    return {
+      schemaDirty: this.contractState?.isSchemaDirty ?? false,
+      examplesDirty: this.contractState?.isExamplesDirty ?? false,
+      saving: this._saving,
+      saveSuccess: this._saveSuccess,
+      saveError: this._saveError,
+      canForceSave: this._canForceSave,
+      blockedReason: this._saveBlockedReason,
+    };
+  }
+
+  private _saveControlsCallbacks() {
+    return {
+      onSave: () => this._saveAll(),
+      onForceSave: () => this._executeForceSave(),
+    };
+  }
+
+  private _renderExternalSaveControls(): void {
+    if (!this._saveControlsContainer) return;
+
+    renderLit(
+      this._readOnly
+        ? nothing
+        : renderContractSaveControls(this._saveControlsState(), this._saveControlsCallbacks()),
+      this._saveControlsContainer,
+    );
+  }
+
+  private _clearExternalSaveControls(): void {
+    if (this._saveControlsContainer) {
+      renderLit(nothing, this._saveControlsContainer);
+    }
   }
 
   override render() {
@@ -245,24 +296,6 @@ export class EpistolaDataContractEditor extends LitElement {
               </div>
             `
           : nothing}
-        ${this._readOnly
-          ? nothing
-          : renderContractSaveBar(
-              {
-                schemaDirty: this.contractState.isSchemaDirty,
-                examplesDirty: this.contractState.isExamplesDirty,
-                saving: this._saving,
-                saveSuccess: this._saveSuccess,
-                saveError: this._saveError,
-                canForceSave: this._canForceSave,
-                blockedReason: this._saveBlockedReason,
-              },
-              {
-                onSave: () => this._saveAll(),
-                onForceSave: () => this._executeForceSave(),
-              },
-            )}
-
         <!-- Page content: schema then examples -->
         <div class="dc-page-content">
           ${this._renderSchemaSection()} ${this._renderExamplesSection()}

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
@@ -419,6 +419,13 @@ export class EpistolaDataContractEditor extends LitElement {
       canUndo: this._exampleCanUndo,
       canRedo: this._exampleCanRedo,
       readOnly: this._readOnly,
+      saving: this._saving,
+      canSave: state.isDirty && !this._hasExampleErrors && this._hasRequiredExample,
+      saveTooltip: !this._hasRequiredExample
+        ? 'Add at least one test data example before saving'
+        : this._hasExampleErrors
+          ? 'Fix example validation errors before saving'
+          : '',
     };
 
     const callbacks: ExamplesSectionCallbacks = {
@@ -429,6 +436,7 @@ export class EpistolaDataContractEditor extends LitElement {
       onUpdateExampleData: (id, path, value) => this._updateExampleData(id, path, value),
       onUndo: () => this._undoExampleData(),
       onRedo: () => this._redoExampleData(),
+      onSave: () => this._saveAll(),
     };
 
     return renderExamplesSection(state, uiState, callbacks);

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
@@ -789,7 +789,7 @@ export class EpistolaDataContractEditor extends LitElement {
 
   private async _deleteExample(id: string): Promise<void> {
     const state = this.contractState!;
-    if (state.dataExamples.length <= 1) return;
+    if (!state.canDeleteExample(id)) return;
 
     const result = await state.deleteSingleExample(id);
     if (result.success) {

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -47,10 +47,66 @@
   }
 
   /* --------------------------------------------------------------------------
-   * Header bar
+   * Contract-wide save bar
    * ---------------------------------------------------------------------- */
 
-  /* (header bar removed — save button lives in the schema toolbar) */
+  .dc-contract-save-bar {
+    position: sticky;
+    top: 48px;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ep-space-3);
+    padding: var(--ep-space-3) var(--ep-space-4);
+    background: color-mix(in srgb, var(--ep-white) 96%, transparent);
+    border: 1px solid var(--ep-stone-200);
+    border-radius: var(--ep-radius-md);
+    box-shadow: var(--ep-shadow-sm);
+    backdrop-filter: blur(8px);
+  }
+
+  .dc-contract-save-summary,
+  .dc-contract-save-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--ep-space-2);
+  }
+
+  .dc-contract-save-summary {
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  .dc-contract-save-actions {
+    flex-shrink: 0;
+  }
+
+  .dc-contract-save-state {
+    font-size: var(--ep-text-sm);
+    font-weight: 600;
+    color: var(--ep-stone-700);
+  }
+
+  .dc-contract-save-state-muted {
+    font-weight: 500;
+    color: var(--ep-stone-600);
+  }
+
+  .dc-contract-change-badge {
+    padding: var(--ep-space-0-5) var(--ep-space-2);
+    font-size: var(--ep-text-xs);
+    font-weight: 600;
+    color: var(--ep-terracotta-700);
+    background: var(--ep-terracotta-50);
+    border: 1px solid var(--ep-terracotta-200);
+    border-radius: var(--ep-radius-full);
+  }
+
+  .dc-contract-save-blocked {
+    font-size: var(--ep-text-xs);
+    color: var(--ep-red-600);
+  }
 
   .dc-page-content {
     display: flex;
@@ -375,18 +431,6 @@
    * Status bar (save state)
    * ---------------------------------------------------------------------- */
 
-  .dc-status-bar {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: var(--ep-space-3);
-    padding: var(--ep-space-2) var(--ep-space-3);
-    border-top: 1px solid var(--ep-stone-200);
-    background: var(--ep-stone-50);
-    border-radius: var(--ep-radius-sm);
-    margin-top: var(--ep-space-4);
-  }
-
   .dc-status-success {
     font-size: var(--ep-text-xs);
     color: var(--ep-green-700);
@@ -409,6 +453,18 @@
     &:hover:not(:disabled) {
       background: var(--ep-amber-50);
       border-color: var(--ep-amber-500);
+    }
+  }
+
+  @media (max-width: 640px) {
+    .dc-contract-save-bar {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .dc-contract-save-actions {
+      width: 100%;
+      justify-content: flex-end;
     }
   }
 

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -1013,6 +1013,15 @@
     }
   }
 
+  .dc-example-delete-requirement {
+    max-width: 220px;
+    margin-top: auto;
+    font-size: var(--ep-text-xs);
+    line-height: 1.4;
+    color: var(--ep-stone-600);
+    text-align: right;
+  }
+
   /* --------------------------------------------------------------------------
    * Floating toolbar (compact nested syntax)
    * ---------------------------------------------------------------------- */

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -74,6 +74,10 @@
     margin: 0 0 var(--ep-space-2) 0;
   }
 
+  .dc-required-indicator {
+    color: var(--ep-color-danger, #c53030);
+  }
+
   .dc-section-hint {
     font-size: var(--ep-text-xs);
     color: var(--ep-stone-600);

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -47,23 +47,16 @@
   }
 
   /* --------------------------------------------------------------------------
-   * Contract-wide save bar
+   * Contract-wide save controls
    * ---------------------------------------------------------------------- */
 
-  .dc-contract-save-bar {
-    position: sticky;
-    top: 48px;
-    z-index: 20;
+  .dc-contract-save-controls {
     display: flex;
+    flex: 1 1 auto;
     align-items: center;
     justify-content: space-between;
     gap: var(--ep-space-3);
-    padding: var(--ep-space-3) var(--ep-space-4);
-    background: color-mix(in srgb, var(--ep-white) 96%, transparent);
-    border: 1px solid var(--ep-stone-200);
-    border-radius: var(--ep-radius-md);
-    box-shadow: var(--ep-shadow-sm);
-    backdrop-filter: blur(8px);
+    min-width: 0;
   }
 
   .dc-contract-save-summary,
@@ -457,7 +450,7 @@
   }
 
   @media (max-width: 640px) {
-    .dc-contract-save-bar {
+    .dc-contract-save-controls {
       align-items: flex-start;
       flex-wrap: wrap;
     }

--- a/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.test.ts
@@ -7,7 +7,7 @@
 import { render } from 'lit';
 import { describe, expect, it, vi } from 'vitest';
 import {
-  renderContractSaveBar,
+  renderContractSaveControls,
   type ContractSaveBarCallbacks,
   type ContractSaveBarState,
 } from './ContractSaveBar.js';
@@ -27,7 +27,7 @@ function renderBar(
   callbacks: ContractSaveBarCallbacks = { onSave: vi.fn(), onForceSave: vi.fn() },
 ): HTMLElement {
   const container = document.createElement('div');
-  render(renderContractSaveBar({ ...defaultState, ...state }, callbacks), container);
+  render(renderContractSaveControls({ ...defaultState, ...state }, callbacks), container);
   return container;
 }
 
@@ -39,7 +39,7 @@ describe('ContractSaveBar', () => {
       { onSave, onForceSave: vi.fn() },
     );
 
-    expect(container.textContent).toContain('Unsaved changes');
+    expect(container.textContent).toContain('Unsaved draft changes');
     expect(container.textContent).toContain('Schema');
     expect(container.textContent).toContain('Examples');
 
@@ -73,13 +73,21 @@ describe('ContractSaveBar', () => {
 
   it('shows the shared saving and saved states', () => {
     const saving = renderBar({ examplesDirty: true, saving: true });
-    expect(saving.textContent).toContain('Saving contract…');
+    expect(saving.textContent).toContain('Saving draft…');
     expect(saving.querySelector<HTMLButtonElement>('.dc-save-btn')?.textContent).toContain(
       'Saving…',
     );
 
     const saved = renderBar({ saveSuccess: true });
-    expect(saved.textContent).toContain('Contract saved');
+    expect(saved.textContent).toContain('Draft saved');
+  });
+
+  it('labels the shared action as saving the draft', () => {
+    const container = renderBar({ examplesDirty: true });
+    const saveButton = container.querySelector<HTMLButtonElement>('.dc-save-btn');
+
+    expect(saveButton?.textContent).toContain('Save draft');
+    expect(saveButton?.title).toBe('Save schema and examples as one draft');
   });
 
   it('shows errors and exposes the existing force-save action', () => {

--- a/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.test.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { render } from 'lit';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  renderContractSaveBar,
+  type ContractSaveBarCallbacks,
+  type ContractSaveBarState,
+} from './ContractSaveBar.js';
+
+const defaultState: ContractSaveBarState = {
+  schemaDirty: false,
+  examplesDirty: false,
+  saving: false,
+  saveSuccess: false,
+  saveError: null,
+  canForceSave: false,
+  blockedReason: null,
+};
+
+function renderBar(
+  state: Partial<ContractSaveBarState> = {},
+  callbacks: ContractSaveBarCallbacks = { onSave: vi.fn(), onForceSave: vi.fn() },
+): HTMLElement {
+  const container = document.createElement('div');
+  render(renderContractSaveBar({ ...defaultState, ...state }, callbacks), container);
+  return container;
+}
+
+describe('ContractSaveBar', () => {
+  it('shows every dirty contract part and saves through one action', () => {
+    const onSave = vi.fn();
+    const container = renderBar(
+      { schemaDirty: true, examplesDirty: true },
+      { onSave, onForceSave: vi.fn() },
+    );
+
+    expect(container.textContent).toContain('Unsaved changes');
+    expect(container.textContent).toContain('Schema');
+    expect(container.textContent).toContain('Examples');
+
+    const saveButton = container.querySelector<HTMLButtonElement>('.dc-save-btn');
+    expect(saveButton?.disabled).toBe(false);
+    saveButton?.click();
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it('disables saving and explains a blocking validation requirement', () => {
+    const container = renderBar({
+      examplesDirty: true,
+      blockedReason: 'Add at least one test data example before saving',
+    });
+
+    expect(container.textContent).toContain('Add at least one test data example before saving');
+    expect(container.querySelector<HTMLButtonElement>('.dc-save-btn')?.disabled).toBe(true);
+  });
+
+  it('distinguishes a single dirty contract part and disables saving when clean', () => {
+    const schemaOnly = renderBar({ schemaDirty: true });
+    expect(schemaOnly.querySelector('.dc-contract-save-summary')?.textContent).toContain('Schema');
+    expect(schemaOnly.querySelector('.dc-contract-save-summary')?.textContent).not.toContain(
+      'Examples',
+    );
+
+    const clean = renderBar();
+    expect(clean.textContent).toContain('All changes saved');
+    expect(clean.querySelector<HTMLButtonElement>('.dc-save-btn')?.disabled).toBe(true);
+  });
+
+  it('shows the shared saving and saved states', () => {
+    const saving = renderBar({ examplesDirty: true, saving: true });
+    expect(saving.textContent).toContain('Saving contract…');
+    expect(saving.querySelector<HTMLButtonElement>('.dc-save-btn')?.textContent).toContain(
+      'Saving…',
+    );
+
+    const saved = renderBar({ saveSuccess: true });
+    expect(saved.textContent).toContain('Contract saved');
+  });
+
+  it('shows errors and exposes the existing force-save action', () => {
+    const onForceSave = vi.fn();
+    const container = renderBar(
+      { schemaDirty: true, saveError: 'Schema validation failed', canForceSave: true },
+      { onSave: vi.fn(), onForceSave },
+    );
+
+    expect(container.textContent).toContain('Schema validation failed');
+    const forceButton = container.querySelector<HTMLButtonElement>('.dc-force-save-btn');
+    forceButton?.click();
+    expect(onForceSave).toHaveBeenCalledOnce();
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { html, nothing } from 'lit';
+
+export interface ContractSaveBarState {
+  schemaDirty: boolean;
+  examplesDirty: boolean;
+  saving: boolean;
+  saveSuccess: boolean;
+  saveError: string | null;
+  canForceSave: boolean;
+  blockedReason: string | null;
+}
+
+export interface ContractSaveBarCallbacks {
+  onSave: () => void;
+  onForceSave: () => void;
+}
+
+export function renderContractSaveBar(
+  state: ContractSaveBarState,
+  callbacks: ContractSaveBarCallbacks,
+): unknown {
+  const isDirty = state.schemaDirty || state.examplesDirty;
+  const canSave = isDirty && !state.saving && state.blockedReason === null;
+  const saveTooltip =
+    state.blockedReason ?? (isDirty ? 'Save the complete data contract' : 'No unsaved changes');
+
+  return html`
+    <div class="dc-contract-save-bar" role="region" aria-label="Data contract save controls">
+      <div class="dc-contract-save-summary" aria-live="polite">
+        ${state.saving
+          ? html`<span class="dc-contract-save-state">Saving contract…</span>`
+          : state.saveError
+            ? html`<span class="dc-status-error">${state.saveError}</span>`
+            : state.saveSuccess
+              ? html`<span class="dc-status-success">Contract saved</span>`
+              : isDirty
+                ? html`
+                    <span class="dc-contract-save-state">Unsaved changes</span>
+                    ${state.schemaDirty
+                      ? html`<span class="dc-contract-change-badge">Schema</span>`
+                      : nothing}
+                    ${state.examplesDirty
+                      ? html`<span class="dc-contract-change-badge">Examples</span>`
+                      : nothing}
+                  `
+                : html`<span class="dc-contract-save-state dc-contract-save-state-muted"
+                    >All changes saved</span
+                  >`}
+        ${isDirty && state.blockedReason
+          ? html`<span class="dc-contract-save-blocked">${state.blockedReason}</span>`
+          : nothing}
+      </div>
+
+      <div class="dc-contract-save-actions">
+        ${state.canForceSave
+          ? html`
+              <button
+                class="ep-btn ep-btn-outline ep-btn-sm dc-force-save-btn"
+                ?disabled=${state.saving}
+                @click=${() => callbacks.onForceSave()}
+              >
+                Save anyway
+              </button>
+            `
+          : nothing}
+        <button
+          class="ep-btn ep-btn-primary ep-btn-sm dc-save-btn"
+          ?disabled=${!canSave}
+          @click=${() => callbacks.onSave()}
+          title=${saveTooltip}
+        >
+          ${state.saving ? 'Saving…' : 'Save contract'}
+        </button>
+      </div>
+    </div>
+  `;
+}

--- a/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ContractSaveBar.ts
@@ -19,27 +19,28 @@ export interface ContractSaveBarCallbacks {
   onForceSave: () => void;
 }
 
-export function renderContractSaveBar(
+export function renderContractSaveControls(
   state: ContractSaveBarState,
   callbacks: ContractSaveBarCallbacks,
 ): unknown {
   const isDirty = state.schemaDirty || state.examplesDirty;
   const canSave = isDirty && !state.saving && state.blockedReason === null;
   const saveTooltip =
-    state.blockedReason ?? (isDirty ? 'Save the complete data contract' : 'No unsaved changes');
+    state.blockedReason ??
+    (isDirty ? 'Save schema and examples as one draft' : 'No unsaved changes');
 
   return html`
-    <div class="dc-contract-save-bar" role="region" aria-label="Data contract save controls">
+    <div class="dc-contract-save-controls">
       <div class="dc-contract-save-summary" aria-live="polite">
         ${state.saving
-          ? html`<span class="dc-contract-save-state">Saving contract…</span>`
+          ? html`<span class="dc-contract-save-state">Saving draft…</span>`
           : state.saveError
             ? html`<span class="dc-status-error">${state.saveError}</span>`
             : state.saveSuccess
-              ? html`<span class="dc-status-success">Contract saved</span>`
+              ? html`<span class="dc-status-success">Draft saved</span>`
               : isDirty
                 ? html`
-                    <span class="dc-contract-save-state">Unsaved changes</span>
+                    <span class="dc-contract-save-state">Unsaved draft changes</span>
                     ${state.schemaDirty
                       ? html`<span class="dc-contract-change-badge">Schema</span>`
                       : nothing}
@@ -73,7 +74,7 @@ export function renderContractSaveBar(
           @click=${() => callbacks.onSave()}
           title=${saveTooltip}
         >
-          ${state.saving ? 'Saving…' : 'Save contract'}
+          ${state.saving ? 'Saving…' : 'Save draft'}
         </button>
       </div>
     </div>

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
@@ -8,13 +8,7 @@ import { render } from 'lit';
 import { describe, expect, it, vi } from 'vitest';
 import { DataContractState } from '../DataContractState.js';
 import type { DataExample } from '../types.js';
-import {
-  renderExamplesSection,
-  type ExamplesSectionCallbacks,
-  type ExamplesUiState,
-} from './ExamplesSection.js';
-
-const onSave = vi.fn();
+import { renderExamplesSection, type ExamplesSectionCallbacks } from './ExamplesSection.js';
 
 const callbacks: ExamplesSectionCallbacks = {
   onSelectExample: vi.fn(),
@@ -24,7 +18,6 @@ const callbacks: ExamplesSectionCallbacks = {
   onUpdateExampleData: vi.fn(),
   onUndo: vi.fn(),
   onRedo: vi.fn(),
-  onSave,
 };
 
 function renderSection(examples: DataExample[], editingId: string | null = null): HTMLElement {
@@ -32,11 +25,7 @@ function renderSection(examples: DataExample[], editingId: string | null = null)
   return renderState(state, editingId);
 }
 
-function renderState(
-  state: DataContractState,
-  editingId: string | null = null,
-  uiOverrides: Partial<ExamplesUiState> = {},
-): HTMLElement {
+function renderState(state: DataContractState, editingId: string | null = null): HTMLElement {
   const container = document.createElement('div');
   render(
     renderExamplesSection(
@@ -49,10 +38,6 @@ function renderState(
         canUndo: false,
         canRedo: false,
         readOnly: false,
-        saving: false,
-        canSave: false,
-        saveTooltip: '',
-        ...uiOverrides,
       },
       callbacks,
     ),
@@ -62,22 +47,14 @@ function renderState(
 }
 
 describe('ExamplesSection required example state', () => {
-  it('renders a save action directly beside example undo and redo', () => {
+  it('keeps example undo and redo local without a section-specific save action', () => {
     const example = { id: 'one', name: 'Example 1', data: {} };
-    const state = new DataContractState(null, [example], {});
-    state.updateDraftExample(example.id, { name: 'Updated' });
-    const container = renderState(state, example.id, { canSave: true });
+    const container = renderSection([example], example.id);
     const actions = container.querySelector('.dc-example-toolbar-actions');
-    onSave.mockClear();
 
     expect(actions?.textContent).toContain('Undo');
     expect(actions?.textContent).toContain('Redo');
-    expect(actions?.textContent).toContain('Save');
-    const saveButton = actions?.querySelector<HTMLButtonElement>('.dc-example-save-btn');
-    expect(saveButton?.disabled).toBe(false);
-
-    saveButton?.click();
-    expect(onSave).toHaveBeenCalledOnce();
+    expect(actions?.textContent).not.toContain('Save');
   });
 
   it('explains the requirement and offers to add the first example', () => {

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
@@ -52,13 +52,14 @@ describe('ExamplesSection required example state', () => {
     );
   });
 
-  it('disables deleting the last example', () => {
+  it('hides deletion and explains why for the last example', () => {
     const example = { id: 'one', name: 'Example 1', data: {} };
     const container = renderSection([example], example.id);
 
-    const deleteButton = container.querySelector<HTMLButtonElement>('.dc-example-delete-btn');
-    expect(deleteButton?.disabled).toBe(true);
-    expect(deleteButton?.title).toBe('At least one test data example is required');
+    expect(container.querySelector('.dc-example-delete-btn')).toBeNull();
+    expect(container.querySelector('.dc-example-delete-requirement')?.textContent).toContain(
+      'This is the only example. At least one test data example is required.',
+    );
   });
 
   it('allows deleting when another example remains', () => {

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
@@ -21,8 +21,12 @@ const callbacks: ExamplesSectionCallbacks = {
 };
 
 function renderSection(examples: DataExample[], editingId: string | null = null): HTMLElement {
-  const container = document.createElement('div');
   const state = new DataContractState(null, examples, {});
+  return renderState(state, editingId);
+}
+
+function renderState(state: DataContractState, editingId: string | null = null): HTMLElement {
+  const container = document.createElement('div');
   render(
     renderExamplesSection(
       state,
@@ -57,8 +61,12 @@ describe('ExamplesSection required example state', () => {
     const container = renderSection([example], example.id);
 
     expect(container.querySelector('.dc-example-delete-btn')).toBeNull();
-    expect(container.querySelector('.dc-example-delete-requirement')?.textContent).toContain(
-      'This is the only example. At least one test data example is required.',
+    const requirement = container
+      .querySelector('.dc-example-delete-requirement')
+      ?.textContent?.replace(/\s+/g, ' ')
+      .trim();
+    expect(requirement).toBe(
+      'This example cannot be deleted because at least one test data example is required.',
     );
   });
 
@@ -68,6 +76,32 @@ describe('ExamplesSection required example state', () => {
       { id: 'two', name: 'Example 2', data: {} },
     ];
     const container = renderSection(examples, examples[0].id);
+
+    expect(container.querySelector<HTMLButtonElement>('.dc-example-delete-btn')?.disabled).toBe(
+      false,
+    );
+  });
+
+  it('keeps a saved example protected while its alternative is unsaved', () => {
+    const savedExample = { id: 'saved', name: 'Saved example', data: {} };
+    const state = new DataContractState(null, [savedExample], {});
+    state.addDraftExample({ id: 'new', name: 'New example', data: {} });
+
+    const container = renderState(state, savedExample.id);
+
+    expect(container.querySelector('.dc-example-delete-btn')).toBeNull();
+    expect(container.querySelector('.dc-example-delete-requirement')?.textContent).toContain(
+      'Save another example before deleting this one.',
+    );
+  });
+
+  it('allows an unsaved example to be removed locally', () => {
+    const savedExample = { id: 'saved', name: 'Saved example', data: {} };
+    const newExample = { id: 'new', name: 'New example', data: {} };
+    const state = new DataContractState(null, [savedExample], {});
+    state.addDraftExample(newExample);
+
+    const container = renderState(state, newExample.id);
 
     expect(container.querySelector<HTMLButtonElement>('.dc-example-delete-btn')?.disabled).toBe(
       false,

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { render } from 'lit';
+import { describe, expect, it, vi } from 'vitest';
+import { DataContractState } from '../DataContractState.js';
+import type { DataExample } from '../types.js';
+import { renderExamplesSection, type ExamplesSectionCallbacks } from './ExamplesSection.js';
+
+const callbacks: ExamplesSectionCallbacks = {
+  onSelectExample: vi.fn(),
+  onAddExample: vi.fn(),
+  onDeleteExample: vi.fn(),
+  onUpdateExampleName: vi.fn(),
+  onUpdateExampleData: vi.fn(),
+  onUndo: vi.fn(),
+  onRedo: vi.fn(),
+};
+
+function renderSection(examples: DataExample[], editingId: string | null = null): HTMLElement {
+  const container = document.createElement('div');
+  const state = new DataContractState(null, examples, {});
+  render(
+    renderExamplesSection(
+      state,
+      {
+        editingId,
+        fieldErrorMap: new Map(),
+        validationErrorCount: 0,
+        exampleErrorCounts: {},
+        canUndo: false,
+        canRedo: false,
+        readOnly: false,
+      },
+      callbacks,
+    ),
+    container,
+  );
+  return container;
+}
+
+describe('ExamplesSection required example state', () => {
+  it('explains the requirement and offers to add the first example', () => {
+    const container = renderSection([]);
+
+    expect(container.textContent).toContain('At least one test data example is required');
+    expect(container.querySelector<HTMLButtonElement>('.dc-empty-state .ep-btn')?.disabled).toBe(
+      false,
+    );
+  });
+
+  it('disables deleting the last example', () => {
+    const example = { id: 'one', name: 'Example 1', data: {} };
+    const container = renderSection([example], example.id);
+
+    const deleteButton = container.querySelector<HTMLButtonElement>('.dc-example-delete-btn');
+    expect(deleteButton?.disabled).toBe(true);
+    expect(deleteButton?.title).toBe('At least one test data example is required');
+  });
+
+  it('allows deleting when another example remains', () => {
+    const examples = [
+      { id: 'one', name: 'Example 1', data: {} },
+      { id: 'two', name: 'Example 2', data: {} },
+    ];
+    const container = renderSection(examples, examples[0].id);
+
+    expect(container.querySelector<HTMLButtonElement>('.dc-example-delete-btn')?.disabled).toBe(
+      false,
+    );
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
@@ -8,7 +8,13 @@ import { render } from 'lit';
 import { describe, expect, it, vi } from 'vitest';
 import { DataContractState } from '../DataContractState.js';
 import type { DataExample } from '../types.js';
-import { renderExamplesSection, type ExamplesSectionCallbacks } from './ExamplesSection.js';
+import {
+  renderExamplesSection,
+  type ExamplesSectionCallbacks,
+  type ExamplesUiState,
+} from './ExamplesSection.js';
+
+const onSave = vi.fn();
 
 const callbacks: ExamplesSectionCallbacks = {
   onSelectExample: vi.fn(),
@@ -18,6 +24,7 @@ const callbacks: ExamplesSectionCallbacks = {
   onUpdateExampleData: vi.fn(),
   onUndo: vi.fn(),
   onRedo: vi.fn(),
+  onSave,
 };
 
 function renderSection(examples: DataExample[], editingId: string | null = null): HTMLElement {
@@ -25,7 +32,11 @@ function renderSection(examples: DataExample[], editingId: string | null = null)
   return renderState(state, editingId);
 }
 
-function renderState(state: DataContractState, editingId: string | null = null): HTMLElement {
+function renderState(
+  state: DataContractState,
+  editingId: string | null = null,
+  uiOverrides: Partial<ExamplesUiState> = {},
+): HTMLElement {
   const container = document.createElement('div');
   render(
     renderExamplesSection(
@@ -38,6 +49,10 @@ function renderState(state: DataContractState, editingId: string | null = null):
         canUndo: false,
         canRedo: false,
         readOnly: false,
+        saving: false,
+        canSave: false,
+        saveTooltip: '',
+        ...uiOverrides,
       },
       callbacks,
     ),
@@ -47,6 +62,24 @@ function renderState(state: DataContractState, editingId: string | null = null):
 }
 
 describe('ExamplesSection required example state', () => {
+  it('renders a save action directly beside example undo and redo', () => {
+    const example = { id: 'one', name: 'Example 1', data: {} };
+    const state = new DataContractState(null, [example], {});
+    state.updateDraftExample(example.id, { name: 'Updated' });
+    const container = renderState(state, example.id, { canSave: true });
+    const actions = container.querySelector('.dc-example-toolbar-actions');
+    onSave.mockClear();
+
+    expect(actions?.textContent).toContain('Undo');
+    expect(actions?.textContent).toContain('Redo');
+    expect(actions?.textContent).toContain('Save');
+    const saveButton = actions?.querySelector<HTMLButtonElement>('.dc-example-save-btn');
+    expect(saveButton?.disabled).toBe(false);
+
+    saveButton?.click();
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
   it('explains the requirement and offers to add the first example', () => {
     const container = renderSection([]);
 

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
@@ -119,32 +119,38 @@ export function renderExamplesSection(
                     }}
                   />
                 </div>
-                <button
-                  class="dc-example-delete-btn"
-                  ?disabled=${uiState.readOnly || examples.length <= 1}
-                  @click=${() => callbacks.onDeleteExample(selectedExample.id)}
-                  title=${examples.length <= 1
-                    ? 'At least one test data example is required'
-                    : 'Delete this example'}
-                  aria-label="Delete example"
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4H12z"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </button>
+                ${examples.length <= 1
+                  ? html`
+                      <span class="dc-example-delete-requirement">
+                        This is the only example. At least one test data example is required.
+                      </span>
+                    `
+                  : html`
+                      <button
+                        class="dc-example-delete-btn"
+                        ?disabled=${uiState.readOnly}
+                        @click=${() => callbacks.onDeleteExample(selectedExample.id)}
+                        title="Delete this example"
+                        aria-label="Delete example"
+                      >
+                        <svg
+                          width="16"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4H12z"
+                            stroke="currentColor"
+                            stroke-width="1.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          />
+                        </svg>
+                      </button>
+                    `}
               </div>
 
               <!-- Floating Toolbar -->

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
@@ -47,7 +47,9 @@ export function renderExamplesSection(
 
   return html`
     <section class="dc-section dc-examples-section">
-      <h3 class="dc-section-label">Test Data Examples</h3>
+      <h3 class="dc-section-label">
+        Test Data Examples <span class="dc-required-indicator" aria-label="required">*</span>
+      </h3>
       <p class="dc-section-hint">
         Create example data sets to test your templates. Each example must conform to the schema.
       </p>
@@ -119,9 +121,11 @@ export function renderExamplesSection(
                 </div>
                 <button
                   class="dc-example-delete-btn"
-                  ?disabled=${uiState.readOnly}
+                  ?disabled=${uiState.readOnly || examples.length <= 1}
                   @click=${() => callbacks.onDeleteExample(selectedExample.id)}
-                  title="Delete this example"
+                  title=${examples.length <= 1
+                    ? 'At least one test data example is required'
+                    : 'Delete this example'}
                   aria-label="Delete example"
                 >
                   <svg
@@ -259,8 +263,17 @@ export function renderExamplesSection(
                     />
                   </svg>
                 </div>
-                <p>No test data examples yet</p>
-                <span class="dc-empty-state-hint">Click "+ New" to create your first example</span>
+                <p>At least one test data example is required</p>
+                <span class="dc-empty-state-hint">
+                  Add an example before saving or publishing this data contract.
+                </span>
+                <button
+                  class="ep-btn ep-btn-primary ep-btn-sm"
+                  ?disabled=${uiState.readOnly}
+                  @click=${() => callbacks.onAddExample()}
+                >
+                  Add first example
+                </button>
               </div>
             `
           : html`

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
@@ -23,6 +23,9 @@ export interface ExamplesUiState {
   canUndo: boolean;
   canRedo: boolean;
   readOnly: boolean;
+  saving: boolean;
+  canSave: boolean;
+  saveTooltip: string;
 }
 
 export interface ExamplesSectionCallbacks {
@@ -33,6 +36,7 @@ export interface ExamplesSectionCallbacks {
   onUpdateExampleData: (id: string, path: string, value: JsonValue) => void;
   onUndo: () => void;
   onRedo: () => void;
+  onSave: () => void;
 }
 
 export function renderExamplesSection(
@@ -192,6 +196,14 @@ export function renderExamplesSection(
                       />
                     </svg>
                     Redo
+                  </button>
+                  <button
+                    class="ep-btn ep-btn-primary ep-btn-sm dc-example-save-btn"
+                    ?disabled=${uiState.readOnly || uiState.saving || !uiState.canSave}
+                    @click=${() => callbacks.onSave()}
+                    title=${uiState.saveTooltip}
+                  >
+                    ${uiState.saving ? 'Saving...' : 'Save'}
                   </button>
                 </div>
 

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
@@ -44,6 +44,11 @@ export function renderExamplesSection(
   const selectedExample = uiState.editingId
     ? examples.find((e) => e.id === uiState.editingId)
     : null;
+  const canDeleteSelected = selectedExample ? state.canDeleteExample(selectedExample.id) : false;
+  const deleteRequirement =
+    selectedExample && examples.length > 1 && state.isExampleCommitted(selectedExample.id)
+      ? 'Save another example before deleting this one. At least one saved test data example is required.'
+      : 'This example cannot be deleted because at least one test data example is required.';
 
   return html`
     <section class="dc-section dc-examples-section">
@@ -119,12 +124,8 @@ export function renderExamplesSection(
                     }}
                   />
                 </div>
-                ${examples.length <= 1
-                  ? html`
-                      <span class="dc-example-delete-requirement">
-                        This is the only example. At least one test data example is required.
-                      </span>
-                    `
+                ${!canDeleteSelected
+                  ? html` <span class="dc-example-delete-requirement">${deleteRequirement}</span> `
                   : html`
                       <button
                         class="dc-example-delete-btn"

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
@@ -23,9 +23,6 @@ export interface ExamplesUiState {
   canUndo: boolean;
   canRedo: boolean;
   readOnly: boolean;
-  saving: boolean;
-  canSave: boolean;
-  saveTooltip: string;
 }
 
 export interface ExamplesSectionCallbacks {
@@ -36,7 +33,6 @@ export interface ExamplesSectionCallbacks {
   onUpdateExampleData: (id: string, path: string, value: JsonValue) => void;
   onUndo: () => void;
   onRedo: () => void;
-  onSave: () => void;
 }
 
 export function renderExamplesSection(
@@ -196,14 +192,6 @@ export function renderExamplesSection(
                       />
                     </svg>
                     Redo
-                  </button>
-                  <button
-                    class="ep-btn ep-btn-primary ep-btn-sm dc-example-save-btn"
-                    ?disabled=${uiState.readOnly || uiState.saving || !uiState.canSave}
-                    @click=${() => callbacks.onSave()}
-                    title=${uiState.saveTooltip}
-                  >
-                    ${uiState.saving ? 'Saving...' : 'Save'}
                   </button>
                 </div>
 

--- a/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { render } from 'lit';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  renderSchemaSection,
+  type SchemaSectionCallbacks,
+  type SchemaUiState,
+} from './SchemaSection.js';
+
+const uiState: SchemaUiState = {
+  warnings: [],
+  canUndo: false,
+  canRedo: false,
+  selectedFieldId: null,
+  readOnly: false,
+  jsonPanelOpen: false,
+};
+
+const callbacks: SchemaSectionCallbacks = {
+  onCommand: vi.fn(),
+  onToggleFieldExpand: vi.fn(),
+  onSelectField: vi.fn(),
+  onUndo: vi.fn(),
+  onRedo: vi.fn(),
+  onAddField: vi.fn(),
+  onImport: vi.fn(),
+  onToggleJson: vi.fn(),
+};
+
+describe('SchemaSection toolbar', () => {
+  it('keeps schema actions and undo history local without a section-specific save action', () => {
+    const container = document.createElement('div');
+    render(renderSchemaSection({ fields: [] }, uiState, callbacks, new Set()), container);
+
+    const toolbar = container.querySelector('.dc-toolbar');
+    expect(toolbar?.textContent).toContain('Add Field');
+    expect(toolbar?.textContent).toContain('Undo');
+    expect(toolbar?.textContent).toContain('Redo');
+    expect(toolbar?.querySelector('.dc-save-btn')).toBeNull();
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.ts
@@ -38,13 +38,6 @@ export interface SchemaUiState {
   selectedFieldId: string | null;
   readOnly: boolean;
   jsonPanelOpen: boolean;
-  // Save state
-  saving: boolean;
-  canSave: boolean;
-  saveSuccess: boolean;
-  saveError: string | null;
-  canForceSave: boolean;
-  saveTooltip: string;
 }
 
 export interface SchemaSectionCallbacks {
@@ -56,8 +49,6 @@ export interface SchemaSectionCallbacks {
   onAddField: () => void;
   onImport: () => void;
   onToggleJson: () => void;
-  onSave: () => void;
-  onForceSave: () => void;
 }
 
 // =============================================================================
@@ -152,28 +143,6 @@ export function renderSchemaSection(
             />
           </svg>
           Redo
-        </button>
-
-        ${uiState.saveSuccess ? html`<span class="dc-status-success">Saved</span>` : nothing}
-        ${uiState.saveError
-          ? html`<span class="dc-status-error">${uiState.saveError}</span>`
-          : nothing}
-        ${uiState.canForceSave
-          ? html`<button
-              class="ep-btn ep-btn-outline ep-btn-sm dc-force-save-btn"
-              ?disabled=${uiState.saving}
-              @click=${() => callbacks.onForceSave()}
-            >
-              Save Anyway
-            </button>`
-          : nothing}
-        <button
-          class="ep-btn ep-btn-primary ep-btn-sm dc-save-btn"
-          ?disabled=${uiState.readOnly || uiState.saving || !uiState.canSave}
-          @click=${() => callbacks.onSave()}
-          title=${uiState.saveTooltip}
-        >
-          ${uiState.saving ? 'Saving...' : 'Save'}
         </button>
       </div>
 

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/commands/DeleteDataExample.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/commands/DeleteDataExample.kt
@@ -12,6 +12,7 @@ import app.epistola.suite.mediator.CommandHandler
 import app.epistola.suite.security.Permission
 import app.epistola.suite.security.RequiresPermission
 import app.epistola.suite.templates.contracts.model.ContractVersion
+import app.epistola.suite.templates.validation.requireAtLeastOneDataExample
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Component
@@ -65,6 +66,7 @@ class DeleteDataExampleHandler(
             }
 
             val updatedExamples = draftContract.dataExamples.filter { it.id != command.exampleId }
+            requireAtLeastOneDataExample(updatedExamples)
 
             handle.createUpdate(
                 """

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/contracts/commands/PublishContractVersion.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/contracts/commands/PublishContractVersion.kt
@@ -22,6 +22,7 @@ import app.epistola.suite.templates.contracts.queries.CheckContractPublishImpact
 import app.epistola.suite.templates.contracts.queries.ContractPublishImpact
 import app.epistola.suite.templates.validation.JsonSchemaValidator
 import app.epistola.suite.templates.validation.SchemaValidationResult
+import app.epistola.suite.templates.validation.requireAtLeastOneDataExample
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Component
@@ -100,6 +101,7 @@ class PublishContractVersionHandler(
                 .orElse(null) ?: return@inTransaction null
 
             // 2. Validate schema and examples
+            requireAtLeastOneDataExample(draft.dataExamples)
             if (draft.dataModel != null) {
                 val schemaValidation = jsonSchemaValidator.validateSchema(objectMapper.writeValueAsString(draft.dataModel))
                 require(schemaValidation is SchemaValidationResult.Valid) {

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/contracts/commands/UpdateContractVersion.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/contracts/commands/UpdateContractVersion.kt
@@ -15,6 +15,7 @@ import app.epistola.suite.templates.contracts.model.ContractVersion
 import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.validation.DataModelValidationException
 import app.epistola.suite.templates.validation.JsonSchemaValidator
+import app.epistola.suite.templates.validation.requireAtLeastOneDataExample
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Component
@@ -92,6 +93,7 @@ class UpdateContractVersionHandler(
 
             // Validate examples against schema
             val effectiveExamples = command.dataExamples ?: draft.dataExamples.toList()
+            requireAtLeastOneDataExample(effectiveExamples)
             val warnings = mutableMapOf<String, List<String>>()
 
             if (effectiveDataModel != null && effectiveExamples.isNotEmpty()) {

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/contracts/queries/PreviewContractUpdate.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/contracts/queries/PreviewContractUpdate.kt
@@ -15,6 +15,7 @@ import app.epistola.suite.templates.contracts.model.ContractVersion
 import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.validation.JsonSchemaValidator
 import app.epistola.suite.templates.validation.ValidationError
+import app.epistola.suite.templates.validation.requireAtLeastOneDataExample
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.mapTo
 import org.springframework.stereotype.Component
@@ -73,6 +74,7 @@ class PreviewContractUpdateHandler(
         val base = draft ?: published
         val effectiveDataModel = query.dataModel ?: base?.dataModel
         val effectiveExamples = query.dataExamples ?: base?.dataExamples?.toList() ?: emptyList()
+        requireAtLeastOneDataExample(effectiveExamples)
 
         val exampleValidationErrors = if (effectiveDataModel != null && effectiveExamples.isNotEmpty()) {
             jsonSchemaValidator.validateExamples(effectiveDataModel, effectiveExamples)

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/validation/DataExampleRequirements.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/templates/validation/DataExampleRequirements.kt
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.templates.validation
+
+import app.epistola.suite.templates.model.DataExample
+import app.epistola.suite.validation.ValidationCode
+import app.epistola.suite.validation.validate
+
+/** Enforces the authoring invariant without invalidating readable legacy contract versions. */
+fun requireAtLeastOneDataExample(dataExamples: Collection<DataExample>) {
+    validate(
+        field = "dataExamples",
+        value = dataExamples.isNotEmpty(),
+        code = ValidationCode.DATA_EXAMPLE_REQUIRED,
+    ) {
+        "At least one data example is required"
+    }
+}

--- a/modules/epistola-core/src/main/kotlin/app/epistola/suite/validation/ValidationCode.kt
+++ b/modules/epistola-core/src/main/kotlin/app/epistola/suite/validation/ValidationCode.kt
@@ -23,6 +23,9 @@ enum class ValidationCode(val wire: String) {
     /** No specific domain code — generic command/field validation failure. */
     GENERIC("VALIDATION_ERROR"),
 
+    // Data contract authoring.
+    DATA_EXAMPLE_REQUIRED("DATA_EXAMPLE_REQUIRED"),
+
     // Node parameter bindings (cross-document + structural shape).
     NODE_PARAMETER_BINDING_UNKNOWN("NODE_PARAMETER_BINDING_UNKNOWN"),
     NODE_PARAMETER_BINDING_SYNTAX_INVALID("NODE_PARAMETER_BINDING_SYNTAX_INVALID"),

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogExportImportTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/CatalogExportImportTest.kt
@@ -49,6 +49,7 @@ import app.epistola.suite.templates.commands.versions.PublishVersion
 import app.epistola.suite.templates.contracts.commands.PublishContractVersion
 import app.epistola.suite.templates.contracts.commands.UpdateContractVersion
 import app.epistola.suite.templates.contracts.queries.GetLatestContractVersion
+import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.model.Node
 import app.epistola.suite.templates.model.Slot
 import app.epistola.suite.templates.model.TemplateDocument
@@ -56,6 +57,7 @@ import app.epistola.suite.templates.queries.GetDocumentTemplate
 import app.epistola.suite.templates.validation.JsonSchemaValidator
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.themes.commands.CreateTheme
 import app.epistola.template.model.ThemeRef
 import org.assertj.core.api.Assertions.assertThat
@@ -134,6 +136,9 @@ class CatalogExportImportTest : IntegrationTestBase() {
             UpdateContractVersion(
                 templateId = templateId,
                 dataModel = contractSchema,
+                dataExamples = listOf(
+                    DataExample("example-1", "Example 1", ObjectMapper().createObjectNode().put("name", "Ada")),
+                ),
             ).execute()
             PublishContractVersion(templateId = templateId).execute()
 
@@ -369,6 +374,9 @@ class CatalogExportImportTest : IntegrationTestBase() {
             UpdateContractVersion(
                 templateId = templateId,
                 dataModel = contractSchema,
+                dataExamples = listOf(
+                    DataExample("example-1", "Example 1", ObjectMapper().createObjectNode().put("name", "Ada")),
+                ),
             ).execute()
             PublishContractVersion(templateId = templateId).execute()
 
@@ -636,7 +644,7 @@ class CatalogExportImportTest : IntegrationTestBase() {
             // its owning catalog (the cross-catalog reference shape the picker writes).
             val templateKey = TestIdHelpers.nextTemplateId()
             val templateId = TemplateId(templateKey, sourceCatalogId)
-            CreateDocumentTemplate(id = templateId, name = "Cross-Catalog Image Template").execute()
+            CreateDocumentTemplate(id = templateId, name = "Cross-Catalog Image Template").execute().withRequiredDataExample()
             val variantKey = VariantKey.INITIAL
             val variantId = VariantId(variantKey, templateId)
             app.epistola.suite.templates.commands.versions.UpdateDraft(
@@ -879,7 +887,7 @@ class CatalogExportImportTest : IntegrationTestBase() {
 
             // Template embedding the stencil with a binding + snapshot, published.
             val templateId = TemplateId(templateKey, sourceCatalogId)
-            CreateDocumentTemplate(id = templateId, name = "Letter").execute()
+            CreateDocumentTemplate(id = templateId, name = "Letter").execute().withRequiredDataExample()
             val variantId = VariantId(variantKey, templateId)
             app.epistola.suite.templates.commands.versions.UpdateDraft(
                 variantId = variantId,

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/ExportBlocksMultipleStencilVersionsTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/ExportBlocksMultipleStencilVersionsTest.kt
@@ -28,6 +28,7 @@ import app.epistola.suite.templates.model.Node
 import app.epistola.suite.templates.model.Slot
 import app.epistola.suite.templates.model.TemplateDocument
 import app.epistola.suite.testing.IntegrationTestBase
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.template.model.ThemeRef
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -153,7 +154,7 @@ class ExportBlocksMultipleStencilVersionsTest : IntegrationTestBase() {
     ) {
         val templateKey = TemplateKey.of(templateSlug)
         val templateId = TemplateId(templateKey, catalogId)
-        CreateDocumentTemplate(id = templateId, name = templateSlug).execute()
+        CreateDocumentTemplate(id = templateId, name = templateSlug).execute().withRequiredDataExample()
 
         val variantKey = VariantKey.INITIAL
         val variantId = VariantId(variantKey, templateId)

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/RepeatedCatalogDeploymentTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/RepeatedCatalogDeploymentTest.kt
@@ -31,6 +31,7 @@ import app.epistola.suite.templates.queries.versions.ListVersions
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
 import app.epistola.suite.testing.TestTemplateBuilder
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.themes.commands.CreateTheme
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -454,7 +455,7 @@ class RepeatedCatalogDeploymentTest : IntegrationTestBase() {
 
             val templateKey = TestIdHelpers.nextTemplateId()
             val templateId = TemplateId(templateKey, catalogId)
-            CreateDocumentTemplate(id = templateId, name = "ZIP Template").execute()
+            CreateDocumentTemplate(id = templateId, name = "ZIP Template").execute().withRequiredDataExample()
 
             // Create a theme (so export has multiple resource types)
             val themeKey = ThemeKey.of("zip-theme")
@@ -463,7 +464,17 @@ class RepeatedCatalogDeploymentTest : IntegrationTestBase() {
 
             // Add contract data and publish
             val contractSchema = schema("""{"type":"object","properties":{"invoice_number":{"type":"string"},"total":{"type":"number"}},"required":["invoice_number"]}""")
-            UpdateContractVersion(templateId = templateId, dataModel = contractSchema).execute()
+            UpdateContractVersion(
+                templateId = templateId,
+                dataModel = contractSchema,
+                dataExamples = listOf(
+                    app.epistola.suite.templates.model.DataExample(
+                        "example-1",
+                        "Example 1",
+                        schema("""{"invoice_number":"INV-1","total":42}"""),
+                    ),
+                ),
+            ).execute()
             PublishContractVersion(templateId = templateId).execute()
 
             // Export as ZIP

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/StencilVersionImportConflictTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/catalog/commands/StencilVersionImportConflictTest.kt
@@ -36,6 +36,7 @@ import app.epistola.suite.templates.model.Node
 import app.epistola.suite.templates.model.Slot
 import app.epistola.suite.templates.model.TemplateDocument
 import app.epistola.suite.testing.IntegrationTestBase
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.template.model.ThemeRef
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -452,7 +453,7 @@ class StencilVersionImportConflictTest : IntegrationTestBase() {
     private fun publishTemplateReferencingStencil(catalogId: CatalogId, templateSlug: String, stencilKey: StencilKey, stencilVersion: Int) {
         val templateKey = TemplateKey.of(templateSlug)
         val templateId = TemplateId(templateKey, catalogId)
-        CreateDocumentTemplate(id = templateId, name = templateSlug).execute()
+        CreateDocumentTemplate(id = templateId, name = templateSlug).execute().withRequiredDataExample()
 
         val variantId = VariantId(VariantKey.INITIAL, templateId)
         UpdateDraft(

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/documents/PreviewDocumentIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/documents/PreviewDocumentIntegrationTest.kt
@@ -319,6 +319,13 @@ class PreviewDocumentIntegrationTest : IntegrationTestBase() {
                         """{"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}""",
                         tools.jackson.databind.node.ObjectNode::class.java,
                     ),
+                    dataExamples = listOf(
+                        app.epistola.suite.templates.model.DataExample(
+                            "example-1",
+                            "Example 1",
+                            objectMapper.createObjectNode().put("name", "Ada"),
+                        ),
+                    ),
                 ).execute()
                 DocumentSetup(tenant, template, variant, version)
             }.whenever { setup ->
@@ -633,6 +640,13 @@ class PreviewDocumentIntegrationTest : IntegrationTestBase() {
                     dataModel = objectMapper.readValue(
                         """{"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}""",
                         tools.jackson.databind.node.ObjectNode::class.java,
+                    ),
+                    dataExamples = listOf(
+                        app.epistola.suite.templates.model.DataExample(
+                            "example-1",
+                            "Example 1",
+                            objectMapper.createObjectNode().put("name", "Ada"),
+                        ),
                     ),
                 ).execute()
                 app.epistola.suite.templates.contracts.commands.PublishContractVersion(

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/environments/EnvironmentCommandsTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/environments/EnvironmentCommandsTest.kt
@@ -24,6 +24,7 @@ import app.epistola.suite.templates.queries.variants.ListVariants
 import app.epistola.suite.templates.queries.versions.ListVersions
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -61,7 +62,7 @@ class EnvironmentCommandsTest : IntegrationTestBase() {
         // Compose the real publish flow to get an activation: template (auto-creates a variant
         // with a draft version), environment, published contract, then publish to the environment.
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variant = ListVariants(templateId = templateId).query().first()
         val variantId = VariantId(variant.id, templateId)
         val draft = ListVersions(variantId = variantId).query().first()

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/fonts/FontFingerprintDeterminismTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/fonts/FontFingerprintDeterminismTest.kt
@@ -35,6 +35,7 @@ import app.epistola.suite.templates.queries.versions.GetDraft
 import app.epistola.suite.templates.queries.versions.GetLatestPublishedVersion
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.themes.commands.CreateTheme
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -153,7 +154,7 @@ class FontFingerprintDeterminismTest : IntegrationTestBase() {
 
             // 2. Template pinned to that theme + a richtext contract.
             val templateId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
-            CreateDocumentTemplate(id = templateId, name = "fp-determinism-template").execute()
+            CreateDocumentTemplate(id = templateId, name = "fp-determinism-template").execute().withRequiredDataExample()
             UpdateDocumentTemplate(
                 id = templateId,
                 themeId = ThemeKey.of("brand-theme"),

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/StencilIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/StencilIntegrationTest.kt
@@ -36,6 +36,7 @@ import app.epistola.suite.templates.commands.versions.PublishVersion
 import app.epistola.suite.templates.commands.versions.UpdateDraft
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.validation.ValidationException
 import app.epistola.template.model.Node
 import app.epistola.template.model.Slot
@@ -433,7 +434,7 @@ class StencilIntegrationTest : IntegrationTestBase() {
         PublishStencilVersion(versionId = StencilVersionId(VersionKey.of(2), stencilId)).execute()
 
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Letter").execute()
+        CreateDocumentTemplate(id = templateId, name = "Letter").execute().withRequiredDataExample()
         val variantId = VariantId(VariantKey.INITIAL, templateId)
         UpdateDraft(variantId = variantId, templateModel = templateEmbedding(stencilId.key.value)).execute()
 
@@ -473,7 +474,7 @@ class StencilIntegrationTest : IntegrationTestBase() {
         // Template embedding stencil v1, then published — leaving NO open draft.
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Letter").execute()
+        CreateDocumentTemplate(id = templateId, name = "Letter").execute().withRequiredDataExample()
         val variantKey = VariantKey.INITIAL
         val variantId = VariantId(variantKey, templateId)
         UpdateDraft(variantId = variantId, templateModel = templateEmbedding(stencilId.key.value)).execute()
@@ -542,7 +543,7 @@ class StencilIntegrationTest : IntegrationTestBase() {
         // so its only (published) version already pins the latest stencil version.
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Letter").execute()
+        CreateDocumentTemplate(id = templateId, name = "Letter").execute().withRequiredDataExample()
         val variantId = VariantId(VariantKey.INITIAL, templateId)
         UpdateDraft(variantId = variantId, templateModel = templateEmbedding(stencilId.key.value)).execute()
         UpdateStencilInTemplate(variantId = variantId, stencilId = stencilId, newVersion = 2).execute()

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/StencilPlaceholderIntegrationTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/stencils/StencilPlaceholderIntegrationTest.kt
@@ -24,6 +24,7 @@ import app.epistola.suite.templates.commands.versions.UpdateDraft
 import app.epistola.suite.templates.validation.hasValidationCode
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.validation.ValidationCode
 import app.epistola.suite.validation.ValidationException
 import app.epistola.template.model.Node
@@ -274,7 +275,7 @@ class StencilPlaceholderIntegrationTest : IntegrationTestBase() {
 
         val templateKey = TestIdHelpers.nextTemplateId()
         val templateId = TemplateId(templateKey, CatalogId.default(tenantId))
-        CreateDocumentTemplate(id = templateId, name = "Nested stencils").execute()
+        CreateDocumentTemplate(id = templateId, name = "Nested stencils").execute().withRequiredDataExample()
         val variantId = VariantId(VariantKey.INITIAL, templateId)
         val nested = templateWithNestedStencilFill(
             outerStencilId.key.value,

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/DiscardDraftTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/DiscardDraftTest.kt
@@ -19,6 +19,7 @@ import app.epistola.suite.templates.queries.versions.GetDraft
 import app.epistola.suite.templates.queries.versions.GetLatestPublishedVersion
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -38,7 +39,7 @@ class DiscardDraftTest : IntegrationTestBase() {
         val catalogId = CatalogId.default(tenantId)
         templateId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
         withMediator {
-            CreateDocumentTemplate(id = templateId, name = "discard-draft-test").execute()
+            CreateDocumentTemplate(id = templateId, name = "discard-draft-test").execute().withRequiredDataExample()
         }
         defaultVariantId = VariantId(
             VariantKey.INITIAL,

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/PublishToEnvironmentTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/PublishToEnvironmentTest.kt
@@ -28,6 +28,7 @@ import app.epistola.suite.templates.queries.variants.ListVariants
 import app.epistola.suite.templates.queries.versions.ListVersions
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -41,7 +42,7 @@ class PublishToEnvironmentTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val variant = variants.first()
         val variantId = VariantId(variant.id, templateId)
@@ -82,7 +83,7 @@ class PublishToEnvironmentTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val variant = variants.first()
         val variantId = VariantId(variant.id, templateId)
@@ -128,7 +129,7 @@ class PublishToEnvironmentTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val variant = variants.first()
         val variantId = VariantId(variant.id, templateId)
@@ -166,7 +167,7 @@ class PublishToEnvironmentTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val variant = variants.first()
         val variantId = VariantId(variant.id, templateId)
@@ -191,7 +192,7 @@ class PublishToEnvironmentTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val variant = variants.first()
         val variantId = VariantId(variant.id, templateId)
@@ -234,7 +235,7 @@ class PublishToEnvironmentTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val variant = variants.first()
         val variantId = VariantId(variant.id, templateId)
@@ -308,7 +309,7 @@ class PublishToEnvironmentTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val variant = variants.first()
         val variantId = VariantId(variant.id, templateId)

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/PublishVersionTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/PublishVersionTest.kt
@@ -42,6 +42,7 @@ import app.epistola.suite.templates.queries.versions.ListVersions
 import app.epistola.suite.templates.validation.hasValidationCode
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.validation.ValidationCode
 import app.epistola.suite.validation.ValidationException
 import app.epistola.template.model.ThemeRef
@@ -83,7 +84,7 @@ class PublishVersionTest : IntegrationTestBase() {
         val catalogId = CatalogId.default(tenantId)
         templateId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
         withMediator {
-            CreateDocumentTemplate(id = templateId, name = "publish-version-test").execute()
+            CreateDocumentTemplate(id = templateId, name = "publish-version-test").execute().withRequiredDataExample()
         }
         defaultVariantId = VariantId(
             VariantKey.INITIAL,

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/VersionScopingTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/commands/versions/VersionScopingTest.kt
@@ -26,6 +26,7 @@ import app.epistola.suite.templates.model.VersionStatus
 import app.epistola.suite.templates.queries.versions.GetVersion
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.template.model.ThemeRef
 import org.assertj.core.api.Assertions.assertThat
 import org.jdbi.v3.core.Jdbi
@@ -78,7 +79,7 @@ class VersionScopingTest : IntegrationTestBase() {
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
         val variantId = VariantId(VariantKey.INITIAL, templateId)
-        CreateDocumentTemplate(id = templateId, name = "Referenced Paths").execute()
+        CreateDocumentTemplate(id = templateId, name = "Referenced Paths").execute().withRequiredDataExample()
 
         UpdateVersion(
             VersionId(VersionKey.of(1), variantId),
@@ -115,8 +116,8 @@ class VersionScopingTest : IntegrationTestBase() {
         val firstVariantId = VariantId(sharedVariantKey, firstTemplateId)
         val secondVariantId = VariantId(sharedVariantKey, secondTemplateId)
 
-        CreateDocumentTemplate(id = firstTemplateId, name = "First Template").execute()
-        CreateDocumentTemplate(id = secondTemplateId, name = "Second Template").execute()
+        CreateDocumentTemplate(id = firstTemplateId, name = "First Template").execute().withRequiredDataExample()
+        CreateDocumentTemplate(id = secondTemplateId, name = "Second Template").execute().withRequiredDataExample()
         CreateVariant(id = firstVariantId, title = "Shared", description = null).execute()
         CreateVariant(id = secondVariantId, title = "Shared", description = null).execute()
 

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/contracts/ContractVersionCommandsTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/contracts/ContractVersionCommandsTest.kt
@@ -27,9 +27,12 @@ import app.epistola.suite.templates.contracts.model.ContractVersionStatus
 import app.epistola.suite.templates.contracts.queries.GetDraftContractVersion
 import app.epistola.suite.templates.contracts.queries.GetLatestContractVersion
 import app.epistola.suite.templates.contracts.queries.ListContractVersions
+import app.epistola.suite.templates.model.DataExample
 import app.epistola.suite.templates.queries.versions.GetDraft
+import app.epistola.suite.templates.validation.hasValidationCode
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.validation.ValidationCode
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -58,8 +61,18 @@ class ContractVersionCommandsTest : IntegrationTestBase() {
         templateId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
         withMediator {
             CreateDocumentTemplate(id = templateId, name = "contract-test-template").execute()
+            UpdateContractVersion(
+                templateId = templateId,
+                dataExamples = listOf(testExample()),
+            ).execute()
         }
     }
+
+    private fun testExample() = DataExample(
+        id = "example-1",
+        name = "Example 1",
+        data = objectMapper.createObjectNode(),
+    )
 
     @Nested
     inner class CreateContractVersionTest {
@@ -136,6 +149,18 @@ class ContractVersionCommandsTest : IntegrationTestBase() {
             }
             assertThat(result).isNotNull
             assertThat(result!!.contractVersion.dataModel).isNotNull
+        }
+
+        @Test
+        fun `rejects an update without an example`() {
+            assertThatThrownBy {
+                withMediator {
+                    UpdateContractVersion(templateId = templateId, dataExamples = emptyList()).execute()
+                }
+            }
+                .isInstanceOf(app.epistola.suite.validation.ValidationException::class.java)
+                .hasValidationCode(ValidationCode.DATA_EXAMPLE_REQUIRED)
+                .hasMessageContaining("At least one data example")
         }
     }
 
@@ -313,13 +338,17 @@ class ContractVersionCommandsTest : IntegrationTestBase() {
         }
 
         @Test
-        fun `publishes auto-created empty draft`() {
-            // Draft always exists (auto-created with template), publish works immediately
-            val result = withMediator {
-                PublishContractVersion(templateId = templateId).execute()
+        fun `rejects publishing an auto-created draft without an example`() {
+            val emptyTemplateId = TemplateId(TestIdHelpers.nextTemplateId(), templateId.catalogId)
+            withMediator {
+                CreateDocumentTemplate(id = emptyTemplateId, name = "empty-contract-template").execute()
             }
-            assertThat(result).isNotNull
-            assertThat(result!!.publishedVersion!!.dataModel).isNull() // empty contract
+
+            assertThatThrownBy {
+                withMediator { PublishContractVersion(templateId = emptyTemplateId).execute() }
+            }
+                .isInstanceOf(app.epistola.suite.validation.ValidationException::class.java)
+                .hasValidationCode(ValidationCode.DATA_EXAMPLE_REQUIRED)
         }
     }
 
@@ -327,7 +356,7 @@ class ContractVersionCommandsTest : IntegrationTestBase() {
     inner class PublishGuardTest {
         @Test
         fun `PublishToEnvironment auto-publishes compatible draft contract`() {
-            // The auto-created draft v1 (empty) is compatible — auto-publishes on deploy
+            // The draft v1 is compatible and has the required example, so it auto-publishes.
             val tenantId = TenantId(tenantKey)
             val env = withMediator {
                 CreateEnvironment(

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/contracts/ContractVersionScenariosTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/contracts/ContractVersionScenariosTest.kt
@@ -33,6 +33,7 @@ import app.epistola.suite.templates.queries.versions.GetDraft
 import app.epistola.suite.templates.queries.versions.ListVersions
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -66,7 +67,7 @@ class ContractVersionScenariosTest : IntegrationTestBase() {
         val catalogId = CatalogId.default(tenantId)
         templateId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
         withMediator {
-            CreateDocumentTemplate(id = templateId, name = "scenario-template").execute()
+            CreateDocumentTemplate(id = templateId, name = "scenario-template").execute().withRequiredDataExample()
         }
         defaultVariantId = VariantId(
             VariantKey.INITIAL,
@@ -125,6 +126,13 @@ class ContractVersionScenariosTest : IntegrationTestBase() {
                 UpdateContractVersion(
                     templateId = templateId,
                     dataModel = schema("""{"type":"object","properties":{"name":{"type":"string"},"amount":{"type":"number"}},"required":["name"]}"""),
+                    dataExamples = listOf(
+                        app.epistola.suite.templates.model.DataExample(
+                            id = "example-1",
+                            name = "Example 1",
+                            data = schema("""{"name":"Ada","amount":42}"""),
+                        ),
+                    ),
                 ).execute()
             }
 

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/queries/DeploymentMatrixQueryTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/templates/queries/DeploymentMatrixQueryTest.kt
@@ -24,6 +24,7 @@ import app.epistola.suite.templates.queries.versions.ListPublishableVersionsByTe
 import app.epistola.suite.templates.queries.versions.ListVersions
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -34,7 +35,7 @@ class DeploymentMatrixQueryTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
 
         val cells = GetDeploymentMatrix(templateId = templateId).query()
         assertThat(cells).isEmpty()
@@ -45,7 +46,7 @@ class DeploymentMatrixQueryTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val defaultVariant = variants.first()
         val defaultVariantId = VariantId(defaultVariant.id, templateId)
@@ -100,7 +101,7 @@ class DeploymentMatrixQueryTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val defaultVariant = variants.first()
         val defaultVariantId = VariantId(defaultVariant.id, templateId)
@@ -139,7 +140,7 @@ class DeploymentMatrixQueryTest : IntegrationTestBase() {
         val tenant = createTenant("Test Tenant")
         val tenantId = TenantId(tenant.id)
         val templateId = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId))
-        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute()
+        val template = CreateDocumentTemplate(id = templateId, name = "Invoice").execute().withRequiredDataExample()
         val variants = ListVariants(templateId = templateId).query()
         val defaultVariant = variants.first()
 

--- a/modules/epistola-core/src/test/kotlin/app/epistola/suite/themes/ThemeQueriesTest.kt
+++ b/modules/epistola-core/src/test/kotlin/app/epistola/suite/themes/ThemeQueriesTest.kt
@@ -28,6 +28,7 @@ import app.epistola.suite.templates.model.createDefaultTemplateModel
 import app.epistola.suite.tenants.commands.SetTenantDefaultTheme
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.themes.commands.CreateTheme
 import app.epistola.suite.themes.commands.UpdateTheme
 import app.epistola.suite.themes.queries.GetTheme
@@ -231,10 +232,10 @@ class ThemeQueriesTest : IntegrationTestBase() {
         SetTenantDefaultTheme(tenant.id, targetTheme.key, targetTheme.catalogKey).execute()
 
         val tenantTemplateId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
-        CreateDocumentTemplate(tenantTemplateId, "Tenant Default").execute()
+        CreateDocumentTemplate(tenantTemplateId, "Tenant Default").execute().withRequiredDataExample()
 
         val templateDefaultId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
-        CreateDocumentTemplate(templateDefaultId, "Template Default").execute()
+        CreateDocumentTemplate(templateDefaultId, "Template Default").execute().withRequiredDataExample()
         UpdateDocumentTemplate(
             id = templateDefaultId,
             themeId = targetTheme.key,
@@ -242,7 +243,7 @@ class ThemeQueriesTest : IntegrationTestBase() {
         ).execute()
 
         val overrideTemplateId = TemplateId(TestIdHelpers.nextTemplateId(), catalogId)
-        CreateDocumentTemplate(overrideTemplateId, "Variant Override").execute()
+        CreateDocumentTemplate(overrideTemplateId, "Variant Override").execute().withRequiredDataExample()
         UpdateDocumentTemplate(
             id = overrideTemplateId,
             themeId = otherTheme.key,

--- a/modules/epistola-support-backups/src/test/kotlin/app/epistola/suite/tenantbackup/MergeNotCascadeIntegrationTest.kt
+++ b/modules/epistola-support-backups/src/test/kotlin/app/epistola/suite/tenantbackup/MergeNotCascadeIntegrationTest.kt
@@ -18,6 +18,7 @@ import app.epistola.suite.templates.commands.CreateDocumentTemplate
 import app.epistola.suite.templates.commands.versions.PublishVersion
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import org.assertj.core.api.Assertions.assertThat
 import org.jdbi.v3.core.Jdbi
 import org.junit.jupiter.api.Test
@@ -45,7 +46,7 @@ class MergeNotCascadeIntegrationTest : IntegrationTestBase() {
 
         withMediator {
             CreateCatalog(tenantKey = tenant.id, id = main, name = "Main").execute()
-            CreateDocumentTemplate(id = TemplateId(templateKey, catalogId), name = "Invoice").execute()
+            CreateDocumentTemplate(id = TemplateId(templateKey, catalogId), name = "Invoice").execute().withRequiredDataExample()
             val defaultVariant = VariantId(VariantKey.of(variantKey), TemplateId(templateKey, catalogId))
             PublishVersion(versionId = VersionId(VersionKey.of(1), defaultVariant)).execute()
         }

--- a/modules/epistola-support-backups/src/test/kotlin/app/epistola/suite/tenantbackup/TenantBackupRoundTripIntegrationTest.kt
+++ b/modules/epistola-support-backups/src/test/kotlin/app/epistola/suite/tenantbackup/TenantBackupRoundTripIntegrationTest.kt
@@ -24,6 +24,7 @@ import app.epistola.suite.tenants.commands.SetTenantDefaultTheme
 import app.epistola.suite.tenants.queries.GetTenant
 import app.epistola.suite.testing.IntegrationTestBase
 import app.epistola.suite.testing.TestIdHelpers
+import app.epistola.suite.testing.withRequiredDataExample
 import app.epistola.suite.themes.commands.CreateTheme
 import org.assertj.core.api.Assertions.assertThat
 import org.jdbi.v3.core.Jdbi
@@ -50,7 +51,7 @@ class TenantBackupRoundTripIntegrationTest : IntegrationTestBase() {
         val templateKey = TestIdHelpers.nextTemplateId()
         withMediator {
             CreateCatalog(tenantKey = tenant.id, id = main, name = "Main").execute()
-            CreateDocumentTemplate(id = TemplateId(templateKey, catalogId), name = "Invoice").execute()
+            CreateDocumentTemplate(id = TemplateId(templateKey, catalogId), name = "Invoice").execute().withRequiredDataExample()
             CreateTheme(id = ThemeId(ThemeKey.of("brand"), catalogId), name = "Brand").execute()
             SetTenantDefaultTheme(tenantId = tenant.id, themeId = ThemeKey.of("brand"), catalogKey = main).execute()
 

--- a/modules/testing/src/main/kotlin/app/epistola/suite/testing/Scenario.kt
+++ b/modules/testing/src/main/kotlin/app/epistola/suite/testing/Scenario.kt
@@ -161,12 +161,13 @@ class ScenarioBuilder(private val namespace: String) {
             name: String,
         ): DocumentTemplate {
             val tenantId = TenantId(tenantKey)
-            return capturedMediator.send(
+            val template = capturedMediator.send(
                 CreateDocumentTemplate(
                     id = TemplateId(TestIdHelpers.nextTemplateId(), CatalogId.default(tenantId)),
                     name = name,
                 ),
             )
+            return template.withRequiredDataExample()
         }
 
         /**

--- a/modules/testing/src/main/kotlin/app/epistola/suite/testing/TestDataContracts.kt
+++ b/modules/testing/src/main/kotlin/app/epistola/suite/testing/TestDataContracts.kt
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.testing
+
+import app.epistola.suite.common.ids.CatalogId
+import app.epistola.suite.common.ids.TemplateId
+import app.epistola.suite.common.ids.TenantId
+import app.epistola.suite.mediator.execute
+import app.epistola.suite.templates.DocumentTemplate
+import app.epistola.suite.templates.contracts.commands.UpdateContractVersion
+import app.epistola.suite.templates.model.DataExample
+import tools.jackson.databind.node.JsonNodeFactory
+
+/** Gives general-purpose template fixtures the minimum publishable data contract. */
+fun ensureRequiredDataExample(templateId: TemplateId) {
+    UpdateContractVersion(
+        templateId = templateId,
+        dataExamples = listOf(
+            DataExample(
+                id = "example-1",
+                name = "Example 1",
+                data = JsonNodeFactory.instance.objectNode(),
+            ),
+        ),
+    ).execute()
+}
+
+fun DocumentTemplate.withRequiredDataExample(): DocumentTemplate = apply {
+    ensureRequiredDataExample(
+        TemplateId(
+            id,
+            CatalogId(catalogKey, TenantId(tenantKey)),
+        ),
+    )
+}


### PR DESCRIPTION
## Description

Require every authored data contract to contain at least one test data example, and make the shared schema/example save behavior explicit in the editor.

The final persisted example can no longer be deleted. The editor keeps the delete action disabled and explains that at least one example is required. Newly added examples only count once they can be saved, preventing an unsaved example from incorrectly enabling deletion of the sole persisted example. Backend validation also protects update, publish, preview, and delete operations.

Schema and examples are saved together as one draft. Their combined save controls now live in the sticky contract action bar:

- Editing shows **Save draft** and **Done editing**.
- Viewing shows **Publish** and **Edit**.
- Dirty-state indicators identify whether the schema, examples, or both have changed.
- Save progress, validation failures, and the saved state remain visible while scrolling.
- HTMX status-bar refreshes preserve edit mode and reconnect the editor controls to the replaced bar.

Schema undo/redo and each example's undo/redo remain independent; saving persists the complete contract draft.

## Related Issue(s)

Closes #839
Closes #842

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependencies, CI, tooling)

## Component(s) Affected

- [x] Backend (Spring Boot/Kotlin)
- [x] Frontend (Editor/TypeScript)
- [ ] Documentation
- [ ] CI/CD

## Behavior and compatibility

- New and edited contract drafts require at least one example when saved.
- Publishing a contract without an example is rejected.
- Deleting the final persisted example is rejected by both the UI and backend.
- Existing empty contract versions remain readable.
- Catalog import and snapshot restore can preserve legacy empty versions.
- Creating or copying an incomplete draft remains possible until it is saved or published.

## Verification

- `./gradlew unitTest integrationTest uiTest ktlintCheck`
- Editor suite: 2,024 tests
- `pnpm typecheck`
- `pnpm build`
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm lint:css`
- `pnpm license:check`
- Added browser coverage for the sticky save controls, dirty state, save flow, and HTMX refresh.

## Checklist

- [x] Code follows the project style and formatting rules
- [x] Self-review completed
- [x] Tests added for backend validation and editor behavior
- [x] Existing backend, frontend, integration, and UI tests pass locally
- [x] `CHANGELOG.md` updated
- [x] Commits follow Conventional Commits

## Screenshots

Not included.
