### PR TITLE
fix(auth): close session-expiry popup after SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- **[user]** fix(auth): **The session-expiry login popup closes automatically after SSO.**
+  Popup mode is now stored in the JDBC-backed Spring Session used by OAuth2, so the callback reaches
+  the dedicated success page, not the application overview. The popup then notifies the original
+  window, closes itself, and dismisses the expired-session dialog without manual cleanup.
 - **[user]** feat(data contracts): **Every authored data contract keeps at least one example.**
   Saving or publishing without an example is rejected with an actionable validation error, the
   editor highlights the requirement, and replaces the final example's delete action with an

--- a/apps/epistola/src/main/kotlin/app/epistola/suite/config/PopupLoginFilter.kt
+++ b/apps/epistola/src/main/kotlin/app/epistola/suite/config/PopupLoginFilter.kt
@@ -9,8 +9,8 @@ import app.epistola.suite.security.PopupAwareAuthenticationSuccessHandler.Compan
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
+import org.springframework.session.web.http.SessionRepositoryFilter
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
@@ -23,9 +23,12 @@ import org.springframework.web.filter.OncePerRequestFilter
  * This filter checks for popup=true on OAuth2 authorization requests and saves the
  * state to the session. The PopupAwareAuthenticationSuccessHandler then reads this
  * state after successful authentication.
+ *
+ * It must run after [SessionRepositoryFilter], otherwise `request.session` refers to
+ * the servlet container session instead of Epistola's JDBC-backed Spring Session.
  */
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE) // Run very early
+@Order(SessionRepositoryFilter.DEFAULT_ORDER + 1)
 class PopupLoginFilter : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -35,8 +38,8 @@ class PopupLoginFilter : OncePerRequestFilter() {
     ) {
         // Only the login / OAuth2 authorization entry points carry popup=true, so
         // gate the getParameter() call behind this path check. Reading a request
-        // parameter forces the servlet to parse the body, and this filter runs at
-        // HIGHEST_PRECEDENCE; doing that eagerly on every request is wasteful and
+        // parameter forces the servlet to parse the body, and this filter still runs
+        // very early; doing that eagerly on every request is wasteful and
         // historically also locked form bodies to ISO-8859-1 (mangling diacritics
         // like `Café`) when it parsed before the encoding was set. The container
         // default is now pinned to UTF-8 up front (see RequestEncodingConfig), so

--- a/apps/epistola/src/test/kotlin/app/epistola/suite/config/PopupLoginFilterTest.kt
+++ b/apps/epistola/src/test/kotlin/app/epistola/suite/config/PopupLoginFilterTest.kt
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package app.epistola.suite.config
+
+import app.epistola.suite.security.PopupAwareAuthenticationSuccessHandler
+import app.epistola.suite.security.PopupAwareAuthenticationSuccessHandler.Companion.POPUP_SESSION_ATTR
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.core.annotation.Order
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.session.MapSessionRepository
+import org.springframework.session.Session
+import org.springframework.session.web.http.HeaderHttpSessionIdResolver
+import org.springframework.session.web.http.SessionRepositoryFilter
+import java.util.concurrent.ConcurrentHashMap
+
+class PopupLoginFilterTest {
+
+    @Test
+    fun `filter runs immediately after Spring Session`() {
+        val order = PopupLoginFilter::class.java.getAnnotation(Order::class.java).value
+
+        assertThat(order).isEqualTo(SessionRepositoryFilter.DEFAULT_ORDER + 1)
+    }
+
+    @Test
+    fun `popup marker survives OIDC redirect in the Spring-managed session`() {
+        val sessions = ConcurrentHashMap<String, Session>()
+        val sessionRepositoryFilter = SessionRepositoryFilter(MapSessionRepository(sessions)).apply {
+            setHttpSessionIdResolver(HeaderHttpSessionIdResolver.xAuthToken())
+        }
+        val popupLoginFilter = PopupLoginFilter()
+
+        val loginRequest = MockHttpServletRequest("GET", "/login").apply {
+            setParameter("popup", "true")
+        }
+        val loginResponse = MockHttpServletResponse()
+
+        sessionRepositoryFilter.doFilter(loginRequest, loginResponse) { request, response ->
+            popupLoginFilter.doFilter(request, response, FilterChain { _, _ -> })
+        }
+
+        val sessionId = requireNotNull(loginResponse.getHeader("X-Auth-Token"))
+        assertThat(sessionId).isNotBlank()
+        assertThat(sessions.getValue(sessionId).getAttribute<Boolean>(POPUP_SESSION_ATTR)).isTrue()
+
+        val callbackRequest = MockHttpServletRequest("GET", "/login/oauth2/code/oidc").apply {
+            addHeader("X-Auth-Token", sessionId)
+        }
+        val callbackResponse = MockHttpServletResponse()
+
+        sessionRepositoryFilter.doFilter(callbackRequest, callbackResponse) { request, response ->
+            PopupAwareAuthenticationSuccessHandler().onAuthenticationSuccess(
+                request as HttpServletRequest,
+                response as HttpServletResponse,
+                TestingAuthenticationToken("user", "password"),
+            )
+        }
+
+        assertThat(callbackResponse.redirectedUrl)
+            .isEqualTo(PopupAwareAuthenticationSuccessHandler.POPUP_SUCCESS_URL)
+        assertThat(sessions.getValue(sessionId).getAttribute<Boolean>(POPUP_SESSION_ATTR)).isNull()
+    }
+
+    @Test
+    fun `normal login keeps the default success redirect`() {
+        val request = MockHttpServletRequest("POST", "/login")
+        val response = MockHttpServletResponse()
+
+        PopupAwareAuthenticationSuccessHandler().onAuthenticationSuccess(
+            request,
+            response,
+            TestingAuthenticationToken("user", "password"),
+        )
+
+        assertThat(response.redirectedUrl).isEqualTo("/")
+    }
+}


### PR DESCRIPTION
## Summary

- run `PopupLoginFilter` after Spring Session so popup mode is stored in the JDBC-backed session used by OAuth2
- preserve the dedicated popup-success redirect, opener notification, and automatic close flow
- add regression coverage for filter ordering, the two-request OIDC session handoff, marker cleanup, and normal login redirects
- document the user-visible fix in the changelog

## Root cause

`PopupLoginFilter` ran at `Ordered.HIGHEST_PRECEDENCE`, before `SessionRepositoryFilter`. It wrote `login_popup_mode` to the servlet container session, while the OAuth2 callback read the JDBC-backed Spring Session. The callback therefore missed popup mode and followed the normal redirect to the overview page.

## Verification

- `pnpm build`
- `pnpm format:check`
- `./gradlew ktlintCheck unitTest`
- `./gradlew integrationTest`

Closes #605