### PR TITLE
feat(data-contracts): improve contract editor usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- **[user]** feat(data-contracts): **Schema fields can be added where authors are working.**
+  The visual contract editor offers contextual child and sibling actions with full schema paths,
+  keeps nested parents expanded, selects the new field name for immediate typing, and preserves a
+  nearby selection through delete, undo, and redo operations.
 - **[user]** docs(data-contracts): **Data contract behavior and support boundaries are documented.**
   A new guide explains schema dialects and root requirements, visual and JSON-only editing, safe UI
   import normalization, examples and Autofill, expression field discovery, validation, publishing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - **[user]** feat(data-contracts): **Example array actions identify their destination.** Add-item
   controls now show the complete field path, including human-readable item numbers for nested
   arrays, while retaining their full context for assistive technology and narrow layouts.
+- **[user]** feat(data-contracts): **Complex examples start with a compact overview.** Object and
+  array properties are collapsed by default, with per-example actions to expand or collapse the
+  complete property tree at once.
 - **[user]** docs(data-contracts): **Data contract behavior and support boundaries are documented.**
   A new guide explains schema dialects and root requirements, visual and JSON-only editing, safe UI
   import normalization, examples and Autofill, expression field discovery, validation, publishing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   The visual contract editor offers contextual child and sibling actions with full schema paths,
   keeps nested parents expanded, selects the new field name for immediate typing, and preserves a
   nearby selection through delete, undo, and redo operations.
+- **[user]** feat(data-contracts): **Example array actions identify their destination.** Add-item
+  controls now show the complete field path, including human-readable item numbers for nested
+  arrays, while retaining their full context for assistive technology and narrow layouts.
 - **[user]** docs(data-contracts): **Data contract behavior and support boundaries are documented.**
   A new guide explains schema dialects and root requirements, visual and JSON-only editing, safe UI
   import normalization, examples and Autofill, expression field discovery, validation, publishing,

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -119,6 +119,10 @@ Array add actions show where the new item will be inserted. Nested numeric path 
 written as item numbers, for example `groups › item 1 › members`, so similarly named arrays remain
 distinguishable even in deeply nested examples.
 
+Object and array properties start collapsed to keep large examples scannable. Use **Expand all** or
+**Collapse all** in the example toolbar to change the complete property tree at once; individual
+groups can still be opened independently.
+
 Empty controls show placeholder hints. Placeholders are presentation only and are never included
 in saved JSON. **Autofill** writes actual test values into missing or unusable fields while
 preserving meaningful values already entered. It uses, in order where applicable:

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -47,6 +47,13 @@ The visual editor supports object contracts composed from:
 - `minItems` for arrays;
 - Epistola's registered inline and block rich-text `$ref` types.
 
+Select a field to add another field in context. Container fields offer a primary child action and
+a secondary sibling action; scalar fields offer a sibling action. Each action shows the complete
+destination path, such as `customer › address` or `customer › recipients items`. The new field is
+selected immediately with its generated name ready to replace, so nested fields can be created
+without first navigating back to their parent object. Press Enter to confirm a name or Escape to
+restore it. Delete, undo, and redo keep the closest remaining field selected.
+
 The visual editor currently cannot represent every valid JSON Schema keyword. Among other things,
 multi-value type unions, multi-branch compositions, tuple arrays, arrays directly containing
 arrays, `additionalProperties: false`, arbitrary references, `enum`, `const`, `default`,

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -115,6 +115,10 @@ compositions, nullable unions, union branches selected from the current value, o
 arrays, and directly nested arrays. For constructs it cannot interpret, use a valid example
 supplied through an import or API and rely on backend validation.
 
+Array add actions show where the new item will be inserted. Nested numeric path segments are
+written as item numbers, for example `groups › item 1 › members`, so similarly named arrays remain
+distinguishable even in deeply nested examples.
+
 Empty controls show placeholder hints. Placeholders are presentation only and are never included
 in saved JSON. **Autofill** writes actual test values into missing or unusable fields while
 preserving meaningful values already entered. It uses, in order where applicable:

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.schemaEditing.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.schemaEditing.test.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { EpistolaDataContractEditor } from './EpistolaDataContractEditor.js';
+import type { JsonSchema } from './types.js';
+
+const schema: JsonSchema = {
+  type: 'object',
+  properties: {
+    customer: {
+      type: 'object',
+      properties: {},
+    },
+  },
+};
+
+async function mountEditor(): Promise<EpistolaDataContractEditor> {
+  const editor = new EpistolaDataContractEditor();
+  editor.init(schema, [{ id: 'example-1', name: 'Example 1', data: { customer: {} } }], {});
+  document.body.append(editor);
+  await editor.updateComplete;
+  return editor;
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe('schema field creation usability', () => {
+  it('adds a child, keeps its parent expanded, and selects its generated name', async () => {
+    const editor = await mountEditor();
+    editor.querySelector<HTMLButtonElement>('button[aria-label="Add field to customer"]')!.click();
+    await editor.updateComplete;
+
+    const input = editor.querySelector<HTMLInputElement>('[data-schema-field-name]')!;
+    const customerRow = editor.querySelector<HTMLElement>('[data-field-id="field:customer"]')!;
+
+    expect(editor.contractState?.schema?.properties?.customer.properties).toHaveProperty('field1');
+    expect(customerRow.nextElementSibling?.textContent).toContain('field1');
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe('field1');
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it('adds a sibling from the selected scalar without navigating to its parent', async () => {
+    const editor = await mountEditor();
+    editor.querySelector<HTMLButtonElement>('button[aria-label="Add field to customer"]')!.click();
+    await editor.updateComplete;
+
+    editor.querySelector<HTMLButtonElement>('button[aria-label="Add field to customer"]')!.click();
+    await editor.updateComplete;
+
+    expect(editor.contractState?.schema?.properties?.customer.properties).toEqual({
+      field1: { type: 'string' },
+      field2: { type: 'string' },
+    });
+    expect(editor.querySelector<HTMLInputElement>('[data-schema-field-name]')?.value).toBe(
+      'field2',
+    );
+  });
+
+  it('does not collapse a parent that was already expanded', async () => {
+    const editor = await mountEditor();
+    const expand = editor.querySelector<HTMLButtonElement>('.dc-field-expand-btn')!;
+    expand.click();
+    await editor.updateComplete;
+    expect(expand.getAttribute('aria-expanded')).toBe('true');
+
+    editor.querySelector<HTMLButtonElement>('button[aria-label="Add field to customer"]')!.click();
+    await editor.updateComplete;
+
+    expect(
+      editor
+        .querySelector<HTMLButtonElement>('.dc-field-expand-btn')
+        ?.getAttribute('aria-expanded'),
+    ).toBe('true');
+  });
+
+  it('commits a generated-name replacement with Enter and retains focus', async () => {
+    const editor = await mountEditor();
+    editor.querySelector<HTMLButtonElement>('button[aria-label="Add field to customer"]')!.click();
+    await editor.updateComplete;
+
+    const input = editor.querySelector<HTMLInputElement>('[data-schema-field-name]')!;
+    input.value = 'emailAddress';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await editor.updateComplete;
+
+    const renamedInput = editor.querySelector<HTMLInputElement>('[data-schema-field-name]')!;
+    expect(editor.contractState?.schema?.properties?.customer.properties).toHaveProperty(
+      'emailAddress',
+    );
+    expect(document.activeElement).toBe(renamedInput);
+    expect(renamedInput.selectionStart).toBe(renamedInput.value.length);
+  });
+
+  it('selects the parent when undo removes its only child', async () => {
+    const editor = await mountEditor();
+    editor.querySelector<HTMLButtonElement>('button[aria-label="Add field to customer"]')!.click();
+    await editor.updateComplete;
+
+    editor.querySelector<HTMLButtonElement>('.dc-undo-btn')!.click();
+    await editor.updateComplete;
+
+    expect(
+      editor.querySelector('.dc-field-list-item-selected')?.getAttribute('data-field-id'),
+    ).toBe('field:customer');
+    expect(editor.querySelector<HTMLInputElement>('[data-schema-field-name]')?.value).toBe(
+      'customer',
+    );
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
+++ b/modules/editor/src/main/typescript/data-contract/EpistolaDataContractEditor.ts
@@ -35,7 +35,11 @@ import type {
 import { jsonSchemaToVisualSchema, visualSchemaToJsonSchema } from './schema/conversion.js';
 import type { SchemaCommand } from './schema/commands.js';
 import { SchemaCommandHistory } from './schema/command-history.js';
-import { findFieldPath } from './schema/commands.js';
+import {
+  fieldTargetAncestorIds,
+  findFieldPath,
+  reconcileFieldSelection,
+} from './schema/field-location.js';
 import { SnapshotHistory } from './schema/snapshot-history.js';
 import {
   detectMigrations,
@@ -96,6 +100,7 @@ export class EpistolaDataContractEditor extends LitElement {
   @state() private _schemaWarnings: Array<{ path: string; message: string }> = [];
   @state() private _expandedFields = new Set<string>();
   @state() private _selectedFieldId: string | null = null;
+  private _pendingFieldNameFocus: { fieldId: string; selectAll: boolean } | null = null;
   @state() private _jsonPanelOpen = false;
   @state() private _compatibilityIssues: CompatibilityIssue[] = [];
   @state() private _normalizationChanges: SchemaNormalizationChange[] = [];
@@ -205,6 +210,7 @@ export class EpistolaDataContractEditor extends LitElement {
 
   override updated(): void {
     this._renderExternalSaveControls();
+    this._applyPendingFieldNameFocus();
   }
 
   override disconnectedCallback() {
@@ -448,7 +454,9 @@ export class EpistolaDataContractEditor extends LitElement {
       onSelectField: (fieldId) => this._selectField(fieldId),
       onUndo: () => this._undo(),
       onRedo: () => this._redo(),
-      onAddField: () => this._executeCommand({ type: 'addField', parentFieldId: null }),
+      onAddField: (parentFieldId) => this._addSchemaField(parentFieldId),
+      onRequestFieldNameFocus: (fieldId, selectAll) =>
+        this._queueFieldNameFocus(fieldId, selectAll),
       onImport: () => this._openImportDialog(),
       onToggleJson: () => {
         this._jsonPanelOpen = !this._jsonPanelOpen;
@@ -524,8 +532,9 @@ export class EpistolaDataContractEditor extends LitElement {
   // Schema operations (command-based)
   // ---------------------------------------------------------------------------
 
-  private _executeCommand(command: SchemaCommand): void {
+  private _executeCommand(command: SchemaCommand): string | null {
     const prevSchema = this._visualSchema;
+    const previousSelection = this._selectedFieldId;
     this._visualSchema = this._commandHistory.execute(command, this._visualSchema);
     this._syncVisualSchemaToState();
     this._clearSaveStatus();
@@ -534,12 +543,17 @@ export class EpistolaDataContractEditor extends LitElement {
     if (command.type === 'addField') {
       const newFieldId = this._findNewFieldId(prevSchema.fields, this._visualSchema.fields);
       if (newFieldId) this._selectedFieldId = newFieldId;
+      this._validateAllExamples();
+      this._updateBreakingChanges();
+      return newFieldId;
     }
 
-    // Clear selection if deleted field was selected
-    if (command.type === 'deleteField' && this._selectedFieldId === command.fieldId) {
-      this._selectedFieldId =
-        this._visualSchema.fields.length > 0 ? this._visualSchema.fields[0].id : null;
+    if (command.type === 'deleteField') {
+      this._selectedFieldId = reconcileFieldSelection(
+        prevSchema.fields,
+        this._visualSchema.fields,
+        previousSelection,
+      );
     }
 
     // Auto-rename example data keys when a field is renamed
@@ -556,6 +570,20 @@ export class EpistolaDataContractEditor extends LitElement {
     // Re-validate examples and recompute breaking changes
     this._validateAllExamples();
     this._updateBreakingChanges();
+    return null;
+  }
+
+  private _addSchemaField(parentFieldId: string | null): void {
+    const expandedIds =
+      parentFieldId === null
+        ? []
+        : fieldTargetAncestorIds(this._visualSchema.fields, parentFieldId);
+    if (expandedIds.length > 0) {
+      this._expandedFields = new Set([...this._expandedFields, ...expandedIds]);
+    }
+
+    const newFieldId = this._executeCommand({ type: 'addField', parentFieldId });
+    if (newFieldId) this._queueFieldNameFocus(newFieldId, true);
   }
 
   /** Recompute live breaking changes by diffing committed vs current visual schema. */
@@ -613,9 +641,15 @@ export class EpistolaDataContractEditor extends LitElement {
   }
 
   private _undo(): void {
-    const prev = this._commandHistory.undo(this._visualSchema);
+    const current = this._visualSchema;
+    const prev = this._commandHistory.undo(current);
     if (prev) {
       this._visualSchema = prev;
+      this._selectedFieldId = reconcileFieldSelection(
+        current.fields,
+        prev.fields,
+        this._selectedFieldId,
+      );
       this._syncVisualSchemaToState();
       this._clearSaveStatus();
       this._validateAllExamples();
@@ -624,9 +658,15 @@ export class EpistolaDataContractEditor extends LitElement {
   }
 
   private _redo(): void {
-    const next = this._commandHistory.redo(this._visualSchema);
+    const current = this._visualSchema;
+    const next = this._commandHistory.redo(current);
     if (next) {
       this._visualSchema = next;
+      this._selectedFieldId = reconcileFieldSelection(
+        current.fields,
+        next.fields,
+        this._selectedFieldId,
+      );
       this._syncVisualSchemaToState();
       this._clearSaveStatus();
       this._validateAllExamples();
@@ -657,6 +697,28 @@ export class EpistolaDataContractEditor extends LitElement {
       newSet.add(fieldId);
     }
     this._expandedFields = newSet;
+  }
+
+  private _queueFieldNameFocus(fieldId: string, selectAll: boolean): void {
+    this._pendingFieldNameFocus = { fieldId, selectAll };
+    this.requestUpdate();
+  }
+
+  private _applyPendingFieldNameFocus(): void {
+    const pending = this._pendingFieldNameFocus;
+    if (!pending) return;
+    this._pendingFieldNameFocus = null;
+
+    const input = this.querySelector<HTMLInputElement>(`#dc-schema-field-name-${pending.fieldId}`);
+    if (!input) return;
+
+    input.focus();
+    if (pending.selectAll) {
+      input.select();
+    } else {
+      const end = input.value.length;
+      input.setSelectionRange(end, end);
+    }
   }
 
   private async _saveAll(): Promise<void> {

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -385,13 +385,38 @@
 
   .dc-detail-actions {
     display: flex;
+    align-items: flex-end;
+    flex-wrap: wrap;
     gap: var(--ep-space-2);
     margin-top: var(--ep-space-2);
     padding-top: var(--ep-space-3);
     border-top: 1px solid var(--ep-stone-100);
   }
 
+  .dc-detail-add-actions {
+    display: flex;
+    flex: 1 1 240px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--ep-space-2);
+    min-width: 0;
+  }
+
+  .dc-context-add-field-btn {
+    display: inline-flex;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .dc-context-target {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .dc-detail-delete-btn {
+    flex-shrink: 0;
     font-size: var(--ep-text-xs);
     color: var(--ep-red-500);
     background: none;
@@ -417,7 +442,17 @@
    * ---------------------------------------------------------------------- */
 
   .dc-add-field-btn {
-    flex-shrink: 0;
+    max-width: 100%;
+  }
+
+  @media (max-width: 760px) {
+    .dc-toolbar {
+      flex-wrap: wrap;
+    }
+
+    .dc-schema-layout {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 
   /* --------------------------------------------------------------------------

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -1016,6 +1016,8 @@
     align-items: center;
     justify-content: center;
     gap: var(--ep-space-1-5);
+    max-width: 100%;
+    min-width: 0;
     padding: var(--ep-space-2) var(--ep-space-3);
     font-size: var(--ep-text-xs);
     font-weight: 500;
@@ -1036,6 +1038,18 @@
       outline: none;
       box-shadow: var(--ep-ring);
     }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.5;
+    }
+  }
+
+  .dc-array-add-target {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* --------------------------------------------------------------------------

--- a/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
+++ b/modules/editor/src/main/typescript/data-contract/data-contract-editor.css
@@ -1203,6 +1203,13 @@
       }
     }
 
+    & .dc-example-toolbar-divider {
+      width: 1px;
+      height: var(--ep-space-4);
+      margin: 0 var(--ep-space-1);
+      background: var(--ep-stone-200);
+    }
+
     & .dc-example-generate-btn {
       color: var(--ep-primary-strong);
       background: var(--ep-terracotta-50);

--- a/modules/editor/src/main/typescript/data-contract/schema/commands.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/schema/commands.test.ts
@@ -8,7 +8,6 @@ import {
   addFieldToTree,
   deleteFieldFromTree,
   executeSchemaCommand,
-  findFieldPath,
   updateFieldInTree,
 } from './commands.js';
 
@@ -250,6 +249,30 @@ describe('executeSchemaCommand', () => {
       const address = result.fields[2] as SchemaField & { type: 'object' };
       expect(address.nestedFields).toHaveLength(3);
     });
+
+    it('uses the first available generated name in the target object', () => {
+      const schema: VisualSchema = {
+        fields: [
+          { id: 'one', name: 'field1', type: 'string', required: false },
+          { id: 'three', name: 'field3', type: 'string', required: false },
+        ],
+      };
+
+      const result = executeSchemaCommand(schema, { type: 'addField', parentFieldId: null });
+
+      expect(result.fields[2].name).toBe('field2');
+    });
+
+    it('scopes generated names to the receiving object', () => {
+      const schema = makeSchema();
+      const result = executeSchemaCommand(schema, {
+        type: 'addField',
+        parentFieldId: 'field:address',
+      });
+
+      const address = result.fields[2] as SchemaField & { type: 'object' };
+      expect(address.nestedFields![2].name).toBe('field1');
+    });
   });
 
   describe('deleteField', () => {
@@ -306,50 +329,5 @@ describe('executeSchemaCommand', () => {
     executeSchemaCommand(schema, { type: 'deleteField', fieldId: 'field:name' });
 
     expect(schema).toEqual(original);
-  });
-});
-
-// =============================================================================
-// findFieldPath
-// =============================================================================
-
-describe('findFieldPath', () => {
-  it('finds root-level field with empty path', () => {
-    const schema = makeSchema();
-    const result = findFieldPath(schema.fields, 'field:name');
-
-    expect(result?.path).toEqual([]);
-    expect(result?.field.name).toBe('name');
-  });
-
-  it('finds nested field with parent path', () => {
-    const schema = makeSchema();
-    const result = findFieldPath(schema.fields, 'field:address.street');
-
-    expect(result?.path).toEqual(['address']);
-    expect(result?.field.name).toBe('street');
-  });
-
-  it('finds deeply nested field', () => {
-    const schema = makeDeeplyNestedSchema();
-    const result = findFieldPath(schema.fields, 'field:company.hq.address.zip');
-
-    expect(result?.path).toEqual(['company', 'hq', 'address']);
-    expect(result?.field.name).toBe('zip');
-  });
-
-  it('returns null for nonexistent field', () => {
-    const schema = makeSchema();
-    const result = findFieldPath(schema.fields, 'nonexistent');
-
-    expect(result).toBeNull();
-  });
-
-  it('finds the object field itself', () => {
-    const schema = makeSchema();
-    const result = findFieldPath(schema.fields, 'field:address');
-
-    expect(result?.path).toEqual([]);
-    expect(result?.field.name).toBe('address');
   });
 });

--- a/modules/editor/src/main/typescript/data-contract/schema/commands.ts
+++ b/modules/editor/src/main/typescript/data-contract/schema/commands.ts
@@ -12,6 +12,7 @@
 
 import type { SchemaField, SchemaFieldUpdate, VisualSchema } from '../types.js';
 import { applyFieldUpdate, createEmptyField } from './conversion.js';
+import { nextAvailableFieldName } from './field-location.js';
 
 // =============================================================================
 // Command types
@@ -34,7 +35,7 @@ export function executeSchemaCommand(schema: VisualSchema, command: SchemaComman
   switch (command.type) {
     case 'addField': {
       const newField = createEmptyField(
-        command.name ?? `field${countAllFields(schema.fields) + 1}`,
+        command.name ?? nextAvailableFieldName(schema.fields, command.parentFieldId),
       );
       return { fields: addFieldToTree(schema.fields, command.parentFieldId, newField) };
     }
@@ -138,38 +139,4 @@ function getNestedFields(field: SchemaField): SchemaField[] | undefined {
   if (field.type === 'object') return field.nestedFields;
   if (field.type === 'array') return field.nestedFields;
   return undefined;
-}
-
-/**
- * Find a field by ID and return the path (chain of parent field names) from root.
- * Returns null if the field is not found.
- */
-export function findFieldPath(
-  fields: readonly SchemaField[],
-  fieldId: string,
-  parentPath: string[] = [],
-): { path: string[]; field: SchemaField } | null {
-  for (const field of fields) {
-    if (field.id === fieldId) {
-      return { path: parentPath, field };
-    }
-    const nested = getNestedFields(field);
-    if (nested && nested.length > 0) {
-      const found = findFieldPath(nested, fieldId, [...parentPath, field.name]);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
-function countAllFields(fields: SchemaField[]): number {
-  let count = 0;
-  for (const field of fields) {
-    count++;
-    const nested = getNestedFields(field);
-    if (nested) {
-      count += countAllFields(nested);
-    }
-  }
-  return count;
 }

--- a/modules/editor/src/main/typescript/data-contract/schema/field-location.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/schema/field-location.test.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import type { VisualSchema } from '../types.js';
+import {
+  fieldTargetAncestorIds,
+  fieldTargetLabel,
+  findFieldLocation,
+  findFieldPath,
+  nextAvailableFieldName,
+  reconcileFieldSelection,
+} from './field-location.js';
+
+function makeSchema(): VisualSchema {
+  return {
+    fields: [
+      { id: 'name', name: 'name', type: 'string', required: false },
+      {
+        id: 'customer',
+        name: 'customer',
+        type: 'object',
+        required: false,
+        nestedFields: [
+          { id: 'customer-reference', name: 'reference', type: 'string', required: false },
+          {
+            id: 'recipients',
+            name: 'recipients',
+            type: 'array',
+            arrayItemType: 'object',
+            required: false,
+            nestedFields: [
+              { id: 'recipient-name', name: 'name', type: 'string', required: false },
+              { id: 'recipient-field1', name: 'field1', type: 'string', required: false },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('field location', () => {
+  it('locates a deeply nested field with its parent and ancestors', () => {
+    const location = findFieldLocation(makeSchema().fields, 'recipient-name');
+
+    expect(location?.parentFieldId).toBe('recipients');
+    expect(location?.ancestors.map((field) => field.id)).toEqual(['customer', 'recipients']);
+    expect(location?.index).toBe(0);
+  });
+
+  it('retains the parent-name path needed for example key migration', () => {
+    const result = findFieldPath(makeSchema().fields, 'recipient-name');
+
+    expect(result?.path).toEqual(['customer', 'recipients']);
+    expect(result?.field.name).toBe('name');
+  });
+
+  it('formats root, object, and object-array destinations naturally', () => {
+    const fields = makeSchema().fields;
+
+    expect(fieldTargetLabel(fields, null)).toEqual({
+      visible: 'data contract',
+      accessible: 'data contract',
+    });
+    expect(fieldTargetLabel(fields, 'customer')).toEqual({
+      visible: 'customer',
+      accessible: 'customer',
+    });
+    expect(fieldTargetLabel(fields, 'recipients')).toEqual({
+      visible: 'customer › recipients items',
+      accessible: 'customer, recipients items',
+    });
+  });
+
+  it('returns every object that must remain expanded for a nested target', () => {
+    expect(fieldTargetAncestorIds(makeSchema().fields, 'recipients')).toEqual([
+      'customer',
+      'recipients',
+    ]);
+  });
+
+  it('chooses a collision-free name within the receiving object', () => {
+    const fields = makeSchema().fields;
+
+    expect(nextAvailableFieldName(fields, null)).toBe('field1');
+    expect(nextAvailableFieldName(fields, 'recipients')).toBe('field2');
+  });
+});
+
+describe('field selection reconciliation', () => {
+  it('keeps a selection that still exists', () => {
+    const fields = makeSchema().fields;
+    expect(reconcileFieldSelection(fields, fields, 'recipient-name')).toBe('recipient-name');
+  });
+
+  it('selects the next sibling after deleting a field', () => {
+    const previous = makeSchema().fields;
+    const next = structuredClone(previous);
+    const customer = next[1];
+    if (customer.type !== 'object') throw new Error('Expected customer object');
+    const recipients = customer.nestedFields?.[1];
+    if (recipients?.type !== 'array') throw new Error('Expected recipients array');
+    recipients.nestedFields = recipients.nestedFields?.slice(1);
+
+    expect(reconcileFieldSelection(previous, next, 'recipient-name')).toBe('recipient-field1');
+  });
+
+  it('falls back to the previous sibling and then the parent', () => {
+    const previous = makeSchema().fields;
+    const withoutLast = structuredClone(previous);
+    const customer = withoutLast[1];
+    if (customer.type !== 'object') throw new Error('Expected customer object');
+    const recipients = customer.nestedFields?.[1];
+    if (recipients?.type !== 'array') throw new Error('Expected recipients array');
+    recipients.nestedFields = recipients.nestedFields?.slice(0, 1);
+
+    expect(reconcileFieldSelection(previous, withoutLast, 'recipient-field1')).toBe(
+      'recipient-name',
+    );
+
+    recipients.nestedFields = [];
+    expect(reconcileFieldSelection(previous, withoutLast, 'recipient-name')).toBe('recipients');
+  });
+
+  it('falls back to the first root field when the former hierarchy is gone', () => {
+    const previous = makeSchema().fields;
+    const next = previous.slice(0, 1);
+
+    expect(reconcileFieldSelection(previous, next, 'recipient-name')).toBe('name');
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/schema/field-location.ts
+++ b/modules/editor/src/main/typescript/data-contract/schema/field-location.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Epistola Nederland B.V.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { SchemaField } from '../types.js';
+
+export interface FieldLocation {
+  field: SchemaField;
+  parentFieldId: string | null;
+  ancestors: SchemaField[];
+  siblings: readonly SchemaField[];
+  index: number;
+}
+
+export interface FieldTargetLabel {
+  visible: string;
+  accessible: string;
+}
+
+/** Locate a field and retain the hierarchy needed for contextual editor actions. */
+export function findFieldLocation(
+  fields: readonly SchemaField[],
+  fieldId: string,
+  ancestors: SchemaField[] = [],
+): FieldLocation | null {
+  for (const [index, field] of fields.entries()) {
+    if (field.id === fieldId) {
+      return {
+        field,
+        parentFieldId: ancestors.at(-1)?.id ?? null,
+        ancestors,
+        siblings: fields,
+        index,
+      };
+    }
+
+    const nested = nestedFields(field);
+    if (nested.length > 0) {
+      const found = findFieldLocation(nested, fieldId, [...ancestors, field]);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** Return the parent-name path used when migrating renamed example keys. */
+export function findFieldPath(
+  fields: readonly SchemaField[],
+  fieldId: string,
+): { path: string[]; field: SchemaField } | null {
+  const location = findFieldLocation(fields, fieldId);
+  return location
+    ? { path: location.ancestors.map((ancestor) => ancestor.name), field: location.field }
+    : null;
+}
+
+/** Describe the object that receives a field without exposing schema syntax. */
+export function fieldTargetLabel(
+  fields: readonly SchemaField[],
+  parentFieldId: string | null,
+): FieldTargetLabel {
+  if (parentFieldId === null) {
+    return { visible: 'data contract', accessible: 'data contract' };
+  }
+
+  const location = findFieldLocation(fields, parentFieldId);
+  if (!location) {
+    return { visible: 'data contract', accessible: 'data contract' };
+  }
+
+  const segments = [...location.ancestors, location.field].map(fieldTargetSegment);
+  return {
+    visible: segments.join(' › '),
+    accessible: segments.join(', '),
+  };
+}
+
+/** IDs that must be expanded to reveal children added to the target object. */
+export function fieldTargetAncestorIds(
+  fields: readonly SchemaField[],
+  parentFieldId: string,
+): string[] {
+  const location = findFieldLocation(fields, parentFieldId);
+  return location ? [...location.ancestors, location.field].map((field) => field.id) : [];
+}
+
+/** Pick the first unused generated name within the receiving object. */
+export function nextAvailableFieldName(
+  fields: readonly SchemaField[],
+  parentFieldId: string | null,
+): string {
+  const names = new Set(fieldsForParent(fields, parentFieldId).map((field) => field.name));
+  let sequence = 1;
+  while (names.has(`field${sequence}`)) sequence += 1;
+  return `field${sequence}`;
+}
+
+/** Keep selection close to its former location when a structural edit removes it. */
+export function reconcileFieldSelection(
+  previousFields: readonly SchemaField[],
+  nextFields: readonly SchemaField[],
+  selectedFieldId: string | null,
+): string | null {
+  if (selectedFieldId === null) return nextFields[0]?.id ?? null;
+  if (findFieldLocation(nextFields, selectedFieldId)) return selectedFieldId;
+
+  const previous = findFieldLocation(previousFields, selectedFieldId);
+  if (!previous) return nextFields[0]?.id ?? null;
+
+  const nextSiblings = fieldsForParent(nextFields, previous.parentFieldId);
+  const nextSibling = nextSiblings[previous.index];
+  if (nextSibling) return nextSibling.id;
+
+  const previousSibling = nextSiblings[previous.index - 1];
+  if (previousSibling) return previousSibling.id;
+
+  for (const ancestor of previous.ancestors.toReversed()) {
+    if (findFieldLocation(nextFields, ancestor.id)) return ancestor.id;
+  }
+
+  return nextFields[0]?.id ?? null;
+}
+
+export function supportsNestedFields(field: SchemaField): boolean {
+  return field.type === 'object' || (field.type === 'array' && field.arrayItemType === 'object');
+}
+
+function fieldsForParent(
+  fields: readonly SchemaField[],
+  parentFieldId: string | null,
+): readonly SchemaField[] {
+  if (parentFieldId === null) return fields;
+  const parent = findFieldLocation(fields, parentFieldId)?.field;
+  return parent ? nestedFields(parent) : [];
+}
+
+function nestedFields(field: SchemaField): readonly SchemaField[] {
+  return field.type === 'object' || field.type === 'array' ? (field.nestedFields ?? []) : [];
+}
+
+function fieldTargetSegment(field: SchemaField): string {
+  return field.type === 'array' && field.arrayItemType === 'object'
+    ? `${field.name} items`
+    : field.name;
+}

--- a/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.test.ts
@@ -79,6 +79,62 @@ describe('example form placeholders', () => {
   });
 });
 
+describe('example property disclosure', () => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      customer: {
+        type: 'object',
+        properties: {
+          address: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+          },
+        },
+      },
+      contacts: {
+        type: 'array',
+        items: { type: 'object', properties: { name: { type: 'string' } } },
+      },
+    },
+  };
+
+  it('starts every object, array, and array item collapsed', () => {
+    const container = document.createElement('div');
+    render(
+      renderExampleForm(
+        schema,
+        { customer: { address: {} }, contacts: [{ name: 'Ada' }] },
+        () => {},
+      ),
+      container,
+    );
+
+    const groups = [...container.querySelectorAll<HTMLDetailsElement>('details')];
+    expect(groups).toHaveLength(4);
+    expect(groups.every((group) => !group.open)).toBe(true);
+  });
+
+  it('keeps a manually opened group open when example data rerenders', () => {
+    const container = document.createElement('div');
+    render(
+      renderExampleForm(schema, { customer: { address: {} } }, () => {}),
+      container,
+    );
+    const customer = container.querySelector<HTMLDetailsElement>(
+      'details[aria-label="customer properties"]',
+    )!;
+    customer.open = true;
+
+    render(
+      renderExampleForm(schema, { customer: { address: { city: 'Utrecht' } } }, () => {}),
+      container,
+    );
+
+    expect(customer.open).toBe(true);
+  });
+});
+
 describe('array item actions', () => {
   const schema: JsonSchema = {
     type: 'object',

--- a/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'lit';
 import {
+  arrayTargetLabel,
   validationPathToFormPath,
   buildFieldErrorMap,
   hasChildErrors,
@@ -75,6 +76,88 @@ describe('example form placeholders', () => {
     expect(nestedName.value).toBe('');
     expect(nestedName.placeholder).toBe('name');
     expect(nestedName.classList.contains('dc-tree-input')).toBe(true);
+  });
+});
+
+describe('array item actions', () => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      tags: { type: 'array', items: { type: 'string' } },
+      contacts: {
+        type: 'array',
+        items: { type: 'object', properties: { name: { type: 'string' } } },
+      },
+      matrix: {
+        type: 'array',
+        items: {
+          type: 'array',
+          items: { type: 'object', properties: { name: { type: 'string' } } },
+        },
+      },
+    },
+  };
+
+  it('formats nested array paths with human-readable item numbers', () => {
+    expect(arrayTargetLabel('groups.0.members.11')).toEqual({
+      visible: 'groups › item 1 › members › item 12',
+      accessible: 'groups, item 1, members, item 12',
+    });
+  });
+
+  it('shows the destination for primitive, object, and nested-array actions', () => {
+    const container = document.createElement('div');
+    render(
+      renderExampleForm(schema, { matrix: [[]] }, () => {}),
+      container,
+    );
+
+    const labels = [...container.querySelectorAll<HTMLButtonElement>('.dc-array-add-btn')].map(
+      (button) => button.getAttribute('aria-label'),
+    );
+    expect(labels).toEqual([
+      'Add item to tags',
+      'Add item to contacts',
+      'Add item to matrix, item 1',
+      'Add item to matrix',
+    ]);
+
+    const nestedButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Add item to matrix, item 1"]',
+    )!;
+    expect(nestedButton.title).toBe('Add item to matrix, item 1');
+    expect(nestedButton.querySelector('.dc-array-add-target')?.textContent).toBe('matrix › item 1');
+  });
+
+  it('retains the existing add behavior behind the contextual action', () => {
+    let data: JsonObject = { contacts: [] };
+    const container = document.createElement('div');
+    render(
+      renderExampleForm(schema, data, (path, value) => {
+        data = setNestedValue(data, path, value);
+      }),
+      container,
+    );
+
+    container
+      .querySelector<HTMLButtonElement>('button[aria-label="Add item to contacts"]')!
+      .click();
+
+    expect(data).toEqual({ contacts: [{ name: '' }] });
+  });
+
+  it('disables contextual array actions in read-only mode', () => {
+    const container = document.createElement('div');
+    render(
+      renderExampleForm(schema, { matrix: [[]] }, () => {}, new Map(), true),
+      container,
+    );
+
+    expect(
+      [...container.querySelectorAll<HTMLButtonElement>('.dc-array-add-btn')].every(
+        (button) => button.disabled,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
@@ -776,17 +776,7 @@ function renderArrayField(
             </div>
           `;
         })}
-        <button class="dc-array-add-btn" ?disabled=${readOnly} @click=${() => addItem()}>
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <path
-              d="M8 3v10M3 8h10"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-            />
-          </svg>
-          Add ${itemType} item
-        </button>
+        ${renderAddArrayItemButton(path, addItem, readOnly)}
       </div>
     </details>
   `;
@@ -892,17 +882,7 @@ function renderArrayOfObjects(
             </details>
           `;
         })}
-        <button class="dc-array-add-btn" ?disabled=${readOnly} @click=${() => addItem()}>
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <path
-              d="M8 3v10M3 8h10"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-            />
-          </svg>
-          Add object item
-        </button>
+        ${renderAddArrayItemButton(path, addItem, readOnly)}
       </div>
     </details>
   `;
@@ -983,19 +963,48 @@ function renderArrayOfArrays(
             </div>
           `;
         })}
-        <button class="dc-array-add-btn" ?disabled=${readOnly} @click=${() => addItem()}>
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <path
-              d="M8 3v10M3 8h10"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-            />
-          </svg>
-          Add array item
-        </button>
+        ${renderAddArrayItemButton(path, addItem, readOnly)}
       </div>
     </details>
+  `;
+}
+
+interface ArrayTargetLabel {
+  visible: string;
+  accessible: string;
+}
+
+/** Turn a data path into an author-facing destination for an array action. */
+export function arrayTargetLabel(path: string): ArrayTargetLabel {
+  const segments = path.split('.').map((segment) => {
+    const index = Number(segment);
+    return Number.isInteger(index) && index >= 0 && String(index) === segment
+      ? `item ${index + 1}`
+      : segment;
+  });
+  return {
+    visible: segments.join(' › '),
+    accessible: segments.join(', '),
+  };
+}
+
+function renderAddArrayItemButton(path: string, addItem: () => void, readOnly: boolean): unknown {
+  const target = arrayTargetLabel(path);
+  const accessibleLabel = `Add item to ${target.accessible}`;
+  return html`
+    <button
+      class="dc-array-add-btn"
+      ?disabled=${readOnly}
+      @click=${addItem}
+      aria-label=${accessibleLabel}
+      title=${accessibleLabel}
+    >
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M8 3v10M3 8h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+      </svg>
+      <span aria-hidden="true">Add item to</span>
+      <span class="dc-array-add-target" aria-hidden="true">${target.visible}</span>
+    </button>
   `;
 }
 

--- a/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExampleForm.ts
@@ -572,10 +572,7 @@ function renderFormField(
   }
 }
 
-/**
- * Render a collapsible object field with nested properties.
- * Top-level objects open by default; deeper nesting collapsed.
- */
+/** Render a collapsible object field with nested properties. */
 function renderObjectField(
   name: string,
   propSchema: JsonSchemaProperty,
@@ -603,12 +600,10 @@ function renderObjectField(
 
   const nestedRequired = new Set(propSchema.required ?? []);
   const groupHasErrors = hasChildErrors(path, errors);
-  const isTopLevel = depth === 0;
 
   return html`
     <details
       class="dc-tree-group ${groupHasErrors ? 'dc-tree-group-has-errors' : ''}"
-      ?open=${isTopLevel}
       aria-label="${name} properties"
     >
       <summary class="dc-tree-group-header">
@@ -718,7 +713,6 @@ function renderArrayField(
   return html`
     <details
       class="dc-tree-group ${groupHasErrors ? 'dc-tree-group-has-errors' : ''}"
-      ?open=${items.length > 0}
       aria-label="${name} array"
     >
       <summary class="dc-tree-group-header">
@@ -805,7 +799,6 @@ function renderArrayOfObjects(
   return html`
     <details
       class="dc-tree-group ${groupHasErrors ? 'dc-tree-group-has-errors' : ''}"
-      ?open=${items.length > 0}
       aria-label="${name} array of objects"
     >
       <summary class="dc-tree-group-header">
@@ -829,7 +822,6 @@ function renderArrayOfObjects(
           return html`
             <details
               class="dc-array-object-item ${itemHasErrors ? 'dc-tree-group-has-errors' : ''}"
-              open
               role="listitem"
               aria-label="Item ${index + 1}"
             >
@@ -909,7 +901,6 @@ function renderArrayOfArrays(
   return html`
     <details
       class="dc-tree-group ${groupHasErrors ? 'dc-tree-group-has-errors' : ''}"
-      ?open=${items.length > 0}
       aria-label="${name} nested arrays"
     >
       <summary class="dc-tree-group-header">

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.test.ts
@@ -122,3 +122,45 @@ describe('ExamplesSection required example state', () => {
     );
   });
 });
+
+describe('ExamplesSection property disclosure actions', () => {
+  it('expands and collapses every nested property group in the selected example', () => {
+    const example = {
+      id: 'one',
+      name: 'Example 1',
+      data: { customer: { address: {} }, contacts: [{ name: 'Ada' }] },
+    };
+    const state = new DataContractState(
+      {
+        type: 'object',
+        properties: {
+          customer: {
+            type: 'object',
+            properties: {
+              address: {
+                type: 'object',
+                properties: { city: { type: 'string' } },
+              },
+            },
+          },
+          contacts: {
+            type: 'array',
+            items: { type: 'object', properties: { name: { type: 'string' } } },
+          },
+        },
+      },
+      [example],
+      {},
+    );
+    const container = renderState(state, example.id);
+    const groups = [...container.querySelectorAll<HTMLDetailsElement>('details')];
+    expect(groups).toHaveLength(4);
+    expect(groups.every((group) => !group.open)).toBe(true);
+
+    container.querySelector<HTMLButtonElement>('.dc-example-expand-all-btn')!.click();
+    expect(groups.every((group) => group.open)).toBe(true);
+
+    container.querySelector<HTMLButtonElement>('.dc-example-collapse-all-btn')!.click();
+    expect(groups.every((group) => !group.open)).toBe(true);
+  });
+});

--- a/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/ExamplesSection.ts
@@ -11,6 +11,7 @@
  */
 
 import { html } from 'lit';
+import { keyed } from 'lit/directives/keyed.js';
 import type { DataContractState } from '../DataContractState.js';
 import type { JsonValue } from '../types.js';
 import { renderExampleForm } from './ExampleForm.js';
@@ -212,6 +213,23 @@ export function renderExamplesSection(
                     </svg>
                     Redo
                   </button>
+                  <span class="dc-example-toolbar-divider" aria-hidden="true"></span>
+                  <button
+                    class="dc-example-toolbar-btn dc-example-expand-all-btn"
+                    @click=${(event: Event) => setExampleGroupsOpen(event, true)}
+                    title="Expand all properties in this example"
+                    aria-label="Expand all example properties"
+                  >
+                    Expand all
+                  </button>
+                  <button
+                    class="dc-example-toolbar-btn dc-example-collapse-all-btn"
+                    @click=${(event: Event) => setExampleGroupsOpen(event, false)}
+                    title="Collapse all properties in this example"
+                    aria-label="Collapse all example properties"
+                  >
+                    Collapse all
+                  </button>
                 </div>
 
                 ${uiState.validationErrorCount > 0
@@ -261,12 +279,15 @@ export function renderExamplesSection(
 
               <!-- Form -->
               <div class="dc-example-form-container">
-                ${renderExampleForm(
-                  state.schema,
-                  selectedExample.data,
-                  (path, value) => callbacks.onUpdateExampleData(selectedExample.id, path, value),
-                  uiState.fieldErrorMap,
-                  uiState.readOnly,
+                ${keyed(
+                  selectedExample.id,
+                  renderExampleForm(
+                    state.schema,
+                    selectedExample.data,
+                    (path, value) => callbacks.onUpdateExampleData(selectedExample.id, path, value),
+                    uiState.fieldErrorMap,
+                    uiState.readOnly,
+                  ),
                 )}
               </div>
             </div>
@@ -325,4 +346,14 @@ export function renderExamplesSection(
             `}
     </section>
   `;
+}
+
+function setExampleGroupsOpen(event: Event, open: boolean): void {
+  if (!(event.currentTarget instanceof HTMLElement)) return;
+  const card = event.currentTarget.closest('.dc-example-card');
+  for (const group of card?.querySelectorAll<HTMLDetailsElement>(
+    '.dc-example-form-container details',
+  ) ?? []) {
+    group.open = open;
+  }
 }

--- a/modules/editor/src/main/typescript/data-contract/sections/SchemaFieldRow.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/SchemaFieldRow.ts
@@ -40,6 +40,7 @@ export function renderSchemaFieldListItem(
   return html`
     <div
       class="dc-field-list-item ${isSelected ? 'dc-field-list-item-selected' : ''}"
+      data-field-id=${field.id}
       style=${nestStyle ?? nothing}
       @click=${(e: Event) => {
         e.stopPropagation();

--- a/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.test.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.test.ts
@@ -5,20 +5,41 @@
 // @vitest-environment happy-dom
 
 import { render } from 'lit';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VisualSchema } from '../types.js';
 import {
   renderSchemaSection,
   type SchemaSectionCallbacks,
   type SchemaUiState,
 } from './SchemaSection.js';
 
-const uiState: SchemaUiState = {
-  warnings: [],
-  canUndo: false,
-  canRedo: false,
-  selectedFieldId: null,
-  readOnly: false,
-  jsonPanelOpen: false,
+const schema: VisualSchema = {
+  fields: [
+    { id: 'reference', name: 'reference', type: 'string', required: false },
+    {
+      id: 'customer',
+      name: 'customer',
+      type: 'object',
+      required: false,
+      nestedFields: [
+        {
+          id: 'address',
+          name: 'addressWithAnIntentionallyLongNameForLayoutTesting',
+          type: 'object',
+          required: false,
+          nestedFields: [],
+        },
+        {
+          id: 'recipients',
+          name: 'recipients',
+          type: 'array',
+          arrayItemType: 'object',
+          required: false,
+          nestedFields: [],
+        },
+      ],
+    },
+  ],
 };
 
 const callbacks: SchemaSectionCallbacks = {
@@ -28,19 +49,126 @@ const callbacks: SchemaSectionCallbacks = {
   onUndo: vi.fn(),
   onRedo: vi.fn(),
   onAddField: vi.fn(),
+  onRequestFieldNameFocus: vi.fn(),
   onImport: vi.fn(),
   onToggleJson: vi.fn(),
 };
 
+function renderSection(
+  selectedFieldId: string | null,
+  readOnly = false,
+  visualSchema: VisualSchema = schema,
+): HTMLElement {
+  const uiState: SchemaUiState = {
+    warnings: [],
+    canUndo: false,
+    canRedo: false,
+    selectedFieldId,
+    readOnly,
+    jsonPanelOpen: false,
+  };
+  const container = document.createElement('div');
+  render(renderSchemaSection(visualSchema, uiState, callbacks, new Set()), container);
+  document.body.append(container);
+  return container;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  document.body.replaceChildren();
+});
+
 describe('SchemaSection toolbar', () => {
   it('keeps schema actions and undo history local without a section-specific save action', () => {
-    const container = document.createElement('div');
-    render(renderSchemaSection({ fields: [] }, uiState, callbacks, new Set()), container);
-
+    const container = renderSection(null, false, { fields: [] });
     const toolbar = container.querySelector('.dc-toolbar');
-    expect(toolbar?.textContent).toContain('Add Field');
+
+    expect(toolbar?.textContent).toContain('Add field to data contract');
     expect(toolbar?.textContent).toContain('Undo');
     expect(toolbar?.textContent).toContain('Redo');
     expect(toolbar?.querySelector('.dc-save-btn')).toBeNull();
+
+    toolbar?.querySelector<HTMLButtonElement>('.dc-add-field-btn')?.click();
+    expect(callbacks.onAddField).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('SchemaSection contextual field actions', () => {
+  it('offers only the parent target for a scalar field', () => {
+    const container = renderSection('reference');
+    const actions = container.querySelectorAll<HTMLButtonElement>('.dc-context-add-field-btn');
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].getAttribute('aria-label')).toBe('Add field to data contract');
+    expect(actions[0].classList.contains('ep-btn-primary')).toBe(true);
+  });
+
+  it('offers child first and sibling second for a nested object', () => {
+    const container = renderSection('address');
+    const actions = container.querySelectorAll<HTMLButtonElement>('.dc-context-add-field-btn');
+
+    expect(actions).toHaveLength(2);
+    expect(actions[0].getAttribute('aria-label')).toBe(
+      'Add field to customer, addressWithAnIntentionallyLongNameForLayoutTesting',
+    );
+    expect(actions[0].getAttribute('title')).toBe(
+      'Add field to customer, addressWithAnIntentionallyLongNameForLayoutTesting',
+    );
+    expect(actions[0].classList.contains('ep-btn-primary')).toBe(true);
+    expect(actions[0].querySelector('.dc-context-target')?.textContent).toBe(
+      'customer › addressWithAnIntentionallyLongNameForLayoutTesting',
+    );
+    expect(actions[1].getAttribute('aria-label')).toBe('Add field to customer');
+
+    actions[0].click();
+    actions[1].click();
+    expect(callbacks.onAddField).toHaveBeenNthCalledWith(1, 'address');
+    expect(callbacks.onAddField).toHaveBeenNthCalledWith(2, 'customer');
+  });
+
+  it('describes object-array children as items', () => {
+    const container = renderSection('recipients');
+    const action = container.querySelector<HTMLButtonElement>('.dc-context-add-field-btn');
+
+    expect(action?.getAttribute('aria-label')).toBe('Add field to customer, recipients items');
+    expect(action?.querySelector('.dc-context-target')?.textContent).toBe(
+      'customer › recipients items',
+    );
+  });
+
+  it('disables every contextual action in read-only mode', () => {
+    const container = renderSection('address', true);
+    const actions = container.querySelectorAll<HTMLButtonElement>('.dc-context-add-field-btn');
+
+    expect([...actions].every((button) => button.disabled)).toBe(true);
+  });
+});
+
+describe('SchemaSection name editing', () => {
+  it('commits with Enter and requests stable focus', () => {
+    const container = renderSection('reference');
+    const input = container.querySelector<HTMLInputElement>('[data-schema-field-name]')!;
+    input.value = 'caseReference';
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(callbacks.onCommand).toHaveBeenCalledWith({
+      type: 'updateField',
+      fieldId: 'reference',
+      updates: { name: 'caseReference' },
+    });
+    expect(callbacks.onRequestFieldNameFocus).toHaveBeenCalledWith('reference', false);
+  });
+
+  it('restores the stored value with Escape without creating a command', () => {
+    const container = renderSection('reference');
+    const input = container.querySelector<HTMLInputElement>('[data-schema-field-name]')!;
+    input.value = 'unfinished';
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(input.value).toBe('reference');
+    expect(callbacks.onCommand).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.ts
+++ b/modules/editor/src/main/typescript/data-contract/sections/SchemaSection.ts
@@ -24,6 +24,12 @@ import type {
 import type { SchemaCommand } from '../schema/commands.js';
 import { isValidFieldName } from '../schema/conversion.js';
 import {
+  type FieldLocation,
+  fieldTargetLabel,
+  findFieldLocation,
+  supportsNestedFields,
+} from '../schema/field-location.js';
+import {
   ARRAY_ITEM_FIELD_TYPES as ARRAY_ITEM_TYPES,
   CONTRACT_FIELD_TYPES as FIELD_TYPES,
   FIELD_TYPE_LABELS,
@@ -46,7 +52,8 @@ export interface SchemaSectionCallbacks {
   onSelectField: (fieldId: string) => void;
   onUndo: () => void;
   onRedo: () => void;
-  onAddField: () => void;
+  onAddField: (parentFieldId: string | null) => void;
+  onRequestFieldNameFocus: (fieldId: string, selectAll: boolean) => void;
   onImport: () => void;
   onToggleJson: () => void;
 }
@@ -64,7 +71,7 @@ export function renderSchemaSection(
   const fields = visualSchema.fields;
   const hasFields = fields.length > 0;
   const selectedField = uiState.selectedFieldId
-    ? findFieldById(fields, uiState.selectedFieldId)
+    ? findFieldLocation(fields, uiState.selectedFieldId)
     : null;
 
   return html`
@@ -79,10 +86,11 @@ export function renderSchemaSection(
       <div class="dc-toolbar">
         <button
           class="ep-btn ep-btn-outline ep-btn-sm dc-add-field-btn"
-          @click=${() => callbacks.onAddField()}
+          @click=${() => callbacks.onAddField(null)}
           ?disabled=${uiState.readOnly}
+          aria-label="Add field to data contract"
         >
-          + Add Field
+          + Add field to data contract
         </button>
 
         <button
@@ -154,10 +162,12 @@ export function renderSchemaSection(
         ? html`
             <div class="dc-schema-layout">
               ${renderFieldList(fields, uiState, callbacks, expandedFields)}
-              ${renderDetailPanel(selectedField, uiState, callbacks)}
+              ${renderDetailPanel(selectedField, fields, uiState, callbacks)}
             </div>
           `
-        : html`<div class="dc-empty-state">No fields defined yet. Add a field below.</div>`}
+        : html`<div class="dc-empty-state">
+            No fields defined yet. Use Add field to data contract above.
+          </div>`}
     </section>
   `;
 }
@@ -208,11 +218,12 @@ const STRING_FORMATS: Array<{ value: StringFormat | ''; label: string }> = [
 ];
 
 function renderDetailPanel(
-  field: SchemaField | null,
+  location: FieldLocation | null,
+  fields: readonly SchemaField[],
   uiState: SchemaUiState,
   callbacks: SchemaSectionCallbacks,
 ): unknown {
-  if (!field) {
+  if (!location) {
     return html`
       <div class="dc-detail-panel">
         <div class="dc-detail-empty">Select a field to edit its properties</div>
@@ -220,12 +231,24 @@ function renderDetailPanel(
     `;
   }
 
+  const field = location.field;
+
   const emitUpdate = (updates: SchemaFieldUpdate) => {
     callbacks.onCommand({ type: 'updateField', fieldId: field.id, updates });
   };
 
-  const canHaveNested =
-    field.type === 'object' || (field.type === 'array' && field.arrayItemType === 'object');
+  const canHaveNested = supportsNestedFields(field);
+  const childTarget = canHaveNested ? fieldTargetLabel(fields, field.id) : null;
+  const siblingTarget = fieldTargetLabel(fields, location.parentFieldId);
+
+  const commitName = (input: HTMLInputElement): void => {
+    const value = input.value.trim();
+    if (!value || !isValidFieldName(value)) {
+      input.value = field.name;
+      return;
+    }
+    if (value !== field.name) emitUpdate({ name: value });
+  };
 
   return html`
     <div class="dc-detail-panel">
@@ -238,6 +261,8 @@ function renderDetailPanel(
           <input
             type="text"
             class="ep-input dc-detail-input"
+            id="dc-schema-field-name-${field.id}"
+            data-schema-field-name
             .value=${field.name}
             placeholder="Field name"
             title="Letters, digits, and underscores only. Must start with a letter or underscore."
@@ -252,9 +277,18 @@ function renderDetailPanel(
               }
             }}
             @change=${(e: Event) => {
-              const value = (e.target as HTMLInputElement).value.trim();
-              if (value && value !== field.name && isValidFieldName(value)) {
-                emitUpdate({ name: value });
+              commitName(e.target as HTMLInputElement);
+            }}
+            @keydown=${(e: KeyboardEvent) => {
+              const input = e.currentTarget as HTMLInputElement;
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commitName(input);
+                callbacks.onRequestFieldNameFocus(field.id, false);
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                input.value = field.name;
+                input.focus();
               }
             }}
           />
@@ -346,20 +380,18 @@ function renderDetailPanel(
 
         <!-- Actions -->
         <div class="dc-detail-actions">
-          ${canHaveNested
-            ? html`
-                <button
-                  class="ep-btn ep-btn-outline ep-btn-sm"
-                  @click=${() => {
-                    callbacks.onCommand({ type: 'addField', parentFieldId: field.id });
-                    callbacks.onToggleFieldExpand(field.id);
-                  }}
-                  ?disabled=${uiState.readOnly}
-                >
-                  + Add Nested Field
-                </button>
-              `
-            : nothing}
+          <div class="dc-detail-add-actions">
+            ${childTarget
+              ? renderAddFieldAction(field.id, childTarget, true, uiState.readOnly, callbacks)
+              : nothing}
+            ${renderAddFieldAction(
+              location.parentFieldId,
+              siblingTarget,
+              !childTarget,
+              uiState.readOnly,
+              callbacks,
+            )}
+          </div>
 
           <div class="dc-toolbar-spacer"></div>
 
@@ -373,6 +405,30 @@ function renderDetailPanel(
         </div>
       </div>
     </div>
+  `;
+}
+
+function renderAddFieldAction(
+  parentFieldId: string | null,
+  target: { visible: string; accessible: string },
+  primary: boolean,
+  readOnly: boolean,
+  callbacks: SchemaSectionCallbacks,
+): unknown {
+  const accessibleLabel = `Add field to ${target.accessible}`;
+  return html`
+    <button
+      class="ep-btn ${primary
+        ? 'ep-btn-primary'
+        : 'ep-btn-outline'} ep-btn-sm dc-context-add-field-btn"
+      @click=${() => callbacks.onAddField(parentFieldId)}
+      ?disabled=${readOnly}
+      aria-label=${accessibleLabel}
+      title=${accessibleLabel}
+    >
+      <span aria-hidden="true">+ Add field to</span>
+      <span class="dc-context-target" aria-hidden="true">${target.visible}</span>
+    </button>
   `;
 }
 
@@ -499,24 +555,4 @@ function renderArrayConstraints(
       />
     </div>
   `;
-}
-
-// =============================================================================
-// Helpers
-// =============================================================================
-
-/** Find a field by ID in a nested field tree. */
-function findFieldById(fields: SchemaField[], id: string): SchemaField | null {
-  for (const field of fields) {
-    if (field.id === id) return field;
-    if (field.type === 'object' && field.nestedFields) {
-      const found = findFieldById(field.nestedFields, id);
-      if (found) return found;
-    }
-    if (field.type === 'array' && field.nestedFields) {
-      const found = findFieldById(field.nestedFields, id);
-      if (found) return found;
-    }
-  }
-  return null;
 }


### PR DESCRIPTION
## Why

Creating fields in a nested contract currently forces authors to navigate back to the containing object before they can continue. Likewise, add-item actions in complex examples do not identify which array they affect. Both interrupt the editing flow and become increasingly ambiguous as contracts grow.

This PR makes schema and example editing contextual: actions are available where the author is already working and explicitly name their destination.

## What changes

### Schema editing

- Adds child and sibling field actions to the selected field's detail panel.
- Shows the complete destination breadcrumb, including object-array item context, for example `customer › recipients items`.
- Keeps the root-level `Add field to data contract` action available.
- Generates the first unused `fieldN` name within the target object, selects it, and focuses the name input for immediate replacement.
- Enter commits the field name and retains focus; Escape restores the stored name.
- Keeps all ancestors expanded after adding a nested field.
- Reconciles selection after delete, undo, and redo using the next sibling, previous sibling, parent, or first root field.
- Truncates long visible destinations without losing the complete title or accessible name.

### Example editing

- Replaces generic type-based array labels with `Add item to <path>` for primitive, object, and directly nested arrays.
- Formats numeric path segments as human-readable item numbers, for example `groups › item 1 › members`.
- Starts object, array, and array-item groups collapsed for a more scannable overview.
- Adds per-example `Expand all` and `Collapse all` actions.
- Preserves manually opened groups when example data rerenders, while switching examples starts with a fresh collapsed view.

### Documentation

- Updates the data-contract guide with the contextual schema workflow, array action paths, and disclosure behavior.
- Records each user-visible change in the changelog.

## Design and implementation notes

- Hierarchy lookup, destination formatting, generated naming, and selection reconciliation live in a focused schema helper with unit tests.
- All array variants share one contextual add-action renderer.
- Disclosure controls operate only on the selected example and do not change contract data or undo history.
- No backend API, JSON Schema format, or persisted contract representation changes.

## Verification

- 2,119 editor tests passed across 118 test files.
- TypeScript typecheck passed.
- Production editor build passed.
- Component registry projection passed.
- Formatting, CSS lint, license-header, and diff checks passed.
- Code lint passed with existing warnings only.

## Manual test checklist

- [ ] Add a root field from the schema toolbar.
- [ ] Add a child to an object and an object-array item from the detail panel.
- [ ] Add a sibling without navigating back to the parent.
- [ ] Rename the generated field with Enter and cancel a rename with Escape.
- [ ] Delete and undo/redo nested fields and verify expansion and selection remain useful.
- [ ] Verify contextual add-item paths for primitive, object, and nested arrays.
- [ ] Verify examples start collapsed and Expand all / Collapse all affect the complete selected example.
- [ ] Verify long destination paths truncate visually while retaining their full tooltip and accessible label.

Closes #837
Closes #846
