### PR TITLE
feat(data-contracts): autofill realistic schema examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@
   versions remain readable and importable.
 - **[user]** fix(data contracts): **Examples can be deleted directly from a published contract.**
   The editor now starts a draft automatically before applying the deletion.
+- **[user]** feat(data-contracts): **Example data can be completed from its schema.** A new
+  per-example **Autofill** action fills missing values with seeded, realistic Dutch test data inferred from
+  field names, titles, and descriptions, alongside defaults, enums, formats, numeric constraints,
+  and nested object/array structure. Common municipal roles, communication methods, references,
+  and identifiers receive domain-shaped values; unknown strings get a numbered, field-specific
+  fallback instead of a repeated generic placeholder. Related fields share a coherent fictional
+  profile, and unconstrained arrays receive a seeded two or three items rather than an
+  unrepresentative single item. Each object in an array receives its own coherent fictional profile,
+  and generated fallback and formatted values such as names and email addresses are distinct
+  between items. Authored values are preserved and the complete operation can be undone in one
+  step. Empty example fields now render their existing placeholder hints with muted italic text and
+  a subtle accent edge, including rich-text fields, so hints cannot be mistaken for stored test data
+  or disabled controls.
 - **[dev]** feat(logging): **Application logs support structured JSON.** Suite and PDF renderer
   processes can emit newline-delimited Logstash, ECS, or GELF output through
   `LOGGING_STRUCTURED_FORMAT_CONSOLE`, including tenant context when available and bounded stack

--- a/modules/editor/package.json
+++ b/modules/editor/package.json
@@ -21,6 +21,7 @@
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
     "@epistola.app/epistola-catalog": "1.0.1",
     "@epistola/design-system": "workspace:*",
+    "@faker-js/faker": "^10.5.0",
     "@floating-ui/dom": "^1.7.5",
     "driver.js": "^1.8.0",
     "jsonata": "^2.0.5",

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.exampleGeneration.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.exampleGeneration.test.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { JsonSchema } from './types.js';
+import { EpistolaDataContractEditor } from './EpistolaDataContractEditor.js';
+
+const schema: JsonSchema = {
+  type: 'object',
+  required: ['name', 'active', 'address'],
+  properties: {
+    name: { type: 'string' },
+    active: { type: 'boolean' },
+    address: {
+      type: 'object',
+      required: ['city'],
+      properties: {
+        city: { type: 'string' },
+      },
+    },
+  },
+};
+
+async function mountEditor(readOnly = false): Promise<EpistolaDataContractEditor> {
+  const editor = new EpistolaDataContractEditor();
+  editor.init(
+    schema,
+    [{ id: 'example-1', name: 'Example 1', data: { name: 'Authored' } }],
+    {},
+    readOnly,
+  );
+  document.body.append(editor);
+  await editor.updateComplete;
+  return editor;
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe('example generation', () => {
+  it('fills missing values, preserves authored data, and can be undone in one step', async () => {
+    const editor = await mountEditor();
+    const generate = editor.querySelector<HTMLButtonElement>('.dc-example-generate-btn')!;
+
+    generate.click();
+    generate.click();
+    await vi.waitFor(() => expect(editor.contractState!.dataExamples[0].data.active).toBe(true));
+    await editor.updateComplete;
+
+    expect(editor.contractState!.dataExamples[0].data).toMatchObject({
+      name: 'Authored',
+      active: true,
+      address: { city: expect.any(String) },
+    });
+    expect(editor.querySelector('.dc-validation-success')?.textContent).toContain('Valid');
+
+    const undo = editor.querySelector<HTMLButtonElement>(
+      '.dc-example-toolbar button[aria-label="Undo"]',
+    )!;
+    expect(undo.disabled).toBe(false);
+    undo.click();
+    await editor.updateComplete;
+
+    expect(editor.contractState!.dataExamples[0].data).toEqual({ name: 'Authored' });
+  });
+
+  it('disables generation in read-only mode', async () => {
+    const editor = await mountEditor(true);
+
+    expect(editor.querySelector<HTMLButtonElement>('.dc-example-generate-btn')!.disabled).toBe(
+      true,
+    );
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
@@ -61,6 +61,7 @@ import { renderJsonSchemaView } from './sections/JsonSchemaView.js';
 import { renderImportSchemaDialog } from './sections/ImportSchemaDialog.js';
 import { setNestedValue, buildFieldErrorMap } from './sections/ExampleForm.js';
 import { renderContractSaveControls } from './sections/ContractSaveBar.js';
+import { completeExampleFromSchema } from './utils/exampleGeneration.js';
 
 @customElement('epistola-data-contract-editor')
 export class EpistolaDataContractEditor extends LitElement {
@@ -115,6 +116,7 @@ export class EpistolaDataContractEditor extends LitElement {
 
   // Per-example undo/redo stacks
   private _exampleHistories = new Map<string, SnapshotHistory<JsonObject>>();
+  private _generatingExampleIds = new Set<string>();
   @state() private _exampleCanUndo = false;
   @state() private _exampleCanRedo = false;
 
@@ -463,6 +465,9 @@ export class EpistolaDataContractEditor extends LitElement {
       exampleErrorCounts,
       canUndo: this._exampleCanUndo,
       canRedo: this._exampleCanRedo,
+      canGenerate: Boolean(
+        state.schema?.properties && Object.keys(state.schema.properties).length > 0,
+      ),
       readOnly: this._readOnly,
     };
 
@@ -472,6 +477,7 @@ export class EpistolaDataContractEditor extends LitElement {
       onDeleteExample: (id) => this._deleteExample(id),
       onUpdateExampleName: (id, name) => this._updateExampleName(id, name),
       onUpdateExampleData: (id, path, value) => this._updateExampleData(id, path, value),
+      onGenerateExample: (id) => void this._generateExampleData(id),
       onUndo: () => this._undoExampleData(),
       onRedo: () => this._redoExampleData(),
     };
@@ -872,6 +878,41 @@ export class EpistolaDataContractEditor extends LitElement {
     this._clearSaveStatus();
     this._validateAllExamples();
     this._syncExampleUndoRedoState();
+  }
+
+  private async _generateExampleData(id: string): Promise<void> {
+    const state = this.contractState!;
+    if (
+      this._generatingExampleIds.has(id) ||
+      !state.schema ||
+      !state.dataExamples.some((candidate) => candidate.id === id)
+    ) {
+      return;
+    }
+
+    this._generatingExampleIds.add(id);
+    try {
+      const { createSemanticExampleValues } = await import('./utils/semanticExampleValues.js');
+      if (this.contractState !== state) return;
+
+      const example = state.dataExamples.find((candidate) => candidate.id === id);
+      if (!example || !state.schema) return;
+
+      const completedData = completeExampleFromSchema(
+        state.schema,
+        example.data,
+        createSemanticExampleValues(id),
+      );
+      if (JSON.stringify(completedData) === JSON.stringify(example.data)) return;
+
+      this._getExampleHistory(id).push(example.data);
+      state.updateDraftExample(id, { data: completedData });
+      this._clearSaveStatus();
+      this._validateAllExamples();
+      this._syncExampleUndoRedoState();
+    } finally {
+      this._generatingExampleIds.delete(id);
+    }
   }
 
   private _undoExampleData(): void {

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -631,6 +631,20 @@
     }
   }
 
+  .dc-tree-input::placeholder,
+  .dc-array-item-input::placeholder {
+    color: var(--ep-stone-400);
+    font-style: italic;
+    opacity: 1;
+  }
+
+  .dc-tree-input:placeholder-shown:not(:disabled),
+  .dc-array-item-input:placeholder-shown:not(:disabled) {
+    background: var(--ep-white);
+    border-color: var(--ep-terracotta-200);
+    box-shadow: inset 3px 0 0 var(--ep-terracotta-100);
+  }
+
   /* Rich-text input: wraps a ProseMirror editor in place of a single-line input. */
   epistola-rich-text-input {
     display: block;
@@ -643,6 +657,7 @@
     }
 
     .dc-rich-text-container {
+      position: relative;
       min-height: var(--ep-h-9);
       font-size: var(--ep-text-sm);
       padding: var(--ep-space-1-5) var(--ep-space-3);
@@ -663,6 +678,21 @@
         ol {
           padding-left: 1.25em;
         }
+      }
+
+      &.has-placeholder[data-empty]::before {
+        content: attr(data-placeholder);
+        position: absolute;
+        inset: var(--ep-space-1-5) var(--ep-space-3) auto;
+        color: var(--ep-stone-400);
+        font-style: italic;
+        pointer-events: none;
+      }
+
+      &.has-placeholder[data-empty] {
+        background: var(--ep-white);
+        border-color: var(--ep-terracotta-200);
+        box-shadow: inset 3px 0 0 var(--ep-terracotta-100);
       }
     }
 
@@ -1091,6 +1121,7 @@
       display: flex;
       align-items: center;
       gap: var(--ep-space-1);
+      flex-wrap: wrap;
     }
 
     & .dc-example-toolbar-btn {
@@ -1120,6 +1151,16 @@
       &:focus-visible {
         outline: none;
         box-shadow: var(--ep-ring);
+      }
+    }
+
+    & .dc-example-generate-btn {
+      color: var(--ep-primary-strong);
+      background: var(--ep-terracotta-50);
+
+      &:hover:not(:disabled) {
+        color: var(--ep-primary-strong);
+        background: var(--ep-terracotta-100);
       }
     }
   }

--- a/modules/editor/src/main/typescript/data-contract/sections/EpistolaRichTextInput.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/EpistolaRichTextInput.test.ts
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// @vitest-environment happy-dom
+
 import { describe, expect, it } from 'vitest';
 import { EditorState } from 'prosemirror-state';
-import { buildRichTextInputPlugins } from './EpistolaRichTextInput.js';
+import { buildRichTextInputPlugins, EpistolaRichTextInput } from './EpistolaRichTextInput.js';
 import { richTextBlockSchema } from '../../prosemirror/richTextBlockSchema.js';
 import { richTextInlineSchema } from '../../prosemirror/richTextInlineSchema.js';
 import { BUBBLE_MENU_KEY } from '../../prosemirror/bubble-menu.js';
@@ -24,5 +26,27 @@ describe('buildRichTextInputPlugins', () => {
       plugins: buildRichTextInputPlugins('inline', richTextInlineSchema),
     });
     expect(BUBBLE_MENU_KEY.get(state)).toBeDefined();
+  });
+});
+
+describe('EpistolaRichTextInput placeholder', () => {
+  it('marks only empty rich-text content for placeholder styling', async () => {
+    const input = new EpistolaRichTextInput();
+    input.placeholder = 'toelichting';
+    document.body.append(input);
+    await input.updateComplete;
+
+    const container = input.querySelector('.dc-rich-text-container')!;
+    expect(container.getAttribute('data-placeholder')).toBe('toelichting');
+    expect(container.hasAttribute('data-empty')).toBe(true);
+
+    input.value = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Ingevuld' }] }],
+    };
+    await input.updateComplete;
+
+    expect(container.hasAttribute('data-empty')).toBe(false);
+    input.remove();
   });
 });

--- a/modules/editor/src/main/typescript/data-contract/sections/EpistolaRichTextInput.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/EpistolaRichTextInput.ts
@@ -188,6 +188,7 @@ export class EpistolaRichTextInput extends LitElement {
       plugins: this._buildPlugins(),
     });
     this._lastEmittedJson = JSON.stringify(doc.toJSON());
+    this._syncPlaceholderState(doc);
     this._view = new EditorView(this._container, {
       state,
       editable: () => !this.readOnly,
@@ -195,6 +196,7 @@ export class EpistolaRichTextInput extends LitElement {
         if (!this._view) return;
         const newState = this._view.state.apply(tr);
         this._view.updateState(newState);
+        this._syncPlaceholderState(newState.doc);
         if (tr.docChanged) {
           const json = newState.doc.toJSON();
           const serialized = JSON.stringify(json);
@@ -219,11 +221,16 @@ export class EpistolaRichTextInput extends LitElement {
     const next = JSON.stringify(doc.toJSON());
     if (next === this._lastEmittedJson) return;
     this._lastEmittedJson = next;
+    this._syncPlaceholderState(doc);
     const newState = EditorState.create({
       doc,
       plugins: this._view.state.plugins,
     });
     this._view.updateState(newState);
+  }
+
+  private _syncPlaceholderState(doc: ProsemirrorNode): void {
+    this._container?.toggleAttribute('data-empty', doc.textContent.length === 0);
   }
 
   private _docFromValue(value: JsonValue | null): ProsemirrorNode {

--- a/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.test.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// @vitest-environment happy-dom
+
 import { describe, expect, it } from 'vitest';
+import { render } from 'lit';
 import {
   validationPathToFormPath,
   buildFieldErrorMap,
@@ -10,8 +13,69 @@ import {
   toDateTimeLocal,
   dateTimeOffset,
   combineDateTime,
+  renderExampleForm,
 } from './ExampleForm.js';
 import type { SchemaValidationError } from '../utils/schemaValidation.js';
+import type { JsonSchema } from '../types.js';
+
+describe('example form placeholders', () => {
+  it('renders field-name hints without assigning field values', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        emailadres: { type: 'string' },
+        aantal: { type: 'integer' },
+      },
+    };
+    const container = document.createElement('div');
+
+    render(
+      renderExampleForm(schema, {}, () => {}),
+      container,
+    );
+
+    const email = container.querySelector<HTMLInputElement>('#dc-field-emailadres')!;
+    const count = container.querySelector<HTMLInputElement>('#dc-field-aantal')!;
+    expect(email.value).toBe('');
+    expect(email.placeholder).toBe('emailadres');
+    expect(count.value).toBe('');
+    expect(count.placeholder).toBe('aantal');
+  });
+
+  it('renders placeholders at nested object and array depths', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        arr: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              arr: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const container = document.createElement('div');
+
+    render(
+      renderExampleForm(schema, { arr: [{ arr: [{}] }] }, () => {}),
+      container,
+    );
+
+    const nestedName = container.querySelector<HTMLInputElement>('#dc-field-arr-0-arr-0-name')!;
+    expect(nestedName.value).toBe('');
+    expect(nestedName.placeholder).toBe('name');
+    expect(nestedName.classList.contains('dc-tree-input')).toBe(true);
+  });
+});
 
 describe('toDateTimeLocal', () => {
   it('keeps a zoneless local date-time for the picker', () => {

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
@@ -54,7 +54,11 @@ describe('ExamplesSection required example state', () => {
 
     expect(actions?.textContent).toContain('Undo');
     expect(actions?.textContent).toContain('Redo');
+    expect(actions?.textContent).toContain('Autofill');
     expect(actions?.textContent).not.toContain('Save');
+    expect(container.querySelector('.dc-example-generate-btn')?.getAttribute('aria-label')).toBe(
+      'Autofill missing example values from schema',
+    );
   });
 
   it('explains the requirement and offers to add the first example', () => {

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
@@ -22,6 +22,7 @@ export interface ExamplesUiState {
   exampleErrorCounts: Record<string, number>;
   canUndo: boolean;
   canRedo: boolean;
+  canGenerate: boolean;
   readOnly: boolean;
 }
 
@@ -31,6 +32,7 @@ export interface ExamplesSectionCallbacks {
   onDeleteExample: (id: string) => void;
   onUpdateExampleName: (id: string, name: string) => void;
   onUpdateExampleData: (id: string, path: string, value: JsonValue) => void;
+  onGenerateExample: (id: string) => void;
   onUndo: () => void;
   onRedo: () => void;
 }
@@ -157,6 +159,23 @@ export function renderExamplesSection(
               <!-- Floating Toolbar -->
               <div class="dc-example-toolbar">
                 <div class="dc-example-toolbar-actions">
+                  <button
+                    class="dc-example-toolbar-btn dc-example-generate-btn"
+                    ?disabled=${!uiState.canGenerate || uiState.readOnly}
+                    @click=${() => callbacks.onGenerateExample(selectedExample.id)}
+                    title="Fill missing values from the current schema; existing values are kept"
+                    aria-label="Autofill missing example values from schema"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                      <path
+                        d="M8 1.5l.8 2.4 2.4.8-2.4.8L8 7.9l-.8-2.4-2.4-.8 2.4-.8L8 1.5zM12.2 8.1l.55 1.65 1.65.55-1.65.55-.55 1.65-.55-1.65L10 10.3l1.65-.55.55-1.65zM4.2 9.1l.7 2.1 2.1.7-2.1.7-.7 2.1-.7-2.1-2.1-.7 2.1-.7.7-2.1z"
+                        stroke="currentColor"
+                        stroke-width="1.1"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    Autofill
+                  </button>
                   <button
                     class="dc-example-toolbar-btn"
                     ?disabled=${!uiState.canUndo || uiState.readOnly}

--- a/modules/editor/src/main/typescript/data-contract/types.ts
+++ b/modules/editor/src/main/typescript/data-contract/types.ts
@@ -145,6 +145,7 @@ export interface VisualSchema {
 export interface JsonSchemaProperty {
   type?: SchemaFieldType | SchemaFieldType[];
   $ref?: string;
+  title?: string;
   format?: string;
   description?: string;
   items?: JsonSchemaProperty;
@@ -153,6 +154,14 @@ export interface JsonSchemaProperty {
   minimum?: number;
   maximum?: number;
   minItems?: number;
+  maxItems?: number;
+  minLength?: number;
+  maxLength?: number;
+  multipleOf?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  enum?: JsonValue[];
+  const?: JsonValue;
   default?: JsonValue;
 }
 
@@ -163,6 +172,8 @@ export interface JsonSchema {
   properties?: Record<string, JsonSchemaProperty>;
   required?: string[];
   additionalProperties?: boolean;
+  $defs?: Record<string, JsonSchemaProperty>;
+  definitions?: Record<string, JsonSchemaProperty>;
 }
 
 // =============================================================================

--- a/modules/editor/src/main/typescript/data-contract/utils/exampleGeneration.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/exampleGeneration.test.ts
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import {
+  RICH_TEXT_INLINE_SCHEMA_REF,
+  type JsonObject,
+  type JsonSchema,
+  type JsonValue,
+} from '../types.js';
+import { validateDataAgainstSchema } from './schemaValidation.js';
+import { completeExampleFromSchema } from './exampleGeneration.js';
+import { createSemanticExampleValues } from './semanticExampleValues.js';
+
+function complete(schema: JsonSchema, existing: JsonObject) {
+  return completeExampleFromSchema(schema, existing, createSemanticExampleValues('test-example'));
+}
+
+describe('completeExampleFromSchema', () => {
+  it('keeps generic schema completion independent from semantic providers', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { name: { type: 'string' }, active: { type: 'boolean' } },
+    };
+
+    expect(completeExampleFromSchema(schema, {})).toEqual({
+      name: 'Example value',
+      active: false,
+    });
+  });
+
+  it('generates deterministic values that respect schema hints and constraints', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      required: ['name', 'status', 'createdOn', 'amount', 'active'],
+      properties: {
+        name: { type: 'string', minLength: 15 },
+        status: { type: 'string', enum: ['draft', 'final'] },
+        country: { type: 'string', default: 'NL' },
+        createdOn: { type: 'string', format: 'date' },
+        updatedAt: { type: 'string', format: 'date-time' },
+        email: { type: 'string', format: 'email' },
+        website: { type: 'string', format: 'uri' },
+        amount: { type: 'number', minimum: 2.5 },
+        count: { type: 'integer', exclusiveMinimum: 3 },
+        active: { type: 'boolean' },
+      },
+    };
+
+    const generated = complete(schema, {});
+
+    expect(generated.name).not.toBe('Example valuexx');
+    expect((generated.name as string).length).toBeGreaterThanOrEqual(15);
+    expect(generated).toMatchObject({
+      status: 'draft',
+      country: 'NL',
+      createdOn: '2024-01-01',
+      updatedAt: '2024-01-01T12:00:00Z',
+      amount: 125.5,
+      count: 4,
+      active: true,
+    });
+    expect(generated.email).toMatch(/@example\.(com|net|org)$/);
+    expect(() => new URL(generated.website as string)).not.toThrow();
+    expect(complete(schema, {})).toEqual(generated);
+    expect(validateDataAgainstSchema(generated, schema).valid).toBe(true);
+  });
+
+  it('preserves authored values while completing nested objects and arrays', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        address: {
+          type: 'object',
+          properties: {
+            street: { type: 'string' },
+            city: { type: 'string' },
+          },
+          required: ['street', 'city'],
+        },
+        contacts: {
+          type: 'array',
+          minItems: 2,
+          items: {
+            type: 'object',
+            properties: {
+              label: { type: 'string' },
+              preferred: { type: 'boolean' },
+            },
+            required: ['label', 'preferred'],
+          },
+        },
+      },
+    };
+
+    const generated = complete(schema, {
+      name: 'Authored name',
+      address: { city: 'Amsterdam' },
+      contacts: [{ label: 'Personal' }],
+      custom: 'keep me',
+    });
+
+    expect(generated).toMatchObject({
+      name: 'Authored name',
+      address: { street: expect.any(String), city: 'Amsterdam' },
+      custom: 'keep me',
+    });
+    const contacts = generated.contacts as JsonValue[];
+    expect(contacts.length).toBeGreaterThanOrEqual(2);
+    expect(contacts.length).toBeLessThanOrEqual(3);
+    expect(contacts[0]).toEqual({ label: 'Personal', preferred: false });
+    for (const [index, contact] of contacts.slice(1).entries()) {
+      expect(contact).toEqual({ label: `Example label ${index + 2}`, preferred: false });
+    }
+    expect(validateDataAgainstSchema(generated, schema).valid).toBe(true);
+  });
+
+  it('uses defaults as a base and completes their missing nested values', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        settings: {
+          type: 'object',
+          default: { locale: 'nl-NL' },
+          properties: {
+            locale: { type: 'string' },
+            notifications: { type: 'boolean' },
+          },
+        },
+      },
+    };
+
+    expect(complete(schema, {})).toEqual({
+      settings: { locale: 'nl-NL', notifications: false },
+    });
+  });
+
+  it('supports local schema references and registered rich-text references', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      $defs: {
+        address: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        },
+      },
+      properties: {
+        address: { $ref: '#/$defs/address' },
+        introduction: { $ref: RICH_TEXT_INLINE_SCHEMA_REF },
+      },
+    };
+
+    const generated = complete(schema, {});
+
+    expect(generated.address).toEqual({ city: expect.any(String) });
+    expect(generated.introduction).toMatchObject({ type: 'doc' });
+  });
+
+  it('honors array minimum and maximum constraints', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        values: { type: 'array', items: { type: 'string' }, maxItems: 0 },
+        single: { type: 'array', items: { type: 'string' }, maxItems: 1 },
+        requiredItems: { type: 'array', items: { type: 'string' }, minItems: 5 },
+      },
+    };
+
+    const generated = complete(schema, {});
+
+    expect(generated.values).toEqual([]);
+    expect(generated.single).toHaveLength(1);
+    expect(generated.requiredItems).toHaveLength(5);
+    expect(validateDataAgainstSchema(generated, schema).valid).toBe(true);
+  });
+
+  it('generates distinct formatted values for primitive array items', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        recipients: {
+          type: 'array',
+          minItems: 3,
+          items: { type: 'string', format: 'email' },
+        },
+      },
+    };
+
+    const generated = complete(schema, {});
+    const recipients = generated.recipients as string[];
+
+    expect(recipients).toHaveLength(3);
+    expect(new Set(recipients)).toHaveProperty('size', 3);
+    for (const email of recipients) expect(email).toMatch(/@example\./);
+    expect(validateDataAgainstSchema(generated, schema).valid).toBe(true);
+  });
+
+  it('generates a distinct coherent person for every object array item', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        people: {
+          type: 'array',
+          minItems: 3,
+          items: {
+            type: 'object',
+            properties: {
+              firstName: { type: 'string' },
+              lastName: { type: 'string' },
+              name: { type: 'string' },
+              email: { type: 'string', format: 'email' },
+            },
+            required: ['firstName', 'lastName', 'name', 'email'],
+          },
+        },
+      },
+    };
+
+    const generated = complete(schema, {});
+    const people = generated.people as JsonObject[];
+
+    expect(people).toHaveLength(3);
+    expect(new Set(people.map((person) => person.name))).toHaveProperty('size', 3);
+    expect(new Set(people.map((person) => person.email))).toHaveProperty('size', 3);
+    for (const person of people) {
+      if (typeof person.firstName !== 'string' || typeof person.lastName !== 'string') {
+        throw new TypeError('Generated person names must be strings');
+      }
+      expect(person.name).toBe(`${person.firstName} ${person.lastName}`);
+    }
+    expect(validateDataAgainstSchema(generated, schema).valid).toBe(true);
+  });
+
+  it('keeps explicit schema formats and numeric constraints authoritative', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        phoneNumber: { type: 'string', format: 'email' },
+        website: { type: 'string', format: 'date' },
+        amount: { type: 'number', maximum: 100 },
+        age: { type: 'integer', minimum: 50 },
+      },
+    };
+
+    const generated = complete(schema, {});
+
+    expect(generated.phoneNumber).toMatch(/@example\.(com|net|org)$/);
+    expect(generated.website).toBe('2024-01-01');
+    expect(generated.amount).toBe(100);
+    expect(generated.age).toBe(50);
+    expect(validateDataAgainstSchema(generated, schema).valid).toBe(true);
+  });
+
+  it('generates through recursively nested arrays and objects', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        arr: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              arr: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                  required: ['name'],
+                },
+              },
+            },
+            required: ['arr'],
+          },
+        },
+      },
+      required: ['arr'],
+    };
+
+    const generated = complete(schema, {});
+
+    const outerItems = generated.arr as JsonValue[];
+    expect(outerItems.length).toBeGreaterThanOrEqual(2);
+    expect(outerItems.length).toBeLessThanOrEqual(3);
+    for (const outerItem of outerItems) {
+      const innerItems = (outerItem as JsonObject).arr as JsonValue[];
+      expect(innerItems.length).toBeGreaterThanOrEqual(2);
+      expect(innerItems.length).toBeLessThanOrEqual(3);
+      for (const innerItem of innerItems) {
+        expect(innerItem).toEqual({ name: expect.any(String) });
+      }
+    }
+    expect(validateDataAgainstSchema(generated, schema).valid).toBe(true);
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/utils/exampleGeneration.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/exampleGeneration.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { findRefType } from '../ref-types.js';
+import type { JsonArray, JsonObject, JsonSchema, JsonSchemaProperty, JsonValue } from '../types.js';
+import type { ExampleField, ExampleValueProvider } from './exampleValueProvider.js';
+
+const GENERATED_DATE = '2024-01-01';
+const GENERATED_DATE_TIME = '2024-01-01T12:00:00Z';
+
+type SchemaNode = JsonSchemaProperty & {
+  type?: string | string[];
+};
+
+const NO_SEMANTIC_VALUES: ExampleValueProvider = {
+  string: () => undefined,
+  number: () => undefined,
+  boolean: () => undefined,
+  arrayLength: () => undefined,
+};
+
+/**
+ * Complete example data from a JSON Schema without replacing authored values.
+ * Missing nested properties and array items are filled recursively.
+ */
+export function completeExampleFromSchema(
+  schema: JsonSchema | JsonObject,
+  existing: JsonObject,
+  semanticValues: ExampleValueProvider = NO_SEMANTIC_VALUES,
+): JsonObject {
+  return completeObject(
+    schema as SchemaNode,
+    schema as JsonObject,
+    existing,
+    semanticValues,
+    0,
+    [],
+  );
+}
+
+function completeObject(
+  schema: SchemaNode,
+  rootSchema: JsonObject,
+  existing: JsonObject,
+  semanticValues: ExampleValueProvider,
+  depth: number,
+  path: readonly (string | number)[],
+): JsonObject {
+  if (depth > 20) return structuredClone(existing);
+
+  const result = structuredClone(existing);
+  for (const [name, propertySchema] of Object.entries(schema.properties ?? {})) {
+    const present = Object.prototype.hasOwnProperty.call(existing, name);
+    result[name] = completeValue(
+      propertySchema as SchemaNode,
+      rootSchema,
+      existing[name],
+      present,
+      {
+        name,
+        title: propertySchema.title,
+        description: propertySchema.description,
+        path: [...path, name],
+      },
+      semanticValues,
+      depth + 1,
+    );
+  }
+  return result;
+}
+
+function completeValue(
+  originalSchema: SchemaNode,
+  rootSchema: JsonObject,
+  existing: JsonValue | undefined,
+  present: boolean,
+  field: ExampleField,
+  semanticValues: ExampleValueProvider,
+  depth: number,
+): JsonValue {
+  if (depth > 20) return present ? structuredClone(existing as JsonValue) : null;
+
+  const refType = findRefType(originalSchema.$ref);
+  if (refType) {
+    return present ? structuredClone(existing as JsonValue) : refType.defaultValue();
+  }
+
+  const schema = resolveLocalRef(originalSchema, rootSchema) ?? originalSchema;
+  const type = resolveType(schema);
+
+  if (present) {
+    if (type === 'object' && isJsonObject(existing)) {
+      return completeObject(schema, rootSchema, existing, semanticValues, depth, field.path ?? []);
+    }
+    if (type === 'array' && Array.isArray(existing)) {
+      return completeArray(schema, rootSchema, existing, field, semanticValues, depth);
+    }
+    return structuredClone(existing as JsonValue);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(schema, 'const')) {
+    return structuredClone(schema.const as JsonValue);
+  }
+  if (Object.prototype.hasOwnProperty.call(schema, 'default')) {
+    return completeGeneratedContainer(
+      schema,
+      rootSchema,
+      schema.default as JsonValue,
+      field,
+      semanticValues,
+      depth,
+    );
+  }
+  if (schema.enum && schema.enum.length > 0) {
+    return structuredClone(schema.enum[0]);
+  }
+
+  switch (type) {
+    case 'object':
+      return completeObject(schema, rootSchema, {}, semanticValues, depth, field.path ?? []);
+    case 'array':
+      return completeArray(schema, rootSchema, [], field, semanticValues, depth);
+    case 'boolean':
+      return semanticValues.boolean(field) ?? false;
+    case 'integer':
+      return generateNumber(schema, true, semanticValues.number(field));
+    case 'number':
+      return generateNumber(schema, false, semanticValues.number(field));
+    case 'null':
+      return null;
+    case 'string':
+    default:
+      return generateString(schema, semanticValues.string(field, { format: schema.format }));
+  }
+}
+
+function completeGeneratedContainer(
+  schema: SchemaNode,
+  rootSchema: JsonObject,
+  generated: JsonValue,
+  field: ExampleField,
+  semanticValues: ExampleValueProvider,
+  depth: number,
+): JsonValue {
+  const type = resolveType(schema);
+  if (type === 'object' && isJsonObject(generated)) {
+    return completeObject(schema, rootSchema, generated, semanticValues, depth, field.path ?? []);
+  }
+  if (type === 'array' && Array.isArray(generated)) {
+    return completeArray(schema, rootSchema, generated, field, semanticValues, depth);
+  }
+  return structuredClone(generated);
+}
+
+function completeArray(
+  schema: SchemaNode,
+  rootSchema: JsonObject,
+  existing: JsonArray,
+  field: ExampleField,
+  semanticValues: ExampleValueProvider,
+  depth: number,
+): JsonArray {
+  const result = structuredClone(existing);
+  if (!schema.items) return result;
+
+  for (let index = 0; index < result.length; index += 1) {
+    const itemField = arrayItemField(field, index);
+    result[index] = completeValue(
+      schema.items as SchemaNode,
+      rootSchema,
+      result[index],
+      true,
+      itemField,
+      semanticValues,
+      depth + 1,
+    );
+  }
+
+  const minimum = Math.max(0, schema.minItems ?? 0);
+  const fallbackTarget = Math.max(minimum, result.length === 0 ? 1 : result.length);
+  const suggestedTarget = semanticValues.arrayLength(field, {
+    minimum,
+    maximum: schema.maxItems,
+  });
+  const unconstrainedTarget = Math.max(fallbackTarget, suggestedTarget ?? 0);
+  const target =
+    schema.maxItems === undefined
+      ? unconstrainedTarget
+      : Math.min(unconstrainedTarget, schema.maxItems);
+  while (result.length < target) {
+    const itemField = arrayItemField(field, result.length);
+    result.push(
+      completeValue(
+        schema.items as SchemaNode,
+        rootSchema,
+        undefined,
+        false,
+        itemField,
+        semanticValues,
+        depth + 1,
+      ),
+    );
+  }
+  return result;
+}
+
+function arrayItemField(field: ExampleField, index: number): ExampleField {
+  return {
+    ...field,
+    path: [...(field.path ?? [field.name]), index],
+  };
+}
+
+function generateString(schema: SchemaNode, semanticValue?: string): string {
+  let value: string;
+  switch (schema.format) {
+    case 'date':
+      value = semanticValue?.match(/^\d{4}-\d{2}-\d{2}$/) ? semanticValue : GENERATED_DATE;
+      break;
+    case 'date-time':
+      value = GENERATED_DATE_TIME;
+      break;
+    case 'time':
+      value = '12:00:00';
+      break;
+    case 'uuid':
+      value = '00000000-0000-4000-8000-000000000000';
+      break;
+    case 'email':
+      value = semanticValue?.includes('@') ? semanticValue : 'example@example.com';
+      break;
+    case 'uri':
+      value = semanticValue?.startsWith('http') ? semanticValue : 'https://example.com';
+      break;
+    default:
+      value = semanticValue ?? 'Example value';
+  }
+
+  const minimum = Math.max(0, schema.minLength ?? 0);
+  if (value.length < minimum) value = value.padEnd(minimum, 'x');
+  if (schema.maxLength !== undefined) value = value.slice(0, schema.maxLength);
+  return value;
+}
+
+function generateNumber(schema: SchemaNode, integer: boolean, semanticValue?: number): number {
+  let value = semanticValue ?? 0;
+  if (schema.minimum !== undefined) value = Math.max(value, schema.minimum);
+  if (schema.exclusiveMinimum !== undefined) {
+    value = Math.max(value, schema.exclusiveMinimum + (integer ? 1 : 0.01));
+  }
+  if (schema.maximum !== undefined) value = Math.min(value, schema.maximum);
+  if (schema.exclusiveMaximum !== undefined) {
+    value = Math.min(value, schema.exclusiveMaximum - (integer ? 1 : 0.01));
+  }
+  if (schema.multipleOf && schema.multipleOf > 0) {
+    value = Math.ceil(value / schema.multipleOf) * schema.multipleOf;
+  }
+  return integer ? Math.ceil(value) : value;
+}
+
+function resolveType(schema: SchemaNode): string {
+  const types = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
+  const nonNullType = types.find((type) => type !== 'null');
+  if (nonNullType) return nonNullType;
+  if (schema.properties) return 'object';
+  if (schema.items) return 'array';
+  return types[0] ?? 'string';
+}
+
+function resolveLocalRef(schema: SchemaNode, rootSchema: JsonObject): SchemaNode | null {
+  if (!schema.$ref?.startsWith('#/')) return null;
+  let current: unknown = rootSchema;
+  for (const encodedSegment of schema.$ref.slice(2).split('/')) {
+    if (!isJsonObject(current)) return null;
+    const segment = encodedSegment.replace(/~1/g, '/').replace(/~0/g, '~');
+    current = current[segment];
+  }
+  return isJsonObject(current) ? (current as SchemaNode) : null;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/modules/editor/src/main/typescript/data-contract/utils/exampleValueProvider.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/exampleValueProvider.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+export interface ExampleField {
+  name: string;
+  title?: string;
+  description?: string;
+  path?: readonly (string | number)[];
+}
+
+export interface ExampleValueProvider {
+  string(field: ExampleField, constraints?: { format?: string }): string | undefined;
+  number(field: ExampleField): number | undefined;
+  boolean(field: ExampleField): boolean | undefined;
+  arrayLength(
+    field: ExampleField,
+    constraints: { minimum: number; maximum?: number },
+  ): number | undefined;
+}

--- a/modules/editor/src/main/typescript/data-contract/utils/semanticExampleContext.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/semanticExampleContext.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { base, en, Faker, nl } from '@faker-js/faker';
+import type { ExampleField } from './exampleValueProvider.js';
+
+const DEFAULT_SEED = 20_260_820;
+
+export interface PersonProfile {
+  firstName: string;
+  lastName: string;
+}
+
+interface LocationProfile {
+  street: string;
+  city: string;
+  postalCode: string;
+}
+
+export interface SemanticExampleContext {
+  faker: Faker;
+  personFor(field: ExampleField, role?: string): PersonProfile;
+  locationFor(field: ExampleField): LocationProfile;
+  nextExampleEmail(person: PersonProfile): string;
+  nextFallback(field: ExampleField): string;
+}
+
+export function createSemanticExampleContext(
+  seed: number | string = DEFAULT_SEED,
+): SemanticExampleContext {
+  const faker = new Faker({ locale: [nl, en, base], seed: normalizeSeed(seed) });
+  const people = new Map<string, PersonProfile>();
+  const locations = new Map<string, LocationProfile>();
+  const usedNames = new Set<string>();
+  const fallbackSequences = new Map<string, number>();
+  let emailSequence = 0;
+
+  return {
+    faker,
+
+    personFor(field, role = 'person') {
+      const key = `${role}:${scopeKey(field)}`;
+      const existing = people.get(key);
+      if (existing) return existing;
+
+      const person = uniquePerson(faker, usedNames, people.size + 1);
+      usedNames.add(fullName(person));
+      people.set(key, person);
+      return person;
+    },
+
+    locationFor(field) {
+      const key = scopeKey(field);
+      const existing = locations.get(key);
+      if (existing) return existing;
+
+      const location = {
+        street: faker.location.street(),
+        city: faker.location.city(),
+        postalCode: faker.location.zipCode(),
+      };
+      locations.set(key, location);
+      return location;
+    },
+
+    nextExampleEmail(person) {
+      emailSequence += 1;
+      const [localPart, domain = 'example.com'] = faker.internet.exampleEmail(person).split('@');
+      return `${localPart}+${emailSequence}@${domain}`;
+    },
+
+    nextFallback(field) {
+      const label = humanize(field.title ?? field.name);
+      const sequence = nearestArrayIndex(field) ?? (fallbackSequences.get(label) ?? 0) + 1;
+      fallbackSequences.set(label, sequence);
+      return `Example ${label} ${sequence}`;
+    },
+  };
+}
+
+export function fullName(person: PersonProfile): string {
+  return `${person.firstName} ${person.lastName}`;
+}
+
+function uniquePerson(
+  faker: Faker,
+  usedNames: Set<string>,
+  fallbackSequence: number,
+): PersonProfile {
+  let candidate: PersonProfile = {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+  };
+  for (let attempt = 0; attempt < 10 && usedNames.has(fullName(candidate)); attempt += 1) {
+    candidate = {
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    };
+  }
+  if (usedNames.has(fullName(candidate))) {
+    candidate.lastName = `${candidate.lastName} ${fallbackSequence}`;
+  }
+  return candidate;
+}
+
+function scopeKey(field: ExampleField): string {
+  const path = field.path ?? [];
+  const scope = typeof path.at(-1) === 'number' ? path : path.slice(0, -1);
+  return JSON.stringify(scope);
+}
+
+function nearestArrayIndex(field: ExampleField): number | undefined {
+  const index = field.path?.findLast((segment): segment is number => typeof segment === 'number');
+  return index === undefined ? undefined : index + 1;
+}
+
+function normalizeSeed(seed: number | string): number {
+  if (typeof seed === 'number') return seed;
+
+  let hash = 2_166_136_261;
+  for (const character of seed) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+function humanize(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}

--- a/modules/editor/src/main/typescript/data-contract/utils/semanticExampleValues.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/semanticExampleValues.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import { createSemanticExampleValues } from './semanticExampleValues.js';
+
+describe('createSemanticExampleValues', () => {
+  it('creates a coherent fictional person from Dutch and English field names', () => {
+    const values = createSemanticExampleValues();
+    const firstName = values.string({ name: 'voornaam' });
+    const lastName = values.string({ name: 'lastName' });
+
+    expect(firstName).toBeTruthy();
+    expect(lastName).toBeTruthy();
+    expect(values.string({ name: 'fullName' })).toBe(`${firstName} ${lastName}`);
+    expect(values.string({ name: 'emailAddress' })).toMatch(/@example\.(com|net|org)$/);
+  });
+
+  it('uses titles and descriptions when a technical property name has no semantic meaning', () => {
+    const values = createSemanticExampleValues();
+
+    expect(values.string({ name: 'field_1', title: 'Postcode' })).toBeTruthy();
+    expect(
+      values.string({
+        name: 'field_2',
+        description: 'Het telefoonnummer waarop de aanvrager bereikbaar is.',
+      }),
+    ).toMatch(/^\+31/);
+    expect(values.number({ name: 'field_3', description: 'Leeftijd van de aanvrager' })).toBe(42);
+  });
+
+  it('generates distinct emails from a schema format without relying on the field name', () => {
+    const values = createSemanticExampleValues('email-list');
+
+    const first = values.string({ name: 'recipient' }, { format: 'email' });
+    const second = values.string({ name: 'recipient' }, { format: 'email' });
+
+    expect(first).toMatch(/@example\.(com|net|org)$/);
+    expect(second).toMatch(/@example\.(com|net|org)$/);
+    expect(second).not.toBe(first);
+  });
+
+  it('recognizes semantic numbers and booleans and labels unknown string fields clearly', () => {
+    const values = createSemanticExampleValues();
+
+    expect(values.number({ name: 'amount' })).toBe(125.5);
+    expect(values.number({ name: 'aantalItems' })).toBe(3);
+    expect(values.boolean({ name: 'isActive' })).toBe(true);
+    expect(values.string({ name: 'opaqueValue' })).toBe('Example opaque value 1');
+    expect(values.string({ name: 'opaqueValue' })).toBe('Example opaque value 2');
+    expect(values.number({ name: 'opaqueValue' })).toBeUndefined();
+    expect(values.boolean({ name: 'opaqueValue' })).toBeUndefined();
+  });
+
+  it('suggests representative array sizes within schema constraints', () => {
+    const values = createSemanticExampleValues('array-example');
+    const field = { name: 'items' };
+
+    expect(values.arrayLength(field, { minimum: 0 })).toBeGreaterThanOrEqual(2);
+    expect(values.arrayLength(field, { minimum: 0 })).toBeLessThanOrEqual(3);
+    expect(values.arrayLength(field, { minimum: 0, maximum: 1 })).toBe(1);
+    expect(values.arrayLength(field, { minimum: 0, maximum: 0 })).toBe(0);
+    expect(values.arrayLength(field, { minimum: 5 })).toBe(5);
+  });
+
+  it('covers common fields from Dutch municipal contracts', () => {
+    const values = createSemanticExampleValues('municipal-example');
+
+    expect(values.string({ name: 'beklaagde' })).not.toContain('Example beklaagde');
+    expect(values.string({ name: 'contactfunctionaris' })).not.toContain(
+      'Example contactfunctionaris',
+    );
+    expect(values.string({ name: 'team' })).toMatch(/^Team /);
+    expect(['e-mail', 'telefoon', 'brief']).toContain(values.string({ name: 'communicatie' }));
+    expect(values.string({ name: 'kenmerk_intern' })).toMatch(/^Z\/\d{2}\/\d{6}$/);
+    expect(values.string({ name: 'kenmerk_extern' })).toMatch(/^EXT-\d{4}$/);
+    expect(values.string({ name: 'bsn' })).toBe('111222333');
+    expect(values.string({ name: 'licenceplate' })).toMatch(/^[A-Z]{2}-\d{2}-[A-Z]{2}$/);
+  });
+
+  it('reproduces the same generated profile for the same seed', () => {
+    const first = createSemanticExampleValues(1234);
+    const second = createSemanticExampleValues(1234);
+
+    const fields = ['voornaam', 'achternaam', 'woonplaats', 'straat', 'postcode', 'zaaknummer'];
+    expect(fields.map((name) => first.string({ name }))).toEqual(
+      fields.map((name) => second.string({ name })),
+    );
+  });
+
+  it('uses an example-specific string seed to vary fictional profiles', () => {
+    const first = createSemanticExampleValues('example-a');
+    const second = createSemanticExampleValues('example-b');
+
+    expect(first.string({ name: 'fullName' })).not.toBe(second.string({ name: 'fullName' }));
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/utils/semanticExampleValues.ts
+++ b/modules/editor/src/main/typescript/data-contract/utils/semanticExampleValues.ts
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { ExampleField, ExampleValueProvider } from './exampleValueProvider.js';
+import { createSemanticExampleContext, fullName } from './semanticExampleContext.js';
+
+/**
+ * Creates one generation-scoped provider. Related values share a fictional
+ * profile, while a fixed seed keeps repeated completion predictable.
+ */
+export function createSemanticExampleValues(seed?: number | string): ExampleValueProvider {
+  const context = createSemanticExampleContext(seed);
+  const { faker } = context;
+
+  return {
+    string(field, constraints) {
+      const hint = semanticHint(field);
+      const person = context.personFor(field);
+
+      if (constraints?.format === 'email') return context.nextExampleEmail(person);
+
+      if (matches(hint, ['gebruikersnaam', 'username', 'user name', 'loginnaam'])) {
+        return faker.internet.username(person);
+      }
+      if (matches(hint, ['voornaam', 'first name', 'firstname', 'given name'])) {
+        return person.firstName;
+      }
+      if (matches(hint, ['achternaam', 'last name', 'lastname', 'surname', 'family name'])) {
+        return person.lastName;
+      }
+      if (matches(hint, ['initialen', 'initials'])) {
+        return `${person.firstName.charAt(0)}.${person.lastName.charAt(0)}.`;
+      }
+      if (matches(hint, ['tussenvoegsel', 'middle name', 'middlename'])) return 'van';
+      if (matches(hint, ['email', 'e mail', 'emailadres', 'mailadres'])) {
+        return context.nextExampleEmail(person);
+      }
+      if (matches(hint, ['telefoon', 'telefoonnummer', 'phone', 'mobile', 'mobiel'])) {
+        return faker.phone.number({ style: 'international' });
+      }
+      if (matches(hint, ['postcode', 'postal code', 'zip code', 'zipcode'])) {
+        return context.locationFor(field).postalCode;
+      }
+      if (matches(hint, ['huisnummer', 'house number', 'building number'])) {
+        return faker.location.buildingNumber();
+      }
+      if (matches(hint, ['straatnaam', 'straat', 'street name', 'street'])) {
+        return context.locationFor(field).street;
+      }
+      if (matches(hint, ['woonplaats', 'plaatsnaam', 'stad', 'city', 'town'])) {
+        return context.locationFor(field).city;
+      }
+      if (matches(hint, ['land', 'country'])) return 'Nederland';
+      if (matches(hint, ['beklaagde', 'respondent', 'accused', 'objector'])) {
+        return fullName(context.personFor(field, 'subject'));
+      }
+      if (
+        matches(hint, [
+          'contactfunctionaris',
+          'behandelaar',
+          'case worker',
+          'caseworker',
+          'ambtenaar',
+          'official',
+        ])
+      ) {
+        return fullName(context.personFor(field, 'official'));
+      }
+      if (
+        matches(hint, [
+          'klager',
+          'aanvrager',
+          'applicant',
+          'beneficiary',
+          'begunstigde',
+          'recipient',
+          'ontvanger',
+          'customer',
+          'klant',
+        ])
+      ) {
+        return fullName(person);
+      }
+      if (
+        matches(hint, [
+          'organisatie',
+          'organization',
+          'organisation',
+          'bedrijfsnaam',
+          'company',
+          'gemeente',
+          'municipality',
+          'vendor',
+          'leverancier',
+          'sender',
+          'afzender',
+        ])
+      ) {
+        return faker.company.name();
+      }
+      if (matches(hint, ['team', 'afdeling', 'department'])) {
+        return faker.helpers.arrayElement([
+          'Team Dienstverlening',
+          'Team Vergunningen',
+          'Team Klachtafhandeling',
+        ]);
+      }
+      if (matches(hint, ['communicatie', 'communication', 'contactwijze', 'contact method'])) {
+        return faker.helpers.arrayElement(['e-mail', 'telefoon', 'brief']);
+      }
+      if (matches(hint, ['iban', 'rekeningnummer', 'bank account'])) {
+        return faker.finance.iban({ countryCode: 'NL' });
+      }
+      if (matches(hint, ['bsn', 'burgerservicenummer', 'social security number'])) {
+        return '111222333';
+      }
+      if (matches(hint, ['kenteken', 'licence plate', 'license plate', 'licenceplate'])) {
+        return faker.helpers.fromRegExp(/[A-Z]{2}-[0-9]{2}-[A-Z]{2}/);
+      }
+      if (matches(hint, ['zaaknummer', 'case number', 'casenumber', 'dossiernummer'])) {
+        return `ZAAK-${faker.number.int({ min: 100_000, max: 999_999 })}`;
+      }
+      if (matches(hint, ['factuurnummer', 'invoice number', 'invoicenumber'])) {
+        return `FACT-2026-${faker.number.int({ min: 1_000, max: 9_999 })}`;
+      }
+      if (matches(hint, ['polisnummer', 'policy number', 'policynumber'])) {
+        return `POL-${faker.string.alphanumeric({ length: 8, casing: 'upper' })}`;
+      }
+      if (matches(hint, ['ticketnummer', 'ticket number', 'ticketnumber'])) {
+        return `TKT-${faker.number.int({ min: 10_000, max: 99_999 })}`;
+      }
+      if (matches(hint, ['kenmerk intern', 'kenmerk_intern', 'internal reference'])) {
+        return `Z/${faker.number.int({ min: 10, max: 99 })}/${faker.number.int({ min: 100_000, max: 999_999 })}`;
+      }
+      if (matches(hint, ['kenmerk extern', 'kenmerk_extern', 'external reference'])) {
+        return `EXT-${faker.number.int({ min: 1_000, max: 9_999 })}`;
+      }
+      if (matches(hint, ['referentienummer', 'reference number', 'reference'])) {
+        return `REF-${faker.string.alphanumeric({ length: 8, casing: 'upper' })}`;
+      }
+      if (matches(hint, ['website', 'web site', 'url', 'homepage', 'payment link'])) {
+        return faker.internet.url();
+      }
+      if (matches(hint, ['geboortedatum', 'birth date', 'birthdate', 'date of birth'])) {
+        return faker.date
+          .between({ from: '1970-01-01T00:00:00Z', to: '2000-12-31T00:00:00Z' })
+          .toISOString()
+          .slice(0, 10);
+      }
+      if (matches(hint, ['volledige naam', 'full name', 'fullname', 'contactnaam'])) {
+        return fullName(person);
+      }
+      if (matches(hint, ['programma', 'program name', 'programname', 'product name'])) {
+        return faker.commerce.productName();
+      }
+      if (matches(hint, ['onderwerp', 'subject', 'titel', 'title'])) {
+        return faker.helpers.arrayElement([
+          'Bevestiging van uw aanvraag',
+          'Besluit over uw verzoek',
+          'Aanvullende informatie',
+        ]);
+      }
+      if (
+        matches(hint, [
+          'omschrijving',
+          'description',
+          'beschrijving',
+          'toelichting',
+          'comment',
+          'notes',
+          'body',
+          'message',
+          'bericht',
+          'voorwaarden',
+          'conditions',
+          'feiten',
+          'decision',
+          'besluit',
+          'oordeel',
+        ])
+      ) {
+        return faker.helpers.arrayElement([
+          'Uw aanvraag is door ons ontvangen en in behandeling genomen.',
+          'Hierbij ontvangt u aanvullende informatie over de behandeling.',
+          'Wij hebben de aangeleverde gegevens beoordeeld.',
+        ]);
+      }
+      if (
+        matches(hint, [
+          'kenmerk',
+          'registratienummer',
+          'registration number',
+          'nummer',
+          'number',
+          'identifier',
+          'identification',
+          'identication',
+        ])
+      ) {
+        return `REF-${faker.string.alphanumeric({ length: 8, casing: 'upper' })}`;
+      }
+      if (matches(hint, ['naam', 'name'])) return fullName(person);
+
+      return context.nextFallback(field);
+    },
+
+    number(field) {
+      const hint = semanticHint(field);
+      if (matches(hint, ['leeftijd', 'age'])) return 42;
+      if (matches(hint, ['huisnummer', 'house number', 'building number'])) return 42;
+      if (matches(hint, ['jaar', 'year'])) return 2026;
+      if (matches(hint, ['bedrag', 'amount', 'prijs', 'price'])) return 125.5;
+      if (matches(hint, ['aantal', 'quantity', 'count'])) return 3;
+      if (matches(hint, ['percentage', 'rate', 'overspeed'])) return 10;
+      if (matches(hint, ['snelheid', 'speed', 'measurement', 'measured'])) return 50;
+      if (matches(hint, ['totaal', 'total', 'subtotal', 'fee', 'kosten'])) return 125.5;
+      if (matches(hint, ['limiet', 'limit'])) return 100;
+      return undefined;
+    },
+
+    boolean(field) {
+      const hint = semanticHint(field);
+      if (
+        matches(hint, [
+          'actief',
+          'active',
+          'enabled',
+          'goedgekeurd',
+          'approved',
+          'corrected',
+          'gecorrigeerd',
+          'formeel',
+          'formal',
+          'via email',
+          'measured',
+        ])
+      ) {
+        return true;
+      }
+      return undefined;
+    },
+
+    arrayLength(_field, constraints) {
+      if (constraints.maximum === 0) return 0;
+
+      const minimum = Math.max(constraints.minimum, 2);
+      const maximum = Math.max(constraints.minimum, Math.min(constraints.maximum ?? 3, 3));
+      if (maximum < minimum) return maximum;
+      return faker.number.int({ min: minimum, max: maximum });
+    },
+  };
+}
+
+function semanticHint(field: ExampleField): string {
+  return [field.name, field.title, field.description]
+    .filter((value): value is string => Boolean(value))
+    .map(normalize)
+    .join(' ');
+}
+
+function normalize(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function matches(hint: string, terms: string[]): boolean {
+  return terms.some((term) => ` ${hint} `.includes(` ${term} `));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@epistola/design-system':
         specifier: workspace:*
         version: link:../design-system
+      '@faker-js/faker':
+        specifier: ^10.5.0
+        version: 10.5.0
       '@floating-ui/dom':
         specifier: ^1.7.5
         version: 1.8.0
@@ -407,6 +410,10 @@ packages:
 
   '@epistola.app/epistola-catalog@1.0.1':
     resolution: {integrity: sha512-2eARsOzqUwXttP8RnJBylDthw/qBy5Kwo8h3p7g9kIILhMlj1SI8Vh7eaFb0ooE9V51+CjH9fihim1SqLkFhdQ==}
+
+  '@faker-js/faker@10.5.0':
+    resolution: {integrity: sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
@@ -3802,6 +3809,8 @@ snapshots:
     optional: true
 
   '@epistola.app/epistola-catalog@1.0.1': {}
+
+  '@faker-js/faker@10.5.0': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:


### PR DESCRIPTION
## Description

Promote the exact squashed contents of #848 to `main`.

PR #848 was accidentally squash-merged into `feat/839-require-data-example` after that branch had already been squash-merged into `main`. As a result, GitHub marked #848 as merged while its Autofill changes never reached `main`.

This branch starts at the current `origin/main` and cherry-picks only squash commit `3559adb95`. Its resulting tree is byte-for-byte identical to the merged #848 tree; it contains no additional implementation changes.

The feature adds:

- a per-example **Autofill** action that preserves authored values;
- deterministic, realistic Dutch example values inferred from schema and field metadata;
- recursive nested object and array generation;
- representative two- or three-item arrays within `minItems` and `maxItems` constraints;
- distinct, coherent profiles and values between array items;
- clearer placeholder styling;
- schema validation and single-step Undo after Autofill.

## Related

- Original implementation and review: #848
- Issue: #841
- Required-example predecessor: #847

## Verification

- Recovery tree matches squash commit `3559adb95` exactly.
- Editor suite on #848: 112 files, 2,047 tests.
- Typecheck, formatting, scoped lint, production build, and component-registry validation passed on #848.
- `git diff --check origin/main..HEAD`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Contains only the previously reviewed #848 changes
- [x] `CHANGELOG.md` is included
- [x] Recovery branch is based directly on `main`
